### PR TITLE
Added unique to quoteCart_startCheckout

### DIFF
--- a/Projects/Offer/Sources/OfferStore.swift
+++ b/Projects/Offer/Sources/OfferStore.swift
@@ -260,7 +260,7 @@ public final class OfferStore: StateStore<OfferState, OfferAction> {
             let state = getState()
             if let quoteCartId = state.quoteCartId, let quoteId = state.currentVariant?.id {
                 let ids = state.currentVariant?.bundle.quotes.compactMap { $0.id } ?? [quoteId]
-                return requestQuoteCartSign(quoteCartId: quoteCartId, ids: ids)
+                return requestQuoteCartSign(quoteCartId: quoteCartId, ids: ids.unique())
             }
         case .fetchAccessToken:
             if let quoteCartId = getState().quoteCartId {

--- a/Projects/hCore/Sources/Array+Unique.swift
+++ b/Projects/hCore/Sources/Array+Unique.swift
@@ -1,0 +1,7 @@
+import Foundation
+extension Sequence where Iterator.Element: Hashable {
+    public func unique() -> [Iterator.Element] {
+        var seen: Set<Iterator.Element> = []
+        return filter { seen.insert($0).inserted }
+    }
+}


### PR DESCRIPTION
- Added unique to quoteCart_startCheckout mutation

We got report that moving flow is out of order.
https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1682081269778709

After analysing the issue we found out that we are sending same value 2 times on requestQuoteCartSign mutation.
To avoid this, I have added unique for this before sending this mutation.

This is fast solution that should fix issue.
## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
