### PR TITLE
Use typeOfContract as fingerprint for cross selling notification

### DIFF
--- a/Projects/Contracts/Example/Sources/Debug.swift
+++ b/Projects/Contracts/Example/Sources/Debug.swift
@@ -42,7 +42,8 @@ extension Debug {
                             description: "",
                             imageURL: .mock,
                             blurHash: "",
-                            buttonText: ""
+                            buttonText: "",
+                            typeOfContract: "SE_ACCIDENT"
                         )
 
                         return newState

--- a/Projects/Contracts/Sources/View/CrossSellingItem.swift
+++ b/Projects/Contracts/Sources/View/CrossSellingItem.swift
@@ -53,7 +53,8 @@ struct CrossSellingItem: View {
                 } content: {
                     hText(crossSell.buttonText)
                 }
-            }.hButtonFilledStyle(.overImage)
+            }
+            .hButtonFilledStyle(.overImage)
         }
         .padding(16)
         .frame(

--- a/Projects/Contracts/Sources/View/CrossSellingItem.swift
+++ b/Projects/Contracts/Sources/View/CrossSellingItem.swift
@@ -53,8 +53,7 @@ struct CrossSellingItem: View {
                 } content: {
                     hText(crossSell.buttonText)
                 }
-                .hButtonFilledStyle(.overImage)
-            }
+            }.hButtonFilledStyle(.overImage)
         }
         .padding(16)
         .frame(
@@ -83,7 +82,8 @@ struct CrossSellingItemPreviews: PreviewProvider {
             )!,
             blurHash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
             buttonText: "Calculate price",
-            embarkStoryName: nil
+            embarkStoryName: nil,
+            typeOfContract: "SE_ACCIDENT"
         )
     )
 
@@ -94,7 +94,8 @@ struct CrossSellingItemPreviews: PreviewProvider {
             imageURL: URL(string: "https://hedvig.com/")!,
             blurHash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
             buttonText: "Calculate price",
-            embarkStoryName: nil
+            embarkStoryName: nil,
+            typeOfContract: "SE_ACCIDENT"
         )
     )
 

--- a/Projects/Contracts/Sources/View/CrossSellingSigned.swift
+++ b/Projects/Contracts/Sources/View/CrossSellingSigned.swift
@@ -78,7 +78,8 @@ struct CrossSellingSignedPreviews: PreviewProvider {
                 description: "",
                 imageURL: URL(string: "https://giraffe.hedvig.com")!,
                 blurHash: "",
-                buttonText: ""
+                buttonText: "",
+                typeOfContract: "SE_ACCIDENT"
             )
 
             return newState

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -94,7 +94,7 @@ extension View {
 struct ButtonFilledBackground: View {
     @Environment(\.hButtonFilledStyle) var hButtonFilledStyle
     var configuration: SwiftUI.ButtonStyle.Configuration
-    
+
     var body: some View {
         switch hButtonFilledStyle {
         case .standard:

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -91,9 +91,22 @@ extension View {
     }
 }
 
+struct ButtonFilledBackground: View {
+    @Environment(\.hButtonFilledStyle) var hButtonFilledStyle
+    var configuration: SwiftUI.ButtonStyle.Configuration
+    
+    var body: some View {
+        switch hButtonFilledStyle {
+        case .standard:
+            ButtonFilledStandardBackground(configuration: configuration)
+        case .overImage:
+            ButtonFilledOverImageBackground(configuration: configuration)
+        }
+    }
+}
+
 struct ButtonFilledStyle: SwiftUI.ButtonStyle {
     var size: ButtonSize
-    @Environment(\.hButtonFilledStyle) var hButtonFilledStyle
 
     struct Label: View {
         @Environment(\.isEnabled) var isEnabled
@@ -138,15 +151,6 @@ struct ButtonFilledStyle: SwiftUI.ButtonStyle {
         )
     }
 
-    @ViewBuilder func background(configuration: Configuration) -> some View {
-        switch hButtonFilledStyle {
-        case .standard:
-            ButtonFilledStandardBackground(configuration: configuration)
-        case .overImage:
-            ButtonFilledOverImageBackground(configuration: configuration)
-        }
-    }
-
     func makeBody(configuration: Configuration) -> some View {
         VStack {
             Label(configuration: configuration)
@@ -154,7 +158,7 @@ struct ButtonFilledStyle: SwiftUI.ButtonStyle {
                 .padding(.trailing, 16)
         }
         .buttonSizeModifier(size)
-        .background(background(configuration: configuration))
+        .background(ButtonFilledBackground(configuration: configuration))
         .overlay(configuration.isPressed ? pressedColor : nil)
         .cornerRadius(.defaultCornerRadius)
     }

--- a/Projects/hGraphQL/GraphQL/ActiveContractBundles.graphql
+++ b/Projects/hGraphQL/GraphQL/ActiveContractBundles.graphql
@@ -44,11 +44,15 @@ query ActiveContractBundles($locale: Locale!) {
       addressChange
     }
     potentialCrossSells {
+      contractType
       title
       description
       imageUrl
       blurHash
       callToAction
+      info(locale: $locale) {
+        displayName
+      }
       action {
         ... on CrossSellChat {
           _

--- a/Projects/hGraphQL/Sources/Models/CrossSellModels.swift
+++ b/Projects/hGraphQL/Sources/Models/CrossSellModels.swift
@@ -57,7 +57,9 @@ public struct CrossSell: Codable, Equatable, Hashable {
         buttonText = data.callToAction
         embarkStoryName = data.action.asCrossSellEmbark?.embarkStory.name
         blurHash = data.blurHash
-        hasBeenSeen = UserDefaults.standard.bool(forKey: Self.hasBeenSeenKey(typeOfContract: data.contractType.rawValue))
+        hasBeenSeen = UserDefaults.standard.bool(
+            forKey: Self.hasBeenSeenKey(typeOfContract: data.contractType.rawValue)
+        )
         typeOfContract = data.contractType.rawValue
     }
 }

--- a/Projects/hGraphQL/Sources/Models/CrossSellModels.swift
+++ b/Projects/hGraphQL/Sources/Models/CrossSellModels.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct CrossSell: Codable, Equatable, Hashable {
+    public var typeOfContract: String
     public var title: String
     public var description: String
     public var imageURL: URL
@@ -9,13 +10,13 @@ public struct CrossSell: Codable, Equatable, Hashable {
     public var embarkStoryName: String?
     public var hasBeenSeen: Bool {
         didSet {
-            UserDefaults.standard.set(hasBeenSeen, forKey: Self.hasBeenSeenKey(title: title))
+            UserDefaults.standard.set(hasBeenSeen, forKey: Self.hasBeenSeenKey(typeOfContract: typeOfContract))
             UserDefaults.standard.synchronize()
         }
     }
 
-    fileprivate static func hasBeenSeenKey(title: String) -> String {
-        "CrossSell-hasBeenSeen-\(title)"
+    fileprivate static func hasBeenSeenKey(typeOfContract: String) -> String {
+        "CrossSell-hasBeenSeen-\(typeOfContract)"
     }
 
     public static func == (lhs: CrossSell, rhs: CrossSell) -> Bool {
@@ -29,7 +30,8 @@ public struct CrossSell: Codable, Equatable, Hashable {
         blurHash: String,
         buttonText: String,
         embarkStoryName: String? = nil,
-        hasBeenSeen: Bool = false
+        hasBeenSeen: Bool = false,
+        typeOfContract: String
     ) {
         self.title = title
         self.description = description
@@ -38,6 +40,7 @@ public struct CrossSell: Codable, Equatable, Hashable {
         self.buttonText = buttonText
         self.embarkStoryName = embarkStoryName
         self.hasBeenSeen = hasBeenSeen
+        self.typeOfContract = typeOfContract
     }
 
     init?(
@@ -54,6 +57,7 @@ public struct CrossSell: Codable, Equatable, Hashable {
         buttonText = data.callToAction
         embarkStoryName = data.action.asCrossSellEmbark?.embarkStory.name
         blurHash = data.blurHash
-        hasBeenSeen = UserDefaults.standard.bool(forKey: Self.hasBeenSeenKey(title: title))
+        hasBeenSeen = UserDefaults.standard.bool(forKey: Self.hasBeenSeenKey(typeOfContract: data.contractType.rawValue))
+        typeOfContract = data.contractType.rawValue
     }
 }


### PR DESCRIPTION
## [APP-790]

> Use typeOfContract as fingerprint for cross selling notification, also fix `.hButtonFilledStyle` not being applied on iOS 14.

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-790]: https://hedvig.atlassian.net/browse/APP-790