### PR TITLE
Fix file uploads

### DIFF
--- a/Projects/App/Sources/Generic/Extensions/NSFileCoordinator+Flow.swift
+++ b/Projects/App/Sources/Generic/Extensions/NSFileCoordinator+Flow.swift
@@ -2,21 +2,33 @@ import Flow
 import Foundation
 
 extension NSFileCoordinator {
-    enum CoordinatorError: Error { case failureConvertingToData }
+    enum CoordinatorError: Error {
+        case failureConvertingToData
+        case accessingSecurityScopedResource
+    }
 
     func coordinate(readingItemAt: URL, options: NSFileCoordinator.ReadingOptions) -> Future<Data> {
-        Future { completion in let errorPointer = NSErrorPointer(nilLiteral: ())
+        Future { completion in
+            let errorPointer = NSErrorPointer(nilLiteral: ())
 
             self.coordinate(readingItemAt: readingItemAt, options: options, error: errorPointer) { url in
-
+                guard url.startAccessingSecurityScopedResource() else {
+                    completion(.failure(CoordinatorError.accessingSecurityScopedResource))
+                    return
+                }
+                
                 if let data = try? Data(contentsOf: url) {
                     completion(.success(data))
                 } else {
                     completion(.failure(CoordinatorError.failureConvertingToData))
                 }
+                
+                url.stopAccessingSecurityScopedResource()
             }
 
-            if let error = errorPointer?.pointee { print(error) }
+            if let error = errorPointer?.pointee {
+                print(error)
+            }
 
             return NilDisposer()
         }


### PR DESCRIPTION
Apparently we need to call `url.startAccessingSecurityScopedResource()` before starting to read the data at the URL else it won't do it, how this worked in the past is a mystery to me 🤸‍♂️ 