### PR TITLE
Add contentShape to CrossSellingItem button

### DIFF
--- a/Projects/Contracts/Sources/View/CrossSellingItem.swift
+++ b/Projects/Contracts/Sources/View/CrossSellingItem.swift
@@ -38,6 +38,7 @@ struct CrossSellingItem: View {
             }
         }
         .buttonStyle(CrossSellingCardButtonStyle(crossSell: crossSell))
+        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
## [APP-1787]

Adding contentShape so that the button gets the correct tap area, else it grows outside of it 🤷‍♂️ 


[APP-1787]: https://hedvig.atlassian.net/browse/APP-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ