### PR TITLE
Read claims' status and fetch claims on startup

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -145,6 +145,7 @@ extension AppJourney {
                 }
             )
             .sendActionImmediately(ContractStore.self, .fetch)
+            .sendActionImmediately(ClaimsStore.self, .fetchClaims)
             .syncTabIndex()
             .onAction(UgglanStore.self) { action in
                 if action == .openChat {

--- a/Projects/hGraphQL/GraphQL/Claims.graphql
+++ b/Projects/hGraphQL/GraphQL/Claims.graphql
@@ -2,24 +2,26 @@ fragment ProgressSegmentFragment on ClaimStatusProgressSegment {
   text
   type
 }
+
 query ClaimStatusCards($locale: Locale!) {
-      claims_statusCards(locale: $locale) {
-        id
-        pills {
-          text
-          type
-        }
-        title
-        subtitle
-        progressSegments{
-          ... ProgressSegmentFragment
-        }
+  claims_statusCards(locale: $locale) {
+    id
+    pills {
+      text
+      type
+    }
+    title
+    subtitle
+    progressSegments{
+      ... ProgressSegmentFragment
+    }
     claim {
       id
       outcome
       submittedAt
       closedAt
       signedAudioURL
+      status
       progressSegments {
         ... ProgressSegmentFragment
       }

--- a/Projects/hGraphQL/Sources/Models/Claims.swift
+++ b/Projects/hGraphQL/Sources/Models/Claims.swift
@@ -71,7 +71,7 @@ public struct Claim: Codable, Equatable, Identifiable {
             claim: ClaimStatusCard.Claim
         ) {
             self.id = claim.id
-            self.status = .none
+            self.status = Claim.ClaimDetailData.ClaimStatus(rawValue: claim.status.rawValue) ?? .none
             self.outcome = .init(rawValue: claim.outcome?.rawValue ?? "") ?? .none
             self.submittedAt = claim.submittedAt
             self.closedAt = claim.closedAt


### PR DESCRIPTION
## [APP-1768]

- Fetch claims on app start up. Will be needed going forward for account deletion to check active claims.
- For some reason, the status of claims was always being stored as .none 🤯. It now reads and updates the status properly.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[APP-1768]: https://hedvig.atlassian.net/browse/APP-1768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ