### PR TITLE
[APP-335] Add MaskType.none that handles only spaces

### DIFF
--- a/Projects/Embark/Sources/Viewables/Actions/EmbarkInput.swift
+++ b/Projects/Embark/Sources/Viewables/Actions/EmbarkInput.swift
@@ -15,7 +15,7 @@ struct EmbarkInput {
     let enabledSignal: ReadWriteSignal<Bool>
     let shouldReturn = Delegate<String, Bool>()
     let insets: UIEdgeInsets
-    let masking: Masking?
+    let masking: Masking
     let shouldAutoFocus: Bool
     let fieldStyle: FieldStyle
     let shouldAutoSize: Bool
@@ -29,7 +29,7 @@ struct EmbarkInput {
         autocapitalisationType: UITextAutocapitalizationType,
         insets: UIEdgeInsets = UIEdgeInsets(horizontalInset: 20, verticalInset: 3),
         enabled: Bool = true,
-        masking: Masking? = nil,
+        masking: Masking = Masking(type: .none),
         shouldAutoFocus: Bool = true,
         fieldStyle: FieldStyle = .embarkInputLarge,
         shouldAutoSize: Bool = false,
@@ -118,7 +118,7 @@ extension EmbarkInput: Viewable {
             textField.becomeFirstResponder()
         }
 
-        bag += masking?.applyMasking(textField)
+        bag += masking.applyMasking(textField)
 
         bag += textField.shouldReturn.set { value -> Bool in
             self.shouldReturn.call(value) ?? false

--- a/Projects/Embark/Sources/Viewables/Actions/TextAction/EmbarkTextAction.swift
+++ b/Projects/Embark/Sources/Viewables/Actions/TextAction/EmbarkTextAction.swift
@@ -70,7 +70,7 @@ extension EmbarkTextAction: Viewable {
             keyboardType: masking?.keyboardType,
             textContentType: masking?.textContentType,
             autocapitalisationType: masking?.autocapitalizationType ?? .none,
-            masking: masking,
+            masking: masking ?? Masking(type: .none),
             shouldAutoSize: true
         )
         let textSignal = boxStack.addArranged(input) { inputView in
@@ -156,7 +156,7 @@ extension EmbarkTextAction: Viewable {
 internal extension Masking {
     func maskValueFromStore(text: String) -> String {
         switch type {
-        case .personalNumber, .postalCode, .birthDate, .norwegianPostalCode, .email, .digits, .norwegianPersonalNumber, .danishPersonalNumber:
+        case .personalNumber, .postalCode, .birthDate, .norwegianPostalCode, .email, .digits, .norwegianPersonalNumber, .danishPersonalNumber, .none:
             return maskValue(text: text, previousText: "")
         case .birthDateReverse:
             let reverseDateFormatter = DateFormatter()

--- a/Projects/Embark/Sources/Viewables/Actions/TextActionSet.swift
+++ b/Projects/Embark/Sources/Viewables/Actions/TextActionSet.swift
@@ -48,7 +48,7 @@ extension TextActionSet: Viewable {
                 textContentType: masking?.textContentType,
                 returnKeyType: isLastAction ? .done : .next,
                 autocapitalisationType: masking?.autocapitalizationType ?? .words,
-                masking: masking,
+                masking: masking ?? Masking(type: .none),
                 shouldAutoFocus: index == 0,
                 fieldStyle: .embarkInputSmall,
                 textFieldAlignment: .right

--- a/Projects/hCore/Sources/Masking.swift
+++ b/Projects/hCore/Sources/Masking.swift
@@ -3,6 +3,7 @@ import Foundation
 import UIKit
 
 public enum MaskType: String {
+    case none = "None"
     case personalNumber = "PersonalNumber"
     case norwegianPersonalNumber = "NorwegianPersonalNumber"
     case danishPersonalNumber = "DanishPersonalNumber"
@@ -37,7 +38,7 @@ public struct Masking {
         let bag = DisposeBag()
 
         bag += textField.distinct().onValue { text in
-            let newValue = maskValue(text: text, previousText: previousText)
+            let newValue = maskValue(text: text, previousText: previousText).replacingOccurrences(of: " ", with: "\u{00a0}")
             $previousText.value = newValue
             textField.text = newValue
         }
@@ -71,10 +72,12 @@ public struct Masking {
             return CharacterSet.decimalDigits.isSuperset(
                 of: CharacterSet(charactersIn: text)
             )
+        case .none:
+            return true
         }
     }
 
-    public func unmaskedValue(text: String) -> String {
+    private func unmask(text: String) -> String {
         switch type {
         case .personalNumber:
             return text.replacingOccurrences(of: "-", with: "")
@@ -100,7 +103,13 @@ public struct Masking {
             return text.replacingOccurrences(of: " ", with: "")
         case .danishPersonalNumber:
             return text.replacingOccurrences(of: " ", with: "")
+        case .none:
+            return text
         }
+    }
+    
+    public func unmaskedValue(text: String) -> String {
+        return unmask(text: text).replacingOccurrences(of: "\u{00a0}", with: " ")
     }
 
     public func calculateAge(from text: String) -> Int? {
@@ -170,6 +179,8 @@ public struct Masking {
             return .numberPad
         case .email:
             return .emailAddress
+        case .none:
+            return .default
         }
     }
 
@@ -242,6 +253,8 @@ public struct Masking {
             return delimitedDigits(delimiterPositions: [7], maxCount: 12, delimiter: "-")
         case .danishPersonalNumber:
             return delimitedDigits(delimiterPositions: [7], maxCount: 11, delimiter: "-")
+        case .none:
+            return text
         }
     }
 }


### PR DESCRIPTION
## [APP-335]

- Fix spaces not rendering, see link for why this thing happens 🙃 

https://stackoverflow.com/questions/19569688/right-aligned-uitextfield-spacebar-does-not-advance-cursor-in-ios-7/20129483#20129483

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-335]: https://hedvig.atlassian.net/browse/APP-335