### PR TITLE
Feature/clx 350 add termination flow

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -58,6 +58,10 @@ extension AppJourney {
                 AppJourney.crossSellingJourney(crossSell: crossSell)
             case let .openCrossSellingEmbark(name):
                 AppJourney.crossSellingEmbarkJourney(name: name, style: .detented(.large))
+            case .terminationFlow:
+                AppJourney.terminationFlow
+            case .terminationSuccessFlow:
+                AppJourney.sendTermination()
             }
         }
         .onTabSelected {

--- a/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
+++ b/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
@@ -31,5 +31,6 @@ extension AppJourney {
             }
         }
         .withDismissButton
+        .setScrollEdgeNavigationBarAppearanceToStandard
     }
 }

--- a/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
+++ b/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
@@ -1,0 +1,35 @@
+import Contracts
+import Presentation
+import hCore
+
+extension AppJourney {
+    static var terminationFlow: some JourneyPresentation {
+        HostingJourney(
+            ContractStore.self,
+            rootView: SetTerminationDate(),
+            style: .modal
+        ) {
+            action in
+            if case .sendTermination = action {
+                sendTermination()
+            }
+        }
+        .setScrollEdgeNavigationBarAppearanceToStandard
+        .withDismissButton
+    }
+
+    static func sendTermination() -> some JourneyPresentation {
+
+        HostingJourney(
+            ContractStore.self,
+            rootView: TerminationSuccessScreen(),
+            style: .modal
+        ) {
+            action in
+            if case .dismissTerminationFlow = action {
+                DismissJourney()
+            }
+        }
+        .withDismissButton
+    }
+}

--- a/Projects/Contracts/Sources/Contracts.swift
+++ b/Projects/Contracts/Sources/Contracts.swift
@@ -128,6 +128,8 @@ extension Contracts {
                 resultJourney(.movingFlow)
             } else if case .setTerminationDate = action {
                 SetTerminationDate().disposableHostingJourney
+            } else if case .sendTermination = action {
+                TerminationSuccessScreen().disposableHostingJourney
             }
         }
         .onPresent({

--- a/Projects/Contracts/Sources/Contracts.swift
+++ b/Projects/Contracts/Sources/Contracts.swift
@@ -93,6 +93,8 @@ public enum ContractsResult {
     case openFreeTextChat
     case openCrossSellingDetail(crossSell: CrossSell)
     case openCrossSellingEmbark(name: String)
+    case terminationFlow
+    case terminationSuccessFlow
 }
 
 extension Contracts {
@@ -126,10 +128,8 @@ extension Contracts {
                 resultJourney(.openFreeTextChat)
             } else if case .goToMovingFlow = action {
                 resultJourney(.movingFlow)
-            } else if case .setTerminationDate = action {
-                SetTerminationDate().disposableHostingJourney
-            } else if case .sendTermination = action {
-                TerminationSuccessScreen().disposableHostingJourney
+            } else if case .goToTerminationFlow = action {
+                resultJourney(.terminationFlow)
             }
         }
         .onPresent({

--- a/Projects/Contracts/Sources/Contracts.swift
+++ b/Projects/Contracts/Sources/Contracts.swift
@@ -126,6 +126,8 @@ extension Contracts {
                 resultJourney(.openFreeTextChat)
             } else if case .goToMovingFlow = action {
                 resultJourney(.movingFlow)
+            } else if case .setTerminationDate = action {
+                SetTerminationDate().disposableHostingJourney
             }
         }
         .onPresent({

--- a/Projects/Contracts/Sources/ContractsStore.swift
+++ b/Projects/Contracts/Sources/ContractsStore.swift
@@ -89,8 +89,10 @@ public enum ContractAction: ActionProtocol {
 
     case contractDetailNavigationAction(action: ContractDetailNavigationAction)
 
-    case setTerminationDate
+    case goToTerminationFlow
+    //    case goToTerminationSuccess
     case sendTermination
+    case dismissTerminationFlow
 }
 
 public final class ContractStore: StateStore<ContractState, ContractAction> {

--- a/Projects/Contracts/Sources/ContractsStore.swift
+++ b/Projects/Contracts/Sources/ContractsStore.swift
@@ -90,6 +90,7 @@ public enum ContractAction: ActionProtocol {
     case contractDetailNavigationAction(action: ContractDetailNavigationAction)
 
     case setTerminationDate
+    case sendTermination
 }
 
 public final class ContractStore: StateStore<ContractState, ContractAction> {

--- a/Projects/Contracts/Sources/ContractsStore.swift
+++ b/Projects/Contracts/Sources/ContractsStore.swift
@@ -88,6 +88,8 @@ public enum ContractAction: ActionProtocol {
     case resetSignedCrossSells
 
     case contractDetailNavigationAction(action: ContractDetailNavigationAction)
+
+    case setTerminationDate
 }
 
 public final class ContractStore: StateStore<ContractState, ContractAction> {

--- a/Projects/Contracts/Sources/Screens/ContractDetail.swift
+++ b/Projects/Contracts/Sources/Screens/ContractDetail.swift
@@ -136,6 +136,15 @@ struct ContractDetail: View {
                         .animation(.interpolatingSpring(stiffness: 300, damping: 70))
                 }
             }
+            hButton.SmallButtonText {
+                //                TODO: Add journey
+            } content: {
+                hText(L10n.cancelSubscriptionButton, style: .body)
+                    .foregroundColor(hTintColor.red)
+
+            }
+            .padding(.top, 0)
+            .padding(.bottom, 39)
         }
         .trackOnAppear(hAnalyticsEvent.screenView(screen: .insuranceDetail))
     }

--- a/Projects/Contracts/Sources/Screens/ContractDetail.swift
+++ b/Projects/Contracts/Sources/Screens/ContractDetail.swift
@@ -137,7 +137,7 @@ struct ContractDetail: View {
                 }
             }
             hButton.SmallButtonText {
-                store.send(.setTerminationDate)
+                store.send(.goToTerminationFlow)
             } content: {
                 hText(L10n.cancelSubscriptionButton, style: .body)
                     .foregroundColor(hTintColor.red)

--- a/Projects/Contracts/Sources/Screens/ContractDetail.swift
+++ b/Projects/Contracts/Sources/Screens/ContractDetail.swift
@@ -137,7 +137,7 @@ struct ContractDetail: View {
                 }
             }
             hButton.SmallButtonText {
-                //                TODO: Add journey
+                store.send(.setTerminationDate)
             } content: {
                 hText(L10n.cancelSubscriptionButton, style: .body)
                     .foregroundColor(hTintColor.red)
@@ -147,6 +147,7 @@ struct ContractDetail: View {
             .padding(.bottom, 39)
         }
         .trackOnAppear(hAnalyticsEvent.screenView(screen: .insuranceDetail))
+
     }
 }
 

--- a/Projects/Contracts/Sources/Screens/Viewables/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/Screens/Viewables/SetTerminationDate.swift
@@ -8,20 +8,22 @@ struct SetTerminationDate: View {
     var body: some View {
 
         hForm {
-
-            //            TODO: Fix
-            HStack(alignment: .center, spacing: 0) {
-                hText("Please set termination date for your home insurance.", style: .body)
+            HStack(spacing: 0) {
+                hText(L10n.setTerminationDateText, style: .body)
+                    .padding([.trailing, .leading], 12)
+                    .padding([.top, .bottom], 16)
             }
-            .padding(.trailing, 16)
-            .padding(.top, 20)
-            //            .background(Color.blue)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(hBackgroundColor.tertiary)
             .cornerRadius(12)
+            .padding(.leading, 16)
+            .padding(.trailing, 32)
+            .padding(.top, 20)
 
             hSection {
                 hRow {
                     HStack {
-                        hText("Termination date", style: .body)
+                        hText(L10n.terminationDateText, style: .body)
                         Spacer()
                         hText("\(printDate())", style: .body)
                             .foregroundColor(hLabelColor.link)
@@ -35,8 +37,7 @@ struct SetTerminationDate: View {
                 )
                 .datePickerStyle(.graphical)
             }
-
-            .padding(.top, 94)
+            .padding(.top, 60)
 
             hButton.LargeButtonFilled {
                 // TODO: Add action

--- a/Projects/Contracts/Sources/Screens/Viewables/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/Screens/Viewables/SetTerminationDate.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct SetTerminationDate: View {
+    @State private var terminationDate = Date()
+
+    var body: some View {
+
+        hForm {
+
+            //            TODO: Fix
+            HStack(alignment: .center, spacing: 0) {
+                hText("Please set termination date for your home insurance.", style: .body)
+            }
+            .padding(.trailing, 16)
+            .padding(.top, 20)
+            //            .background(Color.blue)
+            .cornerRadius(12)
+
+            hSection {
+                hRow {
+                    HStack {
+                        hText("Termination date", style: .body)
+                        Spacer()
+                        hText("\(printDate())", style: .body)
+                            .foregroundColor(hLabelColor.link)
+                    }
+                }
+
+                DatePicker(
+                    "Termination Date",
+                    selection: $terminationDate,
+                    displayedComponents: [.date]
+                )
+                .datePickerStyle(.graphical)
+            }
+
+            .padding(.top, 94)
+
+            hButton.LargeButtonFilled {
+                // TODO: Add action
+            } content: {
+                hText(L10n.generalContinueButton, style: .body)
+                    .foregroundColor(hLabelColor.primary.inverted)
+            }
+            .padding([.leading, .trailing], 16)
+        }
+    }
+
+    func printDate() -> String {
+        let dateFormatter = DateFormatter()
+
+        dateFormatter.timeStyle = DateFormatter.Style.none
+        dateFormatter.dateStyle = DateFormatter.Style.short
+        dateFormatter.dateFormat = "dd-MM-yyyy"
+        return dateFormatter.string(from: terminationDate)
+    }
+
+}
+
+struct SetTerminationDate_Previews: PreviewProvider {
+    static var previews: some View {
+        SetTerminationDate()
+    }
+}

--- a/Projects/Contracts/Sources/View/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/View/SetTerminationDate.swift
@@ -42,7 +42,7 @@ public struct SetTerminationDate: View {
                 .padding([.leading, .trailing], (UIScreen.main.bounds.width) / 30)
                 .padding([.top], 5)
             }
-            .padding(.bottom, 40)
+            .padding(.top, 60)  //change
             //            .padding(.top, (UIScreen.main.bounds.height)/8)
         }
         .padding(.bottom, -200)

--- a/Projects/Contracts/Sources/View/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/View/SetTerminationDate.swift
@@ -28,7 +28,7 @@ public struct SetTerminationDate: View {
                     HStack {
                         hText(L10n.terminationDateText, style: .body)
                         Spacer()
-                        hText(printDate(), style: .body)
+                        hText(formatAndPrintDate(), style: .body)
                             .foregroundColor(hLabelColor.link)
                     }
                 }
@@ -39,27 +39,30 @@ public struct SetTerminationDate: View {
                     displayedComponents: [.date]
                 )
                 .datePickerStyle(.graphical)
-                .padding([.leading, .trailing], (UIScreen.main.bounds.width) / 30)
+                .padding(.leading, 16)
                 .padding([.top], 5)
             }
-            .padding(.top, 60)  //change
-            //            .padding(.top, (UIScreen.main.bounds.height)/8)
+            .padding(.top, UIScreen.main.bounds.height / 12)
         }
-        .padding(.bottom, -200)
+        .hFormAttachToBottom {
 
-        hButton.LargeButtonFilled {
-            store.send(.sendTermination)
-        } content: {
-            hText(L10n.generalContinueButton, style: .body)
-                .foregroundColor(hLabelColor.primary.inverted)
+            VStack {
+                hButton.LargeButtonFilled {
+                    store.send(.sendTermination)
+                } content: {
+                    hText(L10n.generalContinueButton, style: .body)
+                        .foregroundColor(hLabelColor.primary.inverted)
+                        .frame(minHeight: 52)
+                        .frame(minWidth: 200)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .padding([.top, .leading, .trailing], 16)
+            .padding(.bottom, 40)
         }
-        .frame(maxWidth: .infinity, alignment: .bottom)
-        .padding([.leading, .trailing], 16)
-        .padding(.bottom, 40)
-        .padding(.top, 10)
     }
 
-    func printDate() -> String {
+    func formatAndPrintDate() -> String {
         let dateFormatter = DateFormatter()
 
         dateFormatter.timeStyle = DateFormatter.Style.none
@@ -67,7 +70,6 @@ public struct SetTerminationDate: View {
         dateFormatter.dateFormat = "dd-MM-yyyy"
         return dateFormatter.string(from: terminationDate)
     }
-
 }
 
 struct SetTerminationDate_Previews: PreviewProvider {

--- a/Projects/Contracts/Sources/View/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/View/SetTerminationDate.swift
@@ -3,6 +3,7 @@ import hCore
 import hCoreUI
 
 struct SetTerminationDate: View {
+    @PresentableStore var store: ContractStore
     @State private var terminationDate = Date()
 
     var body: some View {
@@ -40,7 +41,7 @@ struct SetTerminationDate: View {
             .padding(.top, 60)
 
             hButton.LargeButtonFilled {
-                // TODO: Add action
+                store.send(.sendTermination)
             } content: {
                 hText(L10n.generalContinueButton, style: .body)
                     .foregroundColor(hLabelColor.primary.inverted)

--- a/Projects/Contracts/Sources/View/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/View/SetTerminationDate.swift
@@ -2,11 +2,13 @@ import SwiftUI
 import hCore
 import hCoreUI
 
-struct SetTerminationDate: View {
-    @PresentableStore var store: ContractStore
+public struct SetTerminationDate: View {
     @State private var terminationDate = Date()
+    @PresentableStore var store: ContractStore
 
-    var body: some View {
+    public init() {}
+
+    public var body: some View {
 
         hForm {
             HStack(spacing: 0) {
@@ -26,22 +28,25 @@ struct SetTerminationDate: View {
                     HStack {
                         hText(L10n.terminationDateText, style: .body)
                         Spacer()
-                        hText("\(printDate())", style: .body)
+                        hText(printDate(), style: .body)
                             .foregroundColor(hLabelColor.link)
                     }
                 }
 
                 DatePicker(
                     "Termination Date",
-                    selection: $terminationDate,
+                    selection: self.$terminationDate,
                     displayedComponents: [.date]
                 )
                 .datePickerStyle(.graphical)
+                .padding([.leading, .trailing], 14)
+                .padding([.top], 5)
             }
-            .padding(.top, 60)
+            .padding(.top, (UIScreen.main.bounds.height) / 10)
 
             hButton.LargeButtonFilled {
                 store.send(.sendTermination)
+                store.send(.dismissTerminationFlow)
             } content: {
                 hText(L10n.generalContinueButton, style: .body)
                     .foregroundColor(hLabelColor.primary.inverted)

--- a/Projects/Contracts/Sources/View/SetTerminationDate.swift
+++ b/Projects/Contracts/Sources/View/SetTerminationDate.swift
@@ -39,20 +39,24 @@ public struct SetTerminationDate: View {
                     displayedComponents: [.date]
                 )
                 .datePickerStyle(.graphical)
-                .padding([.leading, .trailing], 14)
+                .padding([.leading, .trailing], (UIScreen.main.bounds.width) / 30)
                 .padding([.top], 5)
             }
-            .padding(.top, (UIScreen.main.bounds.height) / 10)
-
-            hButton.LargeButtonFilled {
-                store.send(.sendTermination)
-                store.send(.dismissTerminationFlow)
-            } content: {
-                hText(L10n.generalContinueButton, style: .body)
-                    .foregroundColor(hLabelColor.primary.inverted)
-            }
-            .padding([.leading, .trailing], 16)
+            .padding(.bottom, 40)
+            //            .padding(.top, (UIScreen.main.bounds.height)/8)
         }
+        .padding(.bottom, -200)
+
+        hButton.LargeButtonFilled {
+            store.send(.sendTermination)
+        } content: {
+            hText(L10n.generalContinueButton, style: .body)
+                .foregroundColor(hLabelColor.primary.inverted)
+        }
+        .frame(maxWidth: .infinity, alignment: .bottom)
+        .padding([.leading, .trailing], 16)
+        .padding(.bottom, 40)
+        .padding(.top, 10)
     }
 
     func printDate() -> String {

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -21,7 +21,7 @@ public struct TerminationSuccessScreen: View {
                 .padding(.leading, 16)
                 .padding([.bottom, .top], 10)
 
-            hText(L10n.terminationSuccessfulText(printDate(), "Hedvig"), style: .body)
+            hText(L10n.terminationSuccessfulText(formatAndPrintDate(), "Hedvig"), style: .body)
                 .foregroundColor(hLabelColor.secondary)
                 .padding([.leading, .trailing], 16)
                 .padding(.bottom, 300)
@@ -39,7 +39,7 @@ public struct TerminationSuccessScreen: View {
         .padding(.bottom, 40)
     }
 
-    func printDate() -> String {
+    func formatAndPrintDate() -> String {
         let formatter = DateFormatter()
         let myString = formatter.string(from: terminationDate)
         let yourDate = formatter.date(from: myString)

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -2,10 +2,13 @@ import SwiftUI
 import hCore
 import hCoreUI
 
-struct TerminationSuccessScreen: View {
+public struct TerminationSuccessScreen: View {
     @State private var terminationDate = Date()
+    @PresentableStore var store: ContractStore
 
-    var body: some View {
+    public init() {}
+
+    public var body: some View {
 
         hForm {
             Image(uiImage: hCoreUIAssets.circularCheckmark.image)
@@ -24,7 +27,7 @@ struct TerminationSuccessScreen: View {
         }
 
         hButton.LargeButtonFilled {
-            /* TODO: Action */
+            store.send(.dismissTerminationFlow)
         } content: {
             hText("Done", style: .body)
                 .foregroundColor(hLabelColor.primary.inverted)

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct TerminationSuccessScreen: View {
+    @State private var terminationDate = Date()
+
+    var body: some View {
+
+        hForm {
+            Image(uiImage: hCoreUIAssets.circularCheckmark.image)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 16)
+                .padding(.top, 81)
+
+            hText(L10n.terminationSuccessfulTitle, style: .title1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 16)
+                .padding([.bottom, .top], 10)
+
+            hText(L10n.terminationSuccessfulText(printDate(), "Hedvig"), style: .body)
+                .foregroundColor(hLabelColor.secondary)
+                .padding([.leading, .trailing], 16)
+        }
+
+        hButton.LargeButtonFilled {
+            /* TODO: Action */
+        } content: {
+            hText("Done", style: .body)
+                .foregroundColor(hLabelColor.primary.inverted)
+        }
+        .frame(maxWidth: .infinity, alignment: .bottom)
+        .padding([.leading, .trailing], 16)
+        .padding(.bottom, 40)
+    }
+
+    func printDate() -> String {
+        let formatter = DateFormatter()
+        let myString = formatter.string(from: terminationDate)
+        let yourDate = formatter.date(from: myString)
+        formatter.dateFormat = "dd-MM-yyyy"
+        let myStringDate = formatter.string(from: yourDate!)
+
+        return (myStringDate)
+    }
+
+}
+
+struct TerminationSuccessScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        TerminationSuccessScreen()
+    }
+}

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -24,7 +24,9 @@ public struct TerminationSuccessScreen: View {
             hText(L10n.terminationSuccessfulText(printDate(), "Hedvig"), style: .body)
                 .foregroundColor(hLabelColor.secondary)
                 .padding([.leading, .trailing], 16)
+                .padding(.bottom, 300)
         }
+        .padding(.bottom, -100)
 
         hButton.LargeButtonFilled {
             store.send(.dismissTerminationFlow)


### PR DESCRIPTION
## [APP-350]

Added summary screen
- Terminate contract button
- Termination Flow Journey
- SetTerminationDate Screen
- TerminationSuccessful screen

Figma link: https://www.figma.com/file/w77DwpXFMMbt3ujLmijYZy/Terminate-Insurance-iOS?node-id=769%3A22924&t=kZIpKEAm1kkgHMy6-0 

## Checklist

- [ x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[APP-350]: https://hedvig.atlassian.net/browse/APP-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ