### PR TITLE
APP-1132 Fix terminated contracts row

### DIFF
--- a/Projects/Contracts/Sources/Contracts.swift
+++ b/Projects/Contracts/Sources/Contracts.swift
@@ -38,6 +38,24 @@ public indirect enum ContractFilter {
     case none
 }
 
+extension ContractFilter {
+    func nonemptyFilter(state: ContractState) -> ContractFilter {
+        switch self {
+        case .active:
+            let activeContracts = state
+                .contractBundles
+                .flatMap { $0.contracts }
+            return activeContracts.isEmpty ? self.emptyFilter : self
+        case .terminated:
+            let terminatedContracts = state.contracts.filter { contract in
+                contract.currentAgreement?.status == .terminated
+            }
+            return terminatedContracts.isEmpty ? self.emptyFilter : self
+        case .none: return self
+        }
+    }
+}
+
 public struct Contracts {
     @PresentableStore var store: ContractStore
     let pollTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()

--- a/Projects/Contracts/Sources/View/ContractTable.swift
+++ b/Projects/Contracts/Sources/View/ContractTable.swift
@@ -35,7 +35,7 @@ extension ContractTable: View {
             PresentableStoreLens(
                 ContractStore.self,
                 getter: { state in
-                    getContractsToShow(for: state, filter: filter)
+                    getContractsToShow(for: state, filter: filter.nonemptyFilter(state: state))
                 }
             ) { contracts in
                 ForEach(contracts, id: \.id) { contract in
@@ -49,35 +49,42 @@ extension ContractTable: View {
         .presentableStoreLensAnimation(.spring())
         .sectionContainerStyle(.transparent)
 
-        if self.filter.displaysActiveContracts {
-            CrossSellingStack()
-
-            PresentableStoreLens(
-                ContractStore.self,
-                getter: { state in
-                    getContractsToShow(for: state, filter: .terminated(ifEmpty: .none))
-                }
-            ) { terminatedContracts in
-                if !terminatedContracts.isEmpty {
-                    hSection(header: hText(L10n.InsurancesTab.moreTitle)) {
-                        hRow {
-                            hText(L10n.InsurancesTab.terminatedInsurancesLabel)
-                        }
-                        .withCustomAccessory({
-                            Spacer()
-                            hText(String(terminatedContracts.count), style: .body)
-                                .foregroundColor(hLabelColor.secondary)
-                                .padding(.trailing, 8)
-                            StandaloneChevronAccessory()
-                        })
-                        .onTap {
-                            store.send(.openTerminatedContracts)
-                        }
-                    }
-                    .transition(.slide)
-                }
+        PresentableStoreLens(
+            ContractStore.self,
+            getter: { state in
+                return self.filter.nonemptyFilter(state: state).displaysActiveContracts
             }
-            .presentableStoreLensAnimation(.spring())
+        ) { displaysActiveContracts in
+            if displaysActiveContracts {
+                CrossSellingStack()
+
+                PresentableStoreLens(
+                    ContractStore.self,
+                    getter: { state in
+                        getContractsToShow(for: state, filter: .terminated(ifEmpty: .none))
+                    }
+                ) { terminatedContracts in
+                    if !terminatedContracts.isEmpty {
+                        hSection(header: hText(L10n.InsurancesTab.moreTitle)) {
+                            hRow {
+                                hText(L10n.InsurancesTab.terminatedInsurancesLabel)
+                            }
+                            .withCustomAccessory({
+                                Spacer()
+                                hText(String(terminatedContracts.count), style: .body)
+                                    .foregroundColor(hLabelColor.secondary)
+                                    .padding(.trailing, 8)
+                                StandaloneChevronAccessory()
+                            })
+                            .onTap {
+                                store.send(.openTerminatedContracts)
+                            }
+                        }
+                        .transition(.slide)
+                    }
+                }
+                .presentableStoreLensAnimation(.spring())
+            }
         }
     }
 }


### PR DESCRIPTION
## [APP-1132]

- Make sure terminated insurances are shown as cards when there are no active contracts.

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-1132]: https://hedvig.atlassian.net/browse/APP-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ