### PR TITLE
Use hGiraffe in Adyen to resolve crash in injecting ApolloClient

### DIFF
--- a/Projects/Payment/Sources/Screens/Adyen/AdyenPayIn.swift
+++ b/Projects/Payment/Sources/Screens/Adyen/AdyenPayIn.swift
@@ -12,8 +12,8 @@ import hGraphQL
 
 extension AdyenMethodsList {
     static var payInOptions: Future<AdyenOptions> {
-        let client: ApolloClient = Dependencies.shared.resolve()
-        return client.fetch(query: GiraffeGraphQL.AdyenAvailableMethodsQuery())
+        let giraffe: hGiraffe = Dependencies.shared.resolve()
+        return giraffe.client.fetch(query: GiraffeGraphQL.AdyenAvailableMethodsQuery())
             .compactMap { data in
                 guard
                     let paymentMethodsData = data.availablePaymentMethods.paymentMethodsResponse

--- a/Projects/Payment/Sources/Screens/Adyen/AdyenPayOut.swift
+++ b/Projects/Payment/Sources/Screens/Adyen/AdyenPayOut.swift
@@ -11,8 +11,8 @@ import hGraphQL
 
 extension AdyenMethodsList {
     static var payOutOptions: Future<AdyenOptions> {
-        let client: ApolloClient = Dependencies.shared.resolve()
-        return client.fetch(query: GiraffeGraphQL.AdyenAvailableMethodsQuery())
+        let giraffe: hGiraffe = Dependencies.shared.resolve()
+        return giraffe.client.fetch(query: GiraffeGraphQL.AdyenAvailableMethodsQuery())
             .compactMap { data in
                 guard
                     let paymentMethodsData = data.availablePayoutMethods.paymentMethodsResponse


### PR DESCRIPTION
#[CLX-536]

> Resolve a crash which happens in Adyen where it tries to resolve ApolloClient, but we changed that to be inside hGiraffe, miss from GraphQL Octopus support refactor.