### PR TITLE
Add naive padding to Wizard

### DIFF
--- a/Projects/App/Sources/Screens/DebugScreen/Debug.swift
+++ b/Projects/App/Sources/Screens/DebugScreen/Debug.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import hCore
 import hGraphQL
 
-@available(iOS 13, *) struct Debug: View {
+struct Debug: View {
     enum EnvironmentOption: String, CaseIterable {
         case production = "Production"
         case staging = "Staging"
@@ -44,6 +44,7 @@ import hGraphQL
         NavigationView {
             Form {
                 Section {
+                    Color.clear.frame(height: 100)
                     Text("Which environment do you want to use?")
                     Picker(
                         selection: $pickedEnvironment,


### PR DESCRIPTION
App got stuck during App Store review because the environment picker got placed under the navigation bar for some reason, we should just rewrite this screen to `hForm` later I think. Doing a simple fix for now.