### PR TITLE
Fixed issue with starting app from notificaiton

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -47,12 +47,6 @@ extension AppJourney {
             .configureClaimsNavigation
             .configureSubmitClaimsNavigation
             .configurePaymentNavigation
-            .onPresent {
-                ApplicationContext.shared.$isLoggedIn.value = true
-            }
-            .onDismiss {
-                ApplicationContext.shared.$isLoggedIn.value = false
-            }
     }
 
     fileprivate static var contractsTab: some JourneyPresentation {
@@ -148,11 +142,16 @@ extension AppJourney {
                     freeTextChat(style: .unlessAlreadyPresented(style: .detented(.large)))
                         .withDismissButton
                 }
+            }.onPresent {
+                ApplicationState.preserveState(.loggedIn)
+                AnalyticsCoordinator().setUserId()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    ApplicationContext.shared.$isLoggedIn.value = true
+                }
             }
         }
-        .onPresent {
-            ApplicationState.preserveState(.loggedIn)
-            AnalyticsCoordinator().setUserId()
+        .onDismiss {
+            ApplicationContext.shared.$isLoggedIn.value = false
         }
     }
 }


### PR DESCRIPTION
[https://www.notion.so/hedviginsurance/Opening-a-chat-notification-takes-the-member-to-the-Home-tab-instead-of-the-chat-4a0bc613c12a40608b3c5330c6ac10dc](url)

Issue was that tabController wasn't loaded and therefore action openChat was't called

- Fixed issue with running app from the notifications

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
