### PR TITLE
CLX-391 Open churn survey from success screen

### DIFF
--- a/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
+++ b/Projects/App/Sources/Journeys/TerminationFlowJourney.swift
@@ -15,7 +15,7 @@ extension AppJourney {
             }
         }
         .setScrollEdgeNavigationBarAppearanceToStandard
-        .withDismissButton
+        .withJourneyDismissButton
     }
 
     static func sendTermination() -> some JourneyPresentation {
@@ -30,7 +30,7 @@ extension AppJourney {
                 DismissJourney()
             }
         }
-        .withDismissButton
+        .withJourneyDismissButton
         .setScrollEdgeNavigationBarAppearanceToStandard
     }
 }

--- a/Projects/Contracts/Sources/ContractsStore.swift
+++ b/Projects/Contracts/Sources/ContractsStore.swift
@@ -91,7 +91,6 @@ public enum ContractAction: ActionProtocol {
     case contractDetailNavigationAction(action: ContractDetailNavigationAction)
 
     case goToTerminationFlow
-    //    case goToTerminationSuccess
     case sendTermination
     case dismissTerminationFlow
 }

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -29,9 +29,30 @@ public struct TerminationSuccessScreen: View {
         .padding(.bottom, -100)
 
         hButton.LargeButtonFilled {
+
+            let currentMarket = Localization.Locale.currentLocale.market
+            var surveyURL = ""
+
+            switch currentMarket {
+            case .se:
+                surveyURL =
+                    "https://hedvigapp.typeform.com/to/YHVVx1#memberid=xxxxx&contract_id=xxxxx&contract_name=xxxxx&terminated_contracts_count=xxxxx"
+            case .no:
+                surveyURL = "https://hedvigapp.typeform.com/to/a7aRZzir#memberid=xxxxx"
+            case .dk:
+                surveyURL = "https://hedvigapp.typeform.com/to/dk9Dj7S8#memberid=xxxxx"
+            default:
+                break
+            }
+
+            if let url = URL(
+                string: surveyURL
+            ) {
+                UIApplication.shared.open(url)
+            }
             store.send(.dismissTerminationFlow)
         } content: {
-            hText("Done", style: .body)
+            hText(L10n.continueToSurveyButton, style: .body)
                 .foregroundColor(hLabelColor.primary.inverted)
         }
         .frame(maxWidth: .infinity, alignment: .bottom)

--- a/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
+++ b/Projects/Contracts/Sources/View/TerminationSuccessScreen.swift
@@ -31,26 +31,28 @@ public struct TerminationSuccessScreen: View {
         hButton.LargeButtonFilled {
 
             let currentMarket = Localization.Locale.currentLocale.market
-            var surveyURL = ""
-
-            switch currentMarket {
-            case .se:
-                surveyURL =
-                    "https://hedvigapp.typeform.com/to/YHVVx1#memberid=xxxxx&contract_id=xxxxx&contract_name=xxxxx&terminated_contracts_count=xxxxx"
-            case .no:
-                surveyURL = "https://hedvigapp.typeform.com/to/a7aRZzir#memberid=xxxxx"
-            case .dk:
-                surveyURL = "https://hedvigapp.typeform.com/to/dk9Dj7S8#memberid=xxxxx"
-            default:
-                break
+            var surveyURL: URL? {
+                switch currentMarket {
+                case .se:
+                    return URL(
+                        string:
+                            "https://hedvigapp.typeform.com/to/YHVVx1#memberid=xxxxx&contract_id=xxxxx&contract_name=xxxxx&terminated_contracts_count=xxxxx"
+                    )
+                case .no:
+                    return URL(string: "https://hedvigapp.typeform.com/to/a7aRZzir#memberid=xxxxx")
+                case .dk:
+                    return URL(string: "https://hedvigapp.typeform.com/to/dk9Dj7S8#memberid=xxxxx")
+                case .fr:
+                    fatalError("not supported in FR")
+                }
             }
 
-            if let url = URL(
-                string: surveyURL
-            ) {
-                UIApplication.shared.open(url)
+            if let surveyURL {
+                UIApplication.shared.open(surveyURL)
             }
+
             store.send(.dismissTerminationFlow)
+
         } content: {
             hText(L10n.continueToSurveyButton, style: .body)
                 .foregroundColor(hLabelColor.primary.inverted)


### PR DESCRIPTION
## [CLX-391]

- Added survey link to all markets from termination successful screen

## Checklist

- [x] Dark/light mode verification
- [x] Landscape verification
- [x] iPad verification
- [x] iPod/iPhone 12 mini/iPhone SE verification


[CLX-391]: https://hedvig.atlassian.net/browse/CLX-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ