### PR TITLE
GEN-1338-remove go back buttton on summary screen and fix date picker color

### DIFF
--- a/Projects/Claims/Sources/Views/SubmitClaim/SummaryInfo/SubmitClaimSummaryScreen.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/SummaryInfo/SubmitClaimSummaryScreen.swift
@@ -34,19 +34,10 @@ public struct SubmitClaimSummaryScreen: View {
             VStack(spacing: 8) {
                 InfoCard(text: L10n.claimsComplementClaim, type: .info)
                     .padding(.bottom, 8)
-                Group {
-                    LoadingButtonWithContent(SubmitClaimStore.self, .postSummary) {
-                        store.send(.summaryRequest)
-                    } content: {
-                        hText(L10n.embarkSubmitClaim)
-                    }
-
-                    hButton.LargeButton(type: .ghost) {
-                        store.send(.navigationAction(action: .dismissScreen))
-                    } content: {
-                        hText(L10n.embarkGoBackButton)
-                    }
-                    .disableOn(SubmitClaimStore.self, [.postSummary])
+                LoadingButtonWithContent(SubmitClaimStore.self, .postSummary) {
+                    store.send(.summaryRequest)
+                } content: {
+                    hText(L10n.embarkSubmitClaim)
                 }
             }
             .padding(.horizontal, 16)

--- a/Projects/hCoreUI/Sources/HedvigColors.swift
+++ b/Projects/hCoreUI/Sources/HedvigColors.swift
@@ -48,7 +48,7 @@ extension UIColor {
         case chatTextView
         case alert
         case caution
-        case primaryAltButton
+        case datePickerSelectionColor
 
         public var color: UIColor {
             switch self {
@@ -157,10 +157,10 @@ extension UIColor {
                     trait.userInterfaceStyle == .dark
                         ? BrandColorBase.redDark : BrandColorBase.red600
                 })
-            case .primaryAltButton:
+            case .datePickerSelectionColor:
                 return UIColor(dynamic: { trait -> UIColor in
                     trait.userInterfaceStyle == .dark
-                        ? BrandColorBase.grayScale500 : BrandColorBase.green200
+                        ? BrandColorBase.grayScale500 : BrandColorBase.grayScale1000
                 })
             }
         }
@@ -191,7 +191,7 @@ extension UIColor {
             case .chatTextView: return Fonts.fontFor(style: .standard)
             case .caution: return Fonts.fontFor(style: .standard)
             case .alert: return Fonts.fontFor(style: .standard)
-            case .primaryAltButton: return Fonts.fontFor(style: .standard)
+            case .datePickerSelectionColor: return Fonts.fontFor(style: .standard)
             }
         }
     }

--- a/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
+++ b/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
@@ -291,7 +291,7 @@ extension DefaultStyling {
         //selection color
         //selected date is this color, system adds bold to it automaticly
         //this color is used as background and system adds some alpha to it
-        UIDatePicker.appearance().tintColor = .brand(.primaryText())
+        UIDatePicker.appearance().tintColor = .brand(.datePickerSelectionColor)
 
         UIImageView.appearance().tintColor = .brand(.primaryText())
         UIImageView.appearance(whenContainedInInstancesOf: [UIDatePicker.self]).tintColor = .brand(


### PR DESCRIPTION
## [GEN-1338]

- remove go back button on summary screen
- date picker color fix

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
