### PR TITLE
UI fixes II

### DIFF
--- a/Projects/Offer/Sources/Components/MainContentForm/Sections/Coverage/FrequentlyAskedQuestionsSection.swift
+++ b/Projects/Offer/Sources/Components/MainContentForm/Sections/Coverage/FrequentlyAskedQuestionsSection.swift
@@ -90,6 +90,9 @@ extension FrequentlyAskedQuestionsSection: Presentable {
                     imageView.setContentHuggingPriority(.required, for: .horizontal)
 
                     row.append(imageView)
+                    imageView.snp.makeConstraints { make in
+                        make.width.equalTo(16)
+                    }
 
                     return innerBag
                 }

--- a/Projects/Payment/Sources/Screens/Adyen/AdyenSuccess.swift
+++ b/Projects/Payment/Sources/Screens/Adyen/AdyenSuccess.swift
@@ -29,7 +29,8 @@ extension AdyenSuccess: Presentable {
             title: L10n.AdyenConfirmation.headline(paymentMethod.name),
             body: "",
             actions: [((), continueButton)],
-            showLogo: false
+            showLogo: false,
+            alignment: .left
         )
 
         let (viewController, signal) = PresentableViewable(viewable: continueAction) { viewController in

--- a/Projects/hCoreUI/Sources/ImageTextAction.swift
+++ b/Projects/hCoreUI/Sources/ImageTextAction.swift
@@ -38,19 +38,22 @@ public struct ImageTextAction<ActionResult> {
     @ReadWriteState public var body: String
     public let actions: [(ActionResult, Button)]
     public let showLogo: Bool
+    public let alignment: NSTextAlignment
 
     public init(
         image: ImageWithOptions,
         title: String,
         body: String,
         actions: [(ActionResult, Button)],
-        showLogo: Bool
+        showLogo: Bool,
+        alignment: NSTextAlignment = .center
     ) {
         self.image = image
         self.title = title
         self.body = body
         self.actions = actions
         self.showLogo = showLogo
+        self.alignment = alignment
     }
 }
 
@@ -70,7 +73,7 @@ extension ImageTextAction: Viewable {
         let view = UIStackView()
         view.spacing = 24
         view.axis = .vertical
-        view.alignment = .center
+        view.alignment = alignment == .left ? .leading : .center
 
         if showLogo {
             let logoImageContainer = UIStackView()
@@ -115,14 +118,14 @@ extension ImageTextAction: Viewable {
 
         var titleLabel = MultilineLabel(
             value: title,
-            style: TextStyle.brand(.title2(color: .primary)).aligned(to: .center)
+            style: TextStyle.brand(.title2(color: .primary)).aligned(to: alignment)
         )
         bag += view.addArranged(titleLabel)
         bag += $title.onValue { value in titleLabel.value = value }
 
         var bodyLabel = MultilineLabel(
             value: body,
-            style: TextStyle.brand(.body(color: .secondary)).aligned(to: .center)
+            style: TextStyle.brand(.body(color: .secondary)).aligned(to: alignment)
         )
         bag += view.addArranged(bodyLabel)
         bag += $body.onValue { value in bodyLabel.value = value }


### PR DESCRIPTION
## [APP-1395], [APP-1401]

- Make center-aligned sucess screen left-aligned (and in the process add an alignment option to ImageTextAction)
- Fix arrow sometimes being compressed in FAQ table

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-1395]: https://hedvig.atlassian.net/browse/APP-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-1401]: https://hedvig.atlassian.net/browse/APP-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ