### PR TITLE
Fix for login screen not showing

### DIFF
--- a/Projects/Market/Sources/Screens/NotLoggedIn/NotLoggedViewModel.swift
+++ b/Projects/Market/Sources/Screens/NotLoggedIn/NotLoggedViewModel.swift
@@ -47,6 +47,8 @@ public class NotLoggedViewModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        self.bootStrapped = true
     }
 
     func onCountryPressed() {


### PR DESCRIPTION
- Login screen not showing since

onLoad() doesn't get called after removing of detectMarket

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
