### PR TITLE
Pass initial data from app to Odyssey

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -37,7 +37,6 @@ extension AppJourney {
         .onTabSelected {
             ContextGradient.currentOption = .home
         }
-        .claimStoreRedirectFromHome
         .makeTabSelected(UgglanStore.self) { action in
             if case .makeTabActive(let deepLink) = action {
                 return deepLink == .home
@@ -135,8 +134,6 @@ extension AppJourney {
             .onAction(UgglanStore.self) { action in
                 if action == .openChat {
                     AppJourney.freeTextChat().withDismissButton
-                } else if action == .openClaims {
-                    AppJourney.claimJourney
                 }
             }
         }
@@ -165,20 +162,12 @@ extension JourneyPresentation {
 }
 
 extension JourneyPresentation {
-    public var claimStoreRedirectFromHome: some JourneyPresentation {
-        onAction(HomeStore.self) { action in
-            if case .openClaim = action {
-                AppJourney.claimJourney
-            }
-        }
-    }
-
     public var configureClaimsNavigation: some JourneyPresentation {
         onAction(ClaimsStore.self) { action in
             if case let .openClaimDetails(claim) = action {
                 AppJourney.claimDetailJourney(claim: claim)
-            } else if case .submitNewClaim = action {
-                AppJourney.claimJourney
+            } else if case let .submitNewClaim(origin) = action {
+                AppJourney.claimJourney(from: origin)
             } else if case .openFreeTextChat = action {
                 AppJourney.freeTextChat()
             } else if case .openHowClaimsWork = action {

--- a/Projects/App/Sources/UgglanStore.swift
+++ b/Projects/App/Sources/UgglanStore.swift
@@ -17,7 +17,6 @@ public enum UgglanAction: ActionProtocol {
     case setSelectedTabIndex(index: Int)
     case makeTabActive(deeplink: DeepLink)
     case showLoggedIn
-    case openClaims
     case exchangePaymentLink(link: String)
     case exchangePaymentToken(token: String)
     case validateAuthToken
@@ -106,8 +105,6 @@ public final class UgglanStore: StateStore<UgglanState, UgglanAction> {
         switch action {
         case let .setSelectedTabIndex(tabIndex):
             newState.selectedTabIndex = tabIndex
-        case .openClaims:
-            break
         default:
             break
         }

--- a/Projects/Claims/Sources/ClaimState.swift
+++ b/Projects/Claims/Sources/ClaimState.swift
@@ -1,5 +1,6 @@
 import Apollo
 import Flow
+import Odyssey
 import Presentation
 import hCore
 import hGraphQL
@@ -25,7 +26,7 @@ public struct ClaimsState: StateProtocol {
 
 public enum ClaimsAction: ActionProtocol {
     case openFreeTextChat
-    case submitNewClaim
+    case submitNewClaim(from: ClaimsOrigin)
     case fetchClaims
     case setClaims(claims: [Claim])
     case fetchCommonClaims
@@ -34,6 +35,23 @@ public enum ClaimsAction: ActionProtocol {
     case openHowClaimsWork
     case openClaimDetails(claim: Claim)
     case odysseyRedirect(url: String)
+}
+
+public enum ClaimsOrigin: Codable {
+    case generic
+    case brokenPhone
+    case commonClaims
+
+    public var initialDataScopeValues: ScopeValues {
+        let scopeValues = ScopeValues()
+        switch self {
+        case .brokenPhone:
+            scopeValues.setValue(key: InitialDataScopeValueKey.shared, value: ["itemType": "PHONE"])
+        default:
+            break
+        }
+        return scopeValues
+    }
 }
 
 public final class ClaimsStore: StateStore<ClaimsState, ClaimsAction> {

--- a/Projects/Claims/Sources/CommonClaims/CommonClaimDetail.swift
+++ b/Projects/Claims/Sources/CommonClaims/CommonClaimDetail.swift
@@ -75,7 +75,12 @@ extension CommonClaimDetail: Presentable {
 
             bag += claimButton.onTapSignal.onValue {
                 hAnalyticsEvent.beginClaim(screen: .commonClaimDetail).send()
-                store.send(.submitNewClaim)
+                switch claim.id {
+                case "6":
+                    store.send(.submitNewClaim(from: .brokenPhone))
+                default:
+                    store.send(.submitNewClaim(from: .commonClaims))
+                }
             }
 
             bag += view.addArranged(BulletPointTable(bulletPoints: bulletPoints))

--- a/Projects/Claims/Sources/Views/ClaimSectionLoading.swift
+++ b/Projects/Claims/Sources/Views/ClaimSectionLoading.swift
@@ -36,14 +36,14 @@ struct ClaimSectionLoading: View {
         if claims.count > 0 {
             hButton.LargeButtonOutlined {
                 hAnalyticsEvent.beginClaim(screen: .home).send()
-                store.send(.submitNewClaim)
+                store.send(.submitNewClaim(from: .generic))
             } content: {
                 L10n.Home.OpenClaim.startNewClaimButton.hText()
             }
         } else {
             hButton.LargeButtonFilled {
                 hAnalyticsEvent.beginClaim(screen: .home).send()
-                store.send(.submitNewClaim)
+                store.send(.submitNewClaim(from: .generic))
             } content: {
                 hText(L10n.HomeTab.claimButtonText)
             }

--- a/Projects/Claims/Sources/Views/ClaimsInfoPager.swift
+++ b/Projects/Claims/Sources/Views/ClaimsInfoPager.swift
@@ -26,7 +26,7 @@ extension ClaimsInfoPager: Presentable {
             pages: []
         ) { viewController in
             hAnalyticsEvent.beginClaim(screen: .home).send()
-            store.send(.submitNewClaim)
+            store.send(.submitNewClaim(from: .generic))
             return Future(.forever)
         }
 

--- a/Projects/Home/Sources/HomeState.swift
+++ b/Projects/Home/Sources/HomeState.swift
@@ -19,7 +19,6 @@ public enum HomeAction: ActionProtocol {
     case openFreeTextChat
     case fetchMemberState
     case openMovingFlow
-    case openClaim
     case connectPayments
     case setMemberContractState(state: MemberStateData)
 }
@@ -61,8 +60,6 @@ public final class HomeStore: StateStore<HomeState, HomeAction> {
         case .connectPayments:
             break
         case .openMovingFlow:
-            break
-        case .openClaim:
             break
         }
 

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -98,7 +98,7 @@ public enum ExternalDependencies: CaseIterable {
             ]
         case .odysseyKit:
             return [
-                .package(url: "https://github.com/HedvigInsurance/OdysseyKit.git", .exact("1.103.0"))
+                .package(url: "https://github.com/HedvigInsurance/OdysseyKit.git", .exact("1.111.0"))
             ]
         }
     }


### PR DESCRIPTION
## [CLX-167]

- `ClaimsOrigin` to encapsulate all the data that will be sent to Odyssey
- Removes unused code for `openClaim` action in `HomeStore` and `openClaims` action in `UgglanStore`

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification


[CLX-167]: https://hedvig.atlassian.net/browse/CLX-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ