### PR TITLE
fixed issue with claim card not opening if only one

### DIFF
--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -14,7 +14,7 @@ struct ClaimStatus: View {
         return { claim in
             store.send(.openClaimDetails(claim: claim))
 
-            hAnalyticsEvent.claimCardClick(
+            _ = hAnalyticsEvent.claimCardClick(
                 claimId: self.claim.id,
                 claimStatus: self.claim.claimDetailData.status.rawValue
             )

--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -10,33 +10,17 @@ struct ClaimStatus: View {
     @PresentableStore
     var store: ClaimsStore
 
-    var body: some View {
-        Button {
+    var tapAction: (Claim) -> Void {
+        return { claim in
             store.send(.openClaimDetails(claim: claim))
-        } label: {
-
         }
-        .buttonStyle(ClaimStatusButtonStyle(claim: claim))
-        .trackOnAppear(
-            hAnalyticsEvent.claimCardVisible(
-                claimId: self.claim.id,
-                claimStatus: self.claim.claimDetailData.status.rawValue
-            )
-        )
-        .trackOnTap(
-            hAnalyticsEvent.claimCardClick(
-                claimId: self.claim.id,
-                claimStatus: self.claim.claimDetailData.status.rawValue
-            )
-        )
     }
-}
 
-struct ClaimStatusButtonStyle: ButtonStyle {
-    let claim: Claim
-
-    func makeBody(configuration: Configuration) -> some View {
+    var body: some View {
         CardComponent(
+            onSelected: {
+                tapAction(claim)
+            },
             mainContent: ClaimPills(claim: claim),
             title: claim.title,
             subTitle: claim.subtitle,

--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -13,6 +13,11 @@ struct ClaimStatus: View {
     var tapAction: (Claim) -> Void {
         return { claim in
             store.send(.openClaimDetails(claim: claim))
+
+            hAnalyticsEvent.claimCardClick(
+                claimId: self.claim.id,
+                claimStatus: self.claim.claimDetailData.status.rawValue
+            )
         }
     }
 
@@ -31,6 +36,12 @@ struct ClaimStatus: View {
                     }
                 }
             }
+        )
+        .trackOnAppear(
+            hAnalyticsEvent.claimCardVisible(
+                claimId: self.claim.id,
+                claimStatus: self.claim.claimDetailData.status.rawValue
+            )
         )
     }
 }


### PR DESCRIPTION
## [APP-XXX]

- Fix bug with claim card not opening if only one claim

## Checklist

- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
