### PR TITLE
Adjust welcomeLabel when verticalSizeClass is compact

### DIFF
--- a/Projects/Market/Sources/MarketPicker.swift
+++ b/Projects/Market/Sources/MarketPicker.swift
@@ -91,8 +91,15 @@ extension MarketPicker: Presentable {
             welcomeLabel.value = L10n.MarketLanguageScreen.title
         }
 
-        welcomeLabel.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+        bag += welcomeLabel.traitCollectionSignal.atOnce().onValue { traitCollection in
+            welcomeLabel.snp.remakeConstraints { make in
+                if traitCollection.verticalSizeClass == .compact {
+                    make.centerX.equalToSuperview()
+                    make.top.equalToSuperview().offset(50)
+                } else {
+                    make.center.equalToSuperview()
+                }
+            }
         }
 
         form.snp.makeConstraints { make in


### PR DESCRIPTION
## [APP-350]

- Adjust welcomeLabel when verticalSizeClass is compact

![Simulator Screen Shot - iPhone 8 - 2021-04-13 at 17 58 19](https://user-images.githubusercontent.com/5459507/114583804-3f808180-9c82-11eb-8405-3539ddf2c6b2.png)

## Checklist

- [X] Dark/light mode verification
- [X] Landscape verification
- [X] iPad verification
- [X] iPod/iPhone 12 mini/iPhone SE verification


[APP-350]: https://hedvig.atlassian.net/browse/APP-350