### PR TITLE
CLX-394: Update Peril Design

### DIFF
--- a/Projects/Claims/Sources/CommonClaims/CommonClaimDetail.swift
+++ b/Projects/Claims/Sources/CommonClaims/CommonClaimDetail.swift
@@ -46,17 +46,10 @@ extension CommonClaimDetail: Presentable {
         topCardContentView.isLayoutMarginsRelativeArrangement = true
         topCard.addSubview(topCardContentView)
 
-        topCardContentView.snp.makeConstraints { make in make.top.bottom.trailing.leading.equalToSuperview() }
-
-        let icon = RemoteVectorIcon(claim.icon, threaded: true)
-        bag += topCardContentView.addArranged(
-            icon.alignedTo(
-                .leading,
-                configure: { iconView in
-                    iconView.snp.makeConstraints { make in make.height.width.equalTo(40) }
-                }
-            )
-        )
+        topCardContentView.snp.makeConstraints { make in
+            make.bottom.trailing.leading.equalToSuperview()
+            make.top.equalTo(40)
+        }
 
         let layoutTitle = MultilineLabel(value: self.layoutTitle, style: .brand(.title2(color: .primary)))
         bag += topCardContentView.addArranged(layoutTitle)

--- a/Projects/hCoreUI/Sources/PerilCollection/PerilDetail.swift
+++ b/Projects/hCoreUI/Sources/PerilCollection/PerilDetail.swift
@@ -31,12 +31,6 @@ extension PerilDetail: Presentable {
 
         form.append(stackView)
 
-        bag += stackView.addArranged(RemoteVectorIcon(peril.icon)) { iconView in
-            iconView.snp.makeConstraints { make in make.height.width.equalTo(80) }
-        }
-
-        bag += stackView.addArranged(Spacing(height: 20))
-
         bag += stackView.addArranged(
             MultilineLabel(value: peril.title, style: .brand(.title1(color: .primary)).centerAligned)
         )


### PR DESCRIPTION
## [CLX-394]

- Removed peril icons to match design
https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/*NEW*-.com-UI-Kit?node-id=1685-7405&t=x53wrpFiNSVZ7Nst-0

![simulator_screenshot_DF27325F-C0B4-46F8-80C6-CB857B7EDEF7](https://user-images.githubusercontent.com/123949181/223661684-b769da57-fed9-4a86-a171-f64b6e114f58.png)
![simulator_screenshot_77E4558F-F5C1-4CE1-9788-8EF118612813](https://user-images.githubusercontent.com/123949181/223661765-b8a30df0-074c-415f-bbe3-cac155580d41.png)

## Checklist

- [X] Dark/light mode verification
- [X] Landscape verification
- [X] iPad verification
- [X] iPod/iPhone 12 mini/iPhone SE verification


[CLX-394]: https://hedvig.atlassian.net/browse/CLX-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ