### PR TITLE
Validate auth token on app startup

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -144,6 +144,7 @@ extension AppJourney {
                     profileTab
                 }
             )
+            .sendActionImmediately(UgglanStore.self, .validateAuthToken)
             .sendActionImmediately(ContractStore.self, .fetch)
             .sendActionImmediately(ClaimsStore.self, .fetchClaims)
             .syncTabIndex()

--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -144,7 +144,6 @@ extension AppJourney {
                     profileTab
                 }
             )
-            .sendActionImmediately(UgglanStore.self, .validateAuthToken)
             .sendActionImmediately(ContractStore.self, .fetch)
             .sendActionImmediately(ClaimsStore.self, .fetchClaims)
             .syncTabIndex()

--- a/Projects/App/Sources/UgglanStore.swift
+++ b/Projects/App/Sources/UgglanStore.swift
@@ -78,7 +78,8 @@ public final class UgglanStore: StateStore<UgglanState, UgglanAction> {
                     UIApplication.shared.appDelegate.logout(token: nil)
                     let toast = Toast(
                         symbol: .icon(hCoreUIAssets.infoShield.image),
-                        body: "You have been logged out, please login again",
+                        body: L10n.forceLogoutMessageTitle,
+                        subtitle: L10n.forceLogoutMessageSubtitle,
                         textColor: .black,
                         backgroundColor: .brand(.regularCaution)
                     )

--- a/Projects/App/Sources/UgglanStore.swift
+++ b/Projects/App/Sources/UgglanStore.swift
@@ -73,7 +73,7 @@ public final class UgglanStore: StateStore<UgglanState, UgglanAction> {
             return client.fetch(query: GraphQL.MemberIdQuery())
                 .valueThenEndSignal
                 .atError(on: .main) { error in
-                    print(error.localizedDescription)
+                    log.error(error.localizedDescription)
                     ApplicationState.preserveState(.marketPicker)
                     UIApplication.shared.appDelegate.logout(token: nil)
                     let toast = Toast(

--- a/Projects/App/Sources/UgglanStore.swift
+++ b/Projects/App/Sources/UgglanStore.swift
@@ -5,7 +5,6 @@ import Offer
 import Presentation
 import UIKit
 import hCore
-import hCoreUI
 import hGraphQL
 
 public struct UgglanState: StateProtocol {
@@ -17,7 +16,6 @@ public enum UgglanAction: ActionProtocol {
     case setSelectedTabIndex(index: Int)
     case makeTabActive(deeplink: DeepLink)
     case showLoggedIn
-    case validateAuthToken
     case openClaims
     case exchangePaymentLink(link: String)
     case exchangePaymentToken(token: String)
@@ -69,26 +67,6 @@ public final class UgglanStore: StateStore<UgglanState, UgglanAction> {
             return performTokenExchange(with: exchangeToken)
         case let .exchangePaymentToken(token):
             return performTokenExchange(with: token)
-        case .validateAuthToken:
-            return client.fetch(query: GraphQL.MemberIdQuery())
-                .valueThenEndSignal
-                .atError(on: .main) { error in
-                    print(error.localizedDescription)
-                    ApplicationState.preserveState(.marketPicker)
-                    UIApplication.shared.appDelegate.logout(token: nil)
-                    let toast = Toast(
-                        symbol: .icon(hCoreUIAssets.infoShield.image),
-                        body: "You have been logged out, please login again",
-                        textColor: .black,
-                        backgroundColor: .brand(.regularCaution)
-                    )
-
-                    Toasts.shared.displayToast(toast: toast)
-                }
-                .compactMap { $0.member.id }
-                .compactMap(on: .main) { _ in
-                    return nil
-                }
         default:
             break
         }


### PR DESCRIPTION
## [APP-1756]

- Validate auth token and logout the member if the token is found to be invalid

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[APP-1756]: https://hedvig.atlassian.net/browse/APP-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ