### PR TITLE
Remove the check which doesn’t let icons update on changing traits

### DIFF
--- a/Projects/hCoreUI/Sources/RemoteVectorIcon.swift
+++ b/Projects/hCoreUI/Sources/RemoteVectorIcon.swift
@@ -45,8 +45,6 @@ extension RemoteVectorIcon: Viewable {
         func renderPdfDocument(pdfDocument: CGPDFDocument) {
             let imageViewSize = imageView.frame.size
 
-            if let image = imageView.image { if image.size == imageViewSize { return } }
-
             let page = pdfDocument.page(at: 1)!
             let rect = page.getBoxRect(CGPDFBox.mediaBox)
 


### PR DESCRIPTION
## [APP-1476]

- The `RemoteVectorIcon` doesn't update on changing from light to dark and vice-versa. The check for imageView's size returns and doesn't let the icon render again.

## Checklist

- [x] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[APP-1476]: https://hedvig.atlassian.net/browse/APP-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ