### PR TITLE
Fix `payInMethodStatus` after setting up Adyen

### DIFF
--- a/Projects/Payment/Sources/Screens/Adyen/AdyenPayIn.swift
+++ b/Projects/Payment/Sources/Screens/Adyen/AdyenPayIn.swift
@@ -27,6 +27,7 @@ extension AdyenMethodsList {
 
 struct AdyenPayIn: Presentable {
     @Inject var client: ApolloClient
+    @Inject var store: ApolloStore
     let adyenOptions: AdyenOptions
     let urlScheme: String
 
@@ -66,6 +67,10 @@ struct AdyenPayIn: Presentable {
                 }
             }
         } onSuccess: {
+            store.update(query: GraphQL.PayInMethodStatusQuery()) { (data: inout GraphQL.PayInMethodStatusQuery.Data) in
+                data.payinMethodStatus = .active
+            }
+            
             // refetch to refresh UI
             Future()
                 .delay(by: 0.5)


### PR DESCRIPTION
## [APP-121]

- Fix `payInMethodStatus` after setting up Adyen

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-121]: https://hedvig.atlassian.net/browse/APP-121