### PR TITLE
Fix bug for insurable limits text size

### DIFF
--- a/Projects/Contracts/Sources/Screens/ContractDetail.swift
+++ b/Projects/Contracts/Sources/Screens/ContractDetail.swift
@@ -112,30 +112,28 @@ struct ContractDetail: View {
     }
 
     var body: some View {
-        VStack {
-            hForm {
-                hSection {
-                    ContractRow(
-                        id: id,
-                        allowDetailNavigation: false
-                    )
-                    .padding(.bottom, 20)
-                    Picker("View", selection: $context.selected) {
-                        ForEach(ContractDetailsViews.allCases) { view in
-                            hText(view.title).tag(view)
-                        }
+        hForm {
+            hSection {
+                ContractRow(
+                    id: id,
+                    allowDetailNavigation: false
+                )
+                .padding(.bottom, 20)
+                Picker("View", selection: $context.selected) {
+                    ForEach(ContractDetailsViews.allCases) { view in
+                        hText(view.title).tag(view)
                     }
-                    .pickerStyle(.segmented)
                 }
-                .withoutBottomPadding
-                .sectionContainerStyle(.transparent)
+                .pickerStyle(.segmented)
+            }
+            .withoutBottomPadding
+            .sectionContainerStyle(.transparent)
 
-                ForEach(ContractDetailsViews.allCases) { panel in
-                    if context.trigger == panel {
-                        viewFor(view: panel)
-                            .transition(.asymmetric(insertion: context.insertion, removal: context.removal))
-                            .animation(.interpolatingSpring(stiffness: 300, damping: 70))
-                    }
+            ForEach(ContractDetailsViews.allCases) { panel in
+                if context.trigger == panel {
+                    viewFor(view: panel)
+                        .transition(.asymmetric(insertion: context.insertion, removal: context.removal))
+                        .animation(.interpolatingSpring(stiffness: 300, damping: 70))
                 }
             }
         }

--- a/Projects/hCoreUI/Sources/InsurableLimits/InsurableLimits.swift
+++ b/Projects/hCoreUI/Sources/InsurableLimits/InsurableLimits.swift
@@ -1,9 +1,5 @@
-import Flow
-import Form
-import Foundation
 import Presentation
 import SwiftUI
-import UIKit
 import hCore
 import hGraphQL
 
@@ -27,6 +23,7 @@ public struct InsurableLimitsSectionView<Header: View>: View {
             hRow {
                 VStack(alignment: .leading, spacing: 4) {
                     hText(limit.label)
+                        .fixedSize(horizontal: false, vertical: true)
                     hText(limit.limit)
                         .foregroundColor(hLabelColor.secondary)
                 }
@@ -42,44 +39,5 @@ public struct InsurableLimitsSectionView<Header: View>: View {
         .withHeader {
             header
         }
-    }
-}
-
-public struct InsurableLimitsSection {
-    let insurableLimits: [InsurableLimits]
-
-    public init(
-        insurableLimits: [InsurableLimits]
-    ) {
-        self.insurableLimits = insurableLimits
-    }
-}
-
-extension InsurableLimitsSection: Viewable {
-    public func materialize(events _: ViewableEvents) -> (SectionView, Disposable) {
-        let bag = DisposeBag()
-
-        let section = SectionView(
-            headerView: UILabel(value: L10n.contractCoverageMoreInfo, style: .default),
-            footerView: nil
-        )
-        section.dynamicStyle = .brandGroupedInset(separatorType: .standard)
-
-        insurableLimits.forEach { insurableLimit in
-            let row = RowView(title: insurableLimit.label)
-            row.axis = .vertical
-            row.alignment = .leading
-            row.spacing = 5
-            section.append(row)
-
-            row.append(
-                UILabel(
-                    value: insurableLimit.limit,
-                    style: .brand(.body(color: .secondary))
-                )
-            )
-        }
-
-        return (section, bag)
     }
 }


### PR DESCRIPTION
## [APP-1622]

When the text in the rows under `Insurable Limits` has many characters, it is causing the whole screen to render with an unwanted offset. This was the reason behind the increase in size of the contract card under Qasa.

The fix includes adding a `fixedSize(horizontal: false, vertical: true)` modifier that now renders the text in multiple lines instead of truncating it.

- removed a `VStack` that wraps a `hForm`.
- Removed `UIKit` implementation of `InsurableLimitsSection`

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[APP-1622]: https://hedvig.atlassian.net/browse/APP-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ