### PR TITLE
trigger action before dismissing

### DIFF
--- a/Projects/App/Sources/Journeys/ClaimsJourney.swift
+++ b/Projects/App/Sources/Journeys/ClaimsJourney.swift
@@ -28,9 +28,7 @@ extension AppJourney {
             }
         }
         .sendActionImmediately(HomeStore.self, .startPollingClaims)
-        .onDismiss {
-            DismissJourney().sendActionImmediately(HomeStore.self, .stopPollingClaims)
-        }
+        .sendActionOnDismiss(HomeStore.self, .stopPollingClaims)
     }
 
     private static func claimsJourneyPledgeAndNotificationWrapper<RedirectJourney: JourneyPresentation>(
@@ -75,6 +73,15 @@ extension AppJourney {
     ) -> some JourneyPresentation {
         Journey(embark, style: style) { redirect in
             redirectJourney(redirect)
+        }
+    }
+}
+extension JourneyPresentation {
+    func sendActionOnDismiss<S: Store>(_ storeType: S.Type, _ action: S.Action) -> Self {
+        return self.onDismiss {
+            let store: S = self.presentable.get()
+            
+            store.send(action)
         }
     }
 }


### PR DESCRIPTION
Fix claim status polling never stopping

- Add new `sendActionOnDismiss`


## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
