### PR TITLE
GEN-785:Added notifications and language to settings screen

### DIFF
--- a/Projects/App/Sources/Screens/SettingsScreen/SettingsScreen.swift
+++ b/Projects/App/Sources/Screens/SettingsScreen/SettingsScreen.swift
@@ -29,10 +29,6 @@ struct SettingsScreen: View {
                                 return
                             }
                             DispatchQueue.main.async { UIApplication.shared.open(settingsUrl) }
-                            UNUserNotificationCenter.current()
-                                .getNotificationSettings { settings in
-                                    settings.setValue(<#T##value: Any?##Any?#>, forKey: <#T##String#>)
-                                }
                         }
                     )
                     PresentableStoreLens(

--- a/Projects/App/Sources/Screens/SettingsScreen/SettingsScreen.swift
+++ b/Projects/App/Sources/Screens/SettingsScreen/SettingsScreen.swift
@@ -25,7 +25,14 @@ struct SettingsScreen: View {
                         value: Localization.Locale.currentLocale.displayName,
                         placeholder: L10n.settingsLanguageTitle,
                         onTap: {
-                            // todo: add action to display language picker
+                            guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                                return
+                            }
+                            DispatchQueue.main.async { UIApplication.shared.open(settingsUrl) }
+                            UNUserNotificationCenter.current()
+                                .getNotificationSettings { settings in
+                                    settings.setValue(<#T##value: Any?##Any?#>, forKey: <#T##String#>)
+                                }
                         }
                     )
                     PresentableStoreLens(
@@ -39,7 +46,15 @@ struct SettingsScreen: View {
                                 ? L10n.profileNotificationsStatusOn : L10n.profileNotificationsStatusOff,
                             placeholder: L10n.pushNotificationsAlertTitle,
                             onTap: {
-                                // todo: add action to allow notifications
+                                if store.state.pushNotificationCurrentStatus() == .authorized {
+                                    guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                                        return
+                                    }
+                                    DispatchQueue.main.async { UIApplication.shared.open(settingsUrl) }
+                                } else {
+                                    _ = UIApplication.shared.appDelegate
+                                        .registerForPushNotifications()
+                                }
                             }
                         )
                     }


### PR DESCRIPTION
## [APP-XXX]

- open settings for language picker
- ask for notification permission or open settings for notifications

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
