### PR TITLE
Added spacing for notifications; fixed issue with recording audio layout

### DIFF
--- a/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
+++ b/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
@@ -28,7 +28,7 @@ public struct ClaimFlowAskForPushnotifications: View {
 
         }
         .hFormAttachToBottom {
-            VStack {
+            VStack(spacing: 12) {
                 hButton.LargeButtonFilled {
                     let current = UNUserNotificationCenter.current()
                     current.getNotificationSettings(completionHandler: { settings in

--- a/Projects/Claims/Sources/Views/SubmitClaim/AudioRecording/SubmitClaimAudioRecordingScreen.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/AudioRecording/SubmitClaimAudioRecordingScreen.swift
@@ -68,7 +68,7 @@ public struct SubmitClaimAudioRecordingScreen: View {
                                     hText(L10n.embarkRecordAgain)
                                 }
                             }
-                            .transition(.move(edge: .bottom))
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
                             .onAppear {
                                 self.audioPlayer.url = recording.url
                             }


### PR DESCRIPTION
- Ask for notification button spacing
- Continue button shows a little bit after we press record again on audio recording screen

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
