### PR TITLE
Fix squished flow on add new co insured

### DIFF
--- a/Projects/Contracts/Sources/Journeys/EditCoInsuredJourney.swift
+++ b/Projects/Contracts/Sources/Journeys/EditCoInsuredJourney.swift
@@ -241,6 +241,7 @@ public class EditCoInsuredJourney {
                 PopJourney()
             }
         }
+        .hidesBackButton
         .configureTitle(L10n.contractAddConisuredInfo)
     }
 

--- a/Projects/Contracts/Sources/View/CoInsured/CoInsuredSelectScreen.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/CoInsuredSelectScreen.swift
@@ -15,9 +15,10 @@ struct CoInsuredSelectScreen: View {
         CheckboxPickerScreen<CoInsuredModel>(
             items: {
                 let contractStore: ContractStore = globalPresentableStoreContainer.get()
-                return contractStore.state.fetchAllCoInsuredNotInContract(contractId: contractId).compactMap {
-                    ((object: $0, displayName: $0.fullName ?? ""))
-                }
+                return contractStore.state.fetchAllCoInsuredNotInContract(contractId: contractId)
+                    .compactMap {
+                        ((object: $0, displayName: $0.fullName ?? ""))
+                    }
             }(),
             preSelectedItems: {
                 let contractStore: ContractStore = globalPresentableStoreContainer.get()
@@ -71,7 +72,8 @@ struct CoInsuredSelectScreen: View {
                 let contractStore: ContractStore = globalPresentableStoreContainer.get()
                 contractStore.send(.coInsuredNavigationAction(action: .dismissEdit))
             },
-            singleSelect: true
+            singleSelect: true,
+            attachToBottom: true
         )
         .hCheckboxPickerBottomAttachedView {
             hButton.LargeButton(type: .ghost) {


### PR DESCRIPTION
## [APP-XXX]

- Fixed UI issue when wants to add new co insured. Steps
1. You have already added co insured to one contract
2. In another contract you want to add new co insured
3. Screen with already added co insured popup but you want to add new co insured
4. you go back - screen get splashed

https://github.com/HedvigInsurance/ugglan/assets/127749787/7b25a7b0-0400-4b26-a825-d3722bc72722

y added coinsured

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
