### PR TITLE
[APP-1180] terminated member claim bug

### DIFF
--- a/Projects/Home/Example/Sources/Debug.swift
+++ b/Projects/Home/Example/Sources/Debug.swift
@@ -77,6 +77,10 @@ extension Debug: Presentable {
         bag += section.appendRow(title: "Renewals - Multiple separate dates")
             .append(hCoreUIAssets.chevronRight.image)
             .onValue { presentHome(.makeActiveWithMultipleRenewalsOnSeparateDates()) }
+        
+        bag += section.appendRow(title: "Home - Terminated")
+            .append(hCoreUIAssets.chevronRight.image)
+            .onValue { presentHome(.makeTerminatedInTheFuture()) }
 
         bag += viewController.install(form)
 

--- a/Projects/Home/Sources/Viewables/TerminatedSection.swift
+++ b/Projects/Home/Sources/Viewables/TerminatedSection.swift
@@ -33,22 +33,22 @@ extension TerminatedSection: Presentable {
         bag += section.append(subtitleLabel)
 
         section.appendSpacing(.top)
-
-        let button = Button(
-            title: L10n.HomeTab.claimButtonText,
-            type: .standardOutline(
-                borderColor: .brand(.secondaryButtonBackgroundColor),
-                textColor: .brand(.secondaryButtonBackgroundColor)
-            )
-        )
-        bag += section.append(button)
-
+        
         let store: HomeStore = self.get()
 
-        bag += button.onTapSignal.onValue {
-            store.send(.openFreeTextChat)
-        }
+        let claimButton = Button(
+            title: L10n.HomeTab.claimButtonText,
+            type: .standard(
+                backgroundColor: .brand(.secondaryButtonBackgroundColor),
+                textColor: .brand(.secondaryButtonTextColor)
+            )
+        )
+        bag += section.append(claimButton)
 
+        bag += claimButton.onTapSignal.onValue {
+            store.send(.openClaims)
+        }
+        
         return (section, bag)
     }
 }

--- a/Projects/Home/Testing/HomeTestingData.swift
+++ b/Projects/Home/Testing/HomeTestingData.swift
@@ -187,4 +187,21 @@ extension JSONObject {
                 .jsonObject, makeCommonClaims(),
         ])
     }
+    
+    public static func makeTerminated() -> JSONObject {
+        combineMultiple([
+            GraphQL.HomeQuery
+                .Data(
+                    member: .init(firstName: "Mock"),
+                    contracts: [
+                        .init(
+                            displayName: "Home insurance",
+                            switchedFromInsuranceProvider: "Hedvig",
+                            status: .makeTerminatedStatus(termination: "Over")
+                        )
+                    ]
+                )
+                .jsonObject, makeCommonClaims(),
+        ])
+    }
 }


### PR DESCRIPTION
## [APP-1180]

- Added the correct action to `Terminated Section` for claims.
- Updated the home example to have a `Terminated` state.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[APP-1180]: https://hedvig.atlassian.net/browse/APP-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ