### PR TITLE
Start generic auth from bank id pages

### DIFF
--- a/Projects/App/Sources/Journeys/LoginJourney.swift
+++ b/Projects/App/Sources/Journeys/LoginJourney.swift
@@ -35,6 +35,8 @@ extension AppJourney {
                 .mapJourneyDismissToCancel
             case .loggedIn:
                 loginCompleted
+            case .emailLogin:
+                otp
             }
         }
         .withDismissButton

--- a/Projects/App/Sources/Journeys/LoginJourney.swift
+++ b/Projects/App/Sources/Journeys/LoginJourney.swift
@@ -27,6 +27,8 @@ extension AppJourney {
                     switch result {
                     case .loggedIn:
                         loginCompleted
+                    case .emailLogin:
+                        otp
                     }
                 }
                 .withJourneyDismissButton

--- a/Projects/App/Sources/Screens/LoginScreen/BankIDLoginQR.swift
+++ b/Projects/App/Sources/Screens/LoginScreen/BankIDLoginQR.swift
@@ -64,14 +64,17 @@ extension BankIDLoginQR: Presentable {
         headerContainer.addArrangedSubview(iconContainerView)
 
         let messageLabel = MultilineLabel(
-            value: L10n.bankidMissingMessage2,
+            value: L10n.bankidMissingMessageGenAuth,
             style: .brand(.headline(color: .primary))
         )
         bag += containerStackView.addArranged(messageLabel)
 
         let emailLoginButton = Button(
             title: L10n.BankidMissingLogin.emailButton,
-            type: .standardOutline(borderColor: .black, textColor: .black)
+            type: .standardOutline(
+                borderColor: .brand(.primaryText()),
+                textColor: .brand(.primaryText())
+            )
         )
         bag += containerStackView.addArranged(emailLoginButton)
 

--- a/Projects/App/Sources/Screens/LoginScreen/BankIDLoginQR.swift
+++ b/Projects/App/Sources/Screens/LoginScreen/BankIDLoginQR.swift
@@ -9,6 +9,7 @@ struct BankIDLoginQR {}
 
 enum BankIDLoginQRResult {
     case loggedIn
+    case emailLogin
 }
 
 extension BankIDLoginQR: Presentable {
@@ -34,30 +35,25 @@ extension BankIDLoginQR: Presentable {
         viewController.navigationItem.rightBarButtonItem = moreBarButtonItem
 
         let containerStackView = UIStackView()
+        containerStackView.spacing = 28
         containerStackView.axis = .vertical
         containerStackView.alignment = .center
+        containerStackView.layoutMargins = UIEdgeInsets(horizontalInset: 16, verticalInset: 24)
+        containerStackView.isLayoutMarginsRelativeArrangement = true
 
         view.addSubview(containerStackView)
 
         containerStackView.snp.makeConstraints { make in make.leading.trailing.top.equalToSuperview() }
 
-        let containerView = UIStackView()
-        containerView.spacing = 15
-        containerView.axis = .vertical
-        containerView.alignment = .center
-        containerView.layoutMargins = UIEdgeInsets(horizontalInset: 15, verticalInset: 24)
-        containerView.isLayoutMarginsRelativeArrangement = true
-        containerStackView.addArrangedSubview(containerView)
-
         let headerContainer = UIStackView()
         headerContainer.axis = .vertical
         headerContainer.spacing = 15
 
-        containerView.addArrangedSubview(headerContainer)
+        containerStackView.addArrangedSubview(headerContainer)
 
         let iconContainerView = UIView()
 
-        iconContainerView.snp.makeConstraints { make in make.height.width.equalTo(120) }
+        iconContainerView.snp.makeConstraints { make in make.height.width.equalTo(128) }
 
         let imageView = UIImageView()
 
@@ -68,10 +64,16 @@ extension BankIDLoginQR: Presentable {
         headerContainer.addArrangedSubview(iconContainerView)
 
         let messageLabel = MultilineLabel(
-            value: L10n.bankidMissingMessage,
+            value: L10n.bankidMissingMessage2,
             style: .brand(.headline(color: .primary))
         )
-        bag += containerView.addArranged(messageLabel)
+        bag += containerStackView.addArranged(messageLabel)
+
+        let emailLoginButton = Button(
+            title: L10n.BankidMissingLogin.emailButton,
+            type: .standardOutline(borderColor: .black, textColor: .black)
+        )
+        bag += containerStackView.addArranged(emailLoginButton)
 
         func generateQRCode(_ url: URL) {
             let data = url.absoluteString.data(using: String.Encoding.ascii)
@@ -121,6 +123,10 @@ extension BankIDLoginQR: Presentable {
                             rect: moreBarButtonItem.view?.frame
                         )
                     )
+                }
+                
+                bag += emailLoginButton.onTapSignal.onValue { _ in
+                    callback(.emailLogin)
                 }
 
                 return bag

--- a/Projects/App/Sources/Screens/LoginScreen/BankIDLoginSweden.swift
+++ b/Projects/App/Sources/Screens/LoginScreen/BankIDLoginSweden.swift
@@ -14,6 +14,7 @@ struct BankIDLoginSweden {
 
 enum BankIDLoginSwedenResult {
     case qrCode
+    case emailLogin
     case loggedIn
 }
 
@@ -102,14 +103,17 @@ extension BankIDLoginSweden: Presentable {
         var statusLabel = MultilineLabel(value: L10n.signStartBankid, style: .brand(.headline(color: .primary)))
         bag += containerView.addArranged(statusLabel)
 
-        let bankIDOnAnotherDeviceContainer = UIStackView()
-        containerView.addArrangedSubview(bankIDOnAnotherDeviceContainer)
+        let alternativeLoginContainer = UIStackView()
+        containerView.addArrangedSubview(alternativeLoginContainer)
 
-        let bankIDOnAnotherDeviceButton = Button(
-            title: L10n.bankidOnAnotherDevice,
-            type: .standardOutline(borderColor: .brand(.primaryText()), textColor: .brand(.primaryText()))
+        let alternativeLoginButton = Button(
+            title: L10n.buttonLoginAlternativeMethod,
+            type: .standard(
+                backgroundColor: .brand(.primaryBackground(true)),
+                textColor: .brand(.primaryText(true))
+            )
         )
-        bag += bankIDOnAnotherDeviceContainer.addArranged(bankIDOnAnotherDeviceButton)
+        bag += alternativeLoginContainer.addArranged(alternativeLoginButton)
 
         let statusSignal =
             client.subscribe(
@@ -153,8 +157,34 @@ extension BankIDLoginSweden: Presentable {
                         }
                     }
 
-                bag += bankIDOnAnotherDeviceButton.onTapSignal.onValue { _ in
-                    callback(.qrCode)
+                bag += alternativeLoginButton.onTapSignal.onValue { _ in
+                    let alert = Alert<Void>(actions: [
+                        .init(
+                            title: L10n.emailRowTitle,
+                            action: {
+                                callback(.emailLogin)
+                            }
+                        ),
+                        .init(
+                            title: L10n.bankidOnAnotherDevice,
+                            action: {
+                                callback(.qrCode)
+                            }
+                        ),
+                        .init(
+                            title: L10n.alertCancel,
+                            style: .cancel,
+                            action: {}
+                        ),
+                    ])
+
+                    viewController.present(
+                        alert,
+                        style: .sheet(
+                            from: alternativeLoginContainer,
+                            rect: alternativeLoginContainer.frame
+                        )
+                    )
                 }
 
                 bag += statusSignal.distinct()


### PR DESCRIPTION
## [APP-1659]

- Changes to an alternative Login button on `BankIDSweden` page to choose between E-mail and bankID on another device.
- Adds email button on `BankIDQRCode` page to start generic auth

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification

## Screenshots
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-10 at 11 59 00](https://user-images.githubusercontent.com/12679792/167603145-8f8433e1-5d31-4608-b956-aac1d60b757c.png)

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-10 at 11 58 52](https://user-images.githubusercontent.com/12679792/167603192-3e353585-0efe-4fb4-b64f-544e6e7216d5.png)



[APP-1659]: https://hedvig.atlassian.net/browse/APP-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ