### PR TITLE
Travel certificate ui fix

### DIFF
--- a/Projects/Payment/Sources/Viewables/PaymentDetailsSection/PaymentInfoView.swift
+++ b/Projects/Payment/Sources/Viewables/PaymentDetailsSection/PaymentInfoView.swift
@@ -113,7 +113,7 @@ struct PaymentInfoView: View {
                             hText(L10n.paymentsAddCodeLabel)
                                 .padding(.leading, 2)
                         }
-                        .toggleStyle(ChecboxToggleStyle())
+                        .toggleStyle(ChecboxToggleStyle(.center))
                         if vm.addCodeState {
                             HStack {
                                 hFloatingTextField(

--- a/Projects/TravelCertificate/Sources/TravelInsuranceFlowJourney.swift
+++ b/Projects/TravelCertificate/Sources/TravelInsuranceFlowJourney.swift
@@ -104,7 +104,8 @@ public struct TravelInsuranceFlowJourney {
         HostingJourney(
             TravelInsuranceStore.self,
             rootView: InsuredMemberScreen(member),
-            style: .detented(.scrollViewContentSize)
+            style: .detented(.scrollViewContentSize),
+            options: [.largeNavigationBar]
         ) { action in
             if case let .navigation(navigationAction) = action {
                 if case .dismissAddUpdateCoinsured = navigationAction {

--- a/Projects/TravelCertificate/Sources/Views/InsuredMemberScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/InsuredMemberScreen.swift
@@ -22,6 +22,7 @@ struct InsuredMemberScreen: View {
             }
             .hWithoutDivider
         }
+        .hDisableScroll
         .sectionContainerStyle(.transparent)
         .hFormAttachToBottom {
             hSection {
@@ -30,13 +31,13 @@ struct InsuredMemberScreen: View {
                         vm.submit()
                     } content: {
                         if vm.policyCoinsuredPerson == nil {
-                            hText(L10n.generalContinueButton)
+                            hText(L10n.generalSaveButton)
                         } else {
                             hText(L10n.TravelCertificate.confirmButtonChangeMember)
                         }
                     }
 
-                    hButton.SmallButtonText {
+                    hButton.LargeButtonGhost {
                         vm.dismiss()
                     } content: {
                         hText(L10n.generalCancelButton)
@@ -108,11 +109,15 @@ class InsuredMemberViewModel: ObservableObject {
             UIApplication.dismissKeyboard()
             let newPolicyCoInsured = PolicyCoinsuredPersonModel(fullName: fullName, personalNumber: personalNumber)
             if let policyCoinsuredPerson = policyCoinsuredPerson {
+                dismiss()
                 store.send(.updatePolicyCoInsured(policyCoinsuredPerson, with: newPolicyCoInsured))
             } else {
-                store.send(
-                    .setPolicyCoInsured(newPolicyCoInsured)
-                )
+                dismiss()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.store.send(
+                        .setPolicyCoInsured(newPolicyCoInsured)
+                    )
+                }
             }
         } else {
 

--- a/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
@@ -40,7 +40,7 @@ struct WhoIsTravelingScreen: View {
                                             .foregroundColor(disabledColorOr(hTextColorNew.secondary))
                                     }
                                 }
-                                .toggleStyle(ChecboxToggleStyle())
+                                .toggleStyle(ChecboxToggleStyle(.top, spacing: 0))
                                 if model?.policyCoinsuredPersons.count ?? 0 == 0
                                     && vm.specifications?.numberOfCoInsured ?? 0 > 0
                                 {

--- a/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
+++ b/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
@@ -2,32 +2,47 @@ import Foundation
 import SwiftUI
 
 public struct ChecboxToggleStyle: ToggleStyle {
-    
-    public init(){}
-    
-    public func makeBody(configuration: Configuration) -> some View {
-        if #available(iOS 15.0, *) {
-            HStack {
-                configuration.label
-                Spacer()
-                RoundedRectangle(cornerRadius: 9)
-                    .fill(backgroundColor(isOn: configuration.isOn))
-                    .overlay {
-                        Circle()
-                            .fill(hTextColorNew.negative)
-                            .padding(1)
-                            .offset(x: configuration.isOn ? 5 : -5)
+    let alignment: VerticalAlignment
+    let spacing: CGFloat
+    public init(_ alignment: VerticalAlignment, spacing: CGFloat = 0) {
+        self.alignment = alignment
+        self.spacing = spacing
+    }
 
-                    }
-                    .frame(width: 28, height: 18)
-                    .onTapGesture {
-                        withAnimation(.spring()) {
-                            configuration.isOn.toggle()
+    public func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: alignment, spacing: 0) {
+            configuration.label
+            Spacer()
+            VStack {
+                if alignment == .top {
+                    Color.clear.frame(height: spacing)
+                }
+                if alignment == .bottom || alignment == .center {
+                    Spacer()
+                }
+                ZStack {
+                    RoundedRectangle(cornerRadius: 9)
+                        .fill(backgroundColor(isOn: configuration.isOn))
+                        .onTapGesture {
+                            withAnimation(.spring()) {
+                                configuration.isOn.toggle()
+                            }
                         }
-                    }
+                    Circle()
+                        .fill(hTextColorNew.negative)
+                        .padding(1)
+                        .offset(x: configuration.isOn ? 5 : -5)
+                }
+                .frame(width: 28, height: 18)
+
+                if alignment == .center {
+                    Spacer()
+                }
+                if alignment == .bottom {
+                    Color.clear.frame(height: spacing)
+                }
             }
-        } else {
-            Text("ssd")
+            .fixedSize(horizontal: true, vertical: false)
         }
     }
 
@@ -37,6 +52,22 @@ public struct ChecboxToggleStyle: ToggleStyle {
             hSignalColorNew.greenElement
         } else {
             hFillColorNew.opaqueThree
+        }
+    }
+}
+
+struct ChecboxToggleStyle_Previews: PreviewProvider {
+    @State static var isOn: Bool = false
+    static var previews: some View {
+        VStack {
+            Toggle(isOn: $isOn.animation(.default)) {
+                VStack(alignment: .leading, spacing: 0) {
+                    hText("tasd", style: .standardLarge)
+                    hText("sasdasdasdasd")
+                }
+            }
+            .toggleStyle(ChecboxToggleStyle(.top, spacing: 0))
+            Spacer()
         }
     }
 }


### PR DESCRIPTION
- Align switcher to top row of name
- Remove scroll
- Animation is too quick. Save - card goes down and the name appears one second later. 
- Add handle on add traveler

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
