### PR TITLE
add possibility to select already entered co-insured for other contracts

### DIFF
--- a/Projects/Contracts/Sources/Stores/ContractState.swift
+++ b/Projects/Contracts/Sources/Stores/ContractState.swift
@@ -28,6 +28,21 @@ public struct ContractState: StateProtocol {
         let unique = Set(upcomingCoInsured + coInsured)
         return unique.sorted(by: { $0.fullName ?? "" > $1.fullName ?? "" })
     }
+    
+    public func fetchAllCoInsuredNotInContract(contractId: String) -> [CoInsuredModel] {
+        let currentCoInsured = contractForId(contractId)?.currentAgreement?.coInsured ?? []
+        let upcomingCoInsured = contractForId(contractId)?.upcomingChangedAgreement?.coInsured ?? []
+        
+        let coInsuredNotAdded = fetchAllCoInsured.compactMap {
+            if !currentCoInsured.contains($0) && !upcomingCoInsured.contains($0) {
+                return $0
+            } else {
+                return nil
+            }
+        }
+        
+        return coInsuredNotAdded
+    }
 
     public func contractForId(_ id: String) -> Contract? {
         let activeContracts = activeContracts.compactMap({ $0 })

--- a/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
@@ -102,16 +102,20 @@ struct InsuredPeopleScreen: View {
 
                         hSection {
                             hButton.LargeButton(type: .secondary) {
-                                store.send(
-                                    .coInsuredNavigationAction(
-                                        action: .openCoInsuredInput(
-                                            actionType: .add,
-                                            coInsuredModel: CoInsuredModel(),
-                                            title: L10n.contractAddCoinsured,
-                                            contractId: contractId
+                                if store.state.fetchAllCoInsuredNotInContract(contractId: contractId).isEmpty  {
+                                    store.send(
+                                        .coInsuredNavigationAction(
+                                            action: .openCoInsuredInput(
+                                                actionType: .add,
+                                                coInsuredModel: CoInsuredModel(),
+                                                title: L10n.contractAddCoinsured,
+                                                contractId: contractId
+                                            )
                                         )
                                     )
-                                )
+                                } else {
+                                    store.send(.coInsuredNavigationAction(action: .openCoInsuredSelectScreen(contractId: contractId)))
+                                }
                             } content: {
                                 hText(L10n.contractAddCoinsured)
                             }

--- a/Projects/Contracts/Sources/View/CoInsured/CoInsuredSelectScreen.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/CoInsuredSelectScreen.swift
@@ -15,7 +15,7 @@ struct CoInsuredSelectScreen: View {
         CheckboxPickerScreen<CoInsuredModel>(
             items: {
                 let contractStore: ContractStore = globalPresentableStoreContainer.get()
-                return contractStore.state.fetchAllCoInsured.compactMap {
+                return contractStore.state.fetchAllCoInsuredNotInContract(contractId: contractId).compactMap {
                     ((object: $0, displayName: $0.fullName ?? ""))
                 }
             }(),


### PR DESCRIPTION
## [APP-XXX]

- Added possibility to reuse already existing co-insured for other contracts when updating your co-insured

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
