### PR TITLE
add datepicker list for birth date instead of typing in text

### DIFF
--- a/Projects/Contracts/Sources/Models/CoInsuredModel.swift
+++ b/Projects/Contracts/Sources/Models/CoInsuredModel.swift
@@ -69,7 +69,6 @@ extension String {
     var calculate12DigitSSN: String {
         let formattedSSN = self.replacingOccurrences(of: "-", with: "")
         if formattedSSN.count == 10 {
-
             let ssnLastTwoDigitsOfYear = formattedSSN.prefix(2)
             let currentYear = Calendar.current.component(.year, from: Date())
             let firstTwoDigitsOfTheYear = currentYear / 100
@@ -85,5 +84,23 @@ extension String {
         } else {
             return self
         }
+    }
+
+    var calculate10DigitBirthDate: String {
+        if self.localDateToDate != nil {
+            return self.localDateToDate?.localDateString ?? ""
+        } else if self.localYYMMDDDateToDate != nil {
+            return self.localYYMMDDDateToDate?.localDateString ?? ""
+        }
+        return ""
+    }
+
+    var birtDateDisplayFormat: String {
+        if self.localDateToDate != nil {
+            return self.localDateToDate?.localBirthDateString ?? ""
+        } else if self.localYYMMDDDateToDate != nil {
+            return self.localYYMMDDDateToDate?.localBirthDateString ?? ""
+        }
+        return ""
     }
 }

--- a/Projects/Contracts/Sources/Models/ContractModels.swift
+++ b/Projects/Contracts/Sources/Models/ContractModels.swift
@@ -13,6 +13,9 @@ extension String {
 
     var localYYMMDDDateToDate: Date? {
         let formatter = DateFormatter()
+        if self == "" {
+            return nil
+        }
         formatter.dateFormat = "yyMMdd"
         return formatter.date(from: self)
     }

--- a/Projects/Contracts/Sources/Models/ContractModels.swift
+++ b/Projects/Contracts/Sources/Models/ContractModels.swift
@@ -10,6 +10,12 @@ extension String {
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.date(from: self)
     }
+
+    var localYYMMDDDateToDate: Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyMMdd"
+        return formatter.date(from: self)
+    }
 }
 
 public struct ProductVariant: Codable, Hashable {

--- a/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
@@ -209,8 +209,6 @@ struct CoInusuredInput: View {
                 }
                 .padding(.top, 12)
                 .disabled(buttonIsDisabled && !(vm.actionType == .delete))
-                //                    }
-                //                }
 
                 hButton.LargeButton(type: .ghost) {
                     store.send(.coInsuredNavigationAction(action: .dismissEdit))
@@ -284,78 +282,16 @@ struct CoInusuredInput: View {
     var addCoInsuredFields: some View {
         Group {
             if vm.noSSN {
-                hSection {
-                    hFloatingTextField(
-                        masking: Masking(type: .birthDateCoInsured),
-                        value: $vm.birthday,
-                        equals: $vm.type,
-                        focusValue: .SSN,
-                        placeholder: L10n.contractBirthDate
-                    )
-                }
-                .sectionContainerStyle(.transparent)
-                .onAppear {
-                    vm.nameFetchedFromSSN = false
-                }
+                datePickerField
             } else {
-                hSection {
-                    hFloatingTextField(
-                        masking: Masking(type: .personalNumber),
-                        value: $vm.SSN,
-                        equals: $vm.type,
-                        focusValue: .SSN,
-                        placeholder: L10n.contractPersonalIdentity
-                    )
-                }
-                .disabled(vm.isLoading)
-                .sectionContainerStyle(.transparent)
-                .onChange(of: vm.SSN) { newValue in
-                    vm.nameFetchedFromSSN = false
-                }
+                ssnField
             }
 
             if vm.nameFetchedFromSSN || vm.noSSN {
-                hSection {
-                    HStack(spacing: 4) {
-                        hFloatingTextField(
-                            masking: Masking(type: .firstName),
-                            value: $vm.firstName,
-                            equals: $vm.type,
-                            focusValue: .firstName,
-                            placeholder: L10n.contractFirstName
-                        )
-                        hFloatingTextField(
-                            masking: Masking(type: .lastName),
-                            value: $vm.lastName,
-                            equals: $vm.type,
-                            focusValue: .lastName,
-                            placeholder: L10n.contractLastName
-                        )
-                    }
-                }
-                .disabled(vm.nameFetchedFromSSN)
-                .sectionContainerStyle(.transparent)
+                nameFields
             }
 
-            hSection {
-                Toggle(isOn: $vm.noSSN.animation(.default)) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        hText(L10n.contractAddCoinsuredNoSsn, style: .body)
-                            .foregroundColor(hTextColor.secondary)
-                    }
-                }
-                .toggleStyle(ChecboxToggleStyle(.center, spacing: 0))
-                .contentShape(Rectangle())
-                .onChange(
-                    of: vm.noSSN,
-                    perform: { newValue in
-                        vm.SSN = ""
-                    }
-                )
-                .padding(.vertical, 12)
-                .padding(.horizontal, 16)
-            }
-            .sectionContainerStyle(.opaque)
+            toggleField
         }
         .hFieldSize(.small)
     }
@@ -391,6 +327,88 @@ struct CoInusuredInput: View {
             .disabled(true)
             .sectionContainerStyle(.transparent)
         }
+    }
+
+    var datePickerField: some View {
+        hSection {
+            hDatePickerField(
+                config: .init(
+                    maxDate: Date(),
+                    placeholder: L10n.contractBirthDate,
+                    title: L10n.contractBirthDate,
+                    showAsList: true
+                ),
+                selectedDate: vm.birthday.localDateToDate
+            ) { date in
+                vm.birthday = date.localDateString
+            }
+        }
+        .sectionContainerStyle(.transparent)
+        .onAppear {
+            vm.nameFetchedFromSSN = false
+        }
+    }
+
+    var ssnField: some View {
+        hSection {
+            hFloatingTextField(
+                masking: Masking(type: .personalNumber),
+                value: $vm.SSN,
+                equals: $vm.type,
+                focusValue: .SSN,
+                placeholder: L10n.contractPersonalIdentity
+            )
+        }
+        .disabled(vm.isLoading)
+        .sectionContainerStyle(.transparent)
+        .onChange(of: vm.SSN) { newValue in
+            vm.nameFetchedFromSSN = false
+        }
+    }
+
+    var nameFields: some View {
+        hSection {
+            HStack(spacing: 4) {
+                hFloatingTextField(
+                    masking: Masking(type: .firstName),
+                    value: $vm.firstName,
+                    equals: $vm.type,
+                    focusValue: .firstName,
+                    placeholder: L10n.contractFirstName
+                )
+                hFloatingTextField(
+                    masking: Masking(type: .lastName),
+                    value: $vm.lastName,
+                    equals: $vm.type,
+                    focusValue: .lastName,
+                    placeholder: L10n.contractLastName
+                )
+            }
+        }
+        .disabled(vm.nameFetchedFromSSN)
+        .sectionContainerStyle(.transparent)
+    }
+
+    var toggleField: some View {
+        hSection {
+            Toggle(isOn: $vm.noSSN.animation(.default)) {
+                VStack(alignment: .leading, spacing: 0) {
+                    hText(L10n.contractAddCoinsuredNoSsn, style: .body)
+                        .foregroundColor(hTextColor.secondary)
+                }
+            }
+            .toggleStyle(ChecboxToggleStyle(.center, spacing: 0))
+            .contentShape(Rectangle())
+            .onChange(
+                of: vm.noSSN,
+                perform: { newValue in
+                    vm.SSN = ""
+                }
+            )
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+        }
+        .sectionContainerStyle(.opaque)
     }
 
     var buttonIsDisabled: Bool {

--- a/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
@@ -332,6 +332,7 @@ struct CoInusuredInput: View {
             hDatePickerField(
                 config: .init(
                     maxDate: Date(),
+                    initialySelectedValue: Date(timeInterval: -60 * 60 * 24 * 365 * 20, since: Date()),
                     placeholder: L10n.contractBirthDate,
                     title: L10n.contractBirthDate,
                     showAsList: true,

--- a/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/CoInusuredInput.swift
@@ -315,8 +315,8 @@ struct CoInusuredInput: View {
 
             hSection {
                 hFloatingField(
-                    value: vm.SSN != "" ? vm.SSN : vm.birthday,
-                    placeholder: L10n.TravelCertificate.personalNumber,
+                    value: vm.SSN != "" ? vm.SSN : vm.birthday.birtDateDisplayFormat,
+                    placeholder: vm.SSN != "" ? L10n.TravelCertificate.personalNumber : L10n.contractBirthDate,
                     onTap: {}
                 )
             }
@@ -336,11 +336,12 @@ struct CoInusuredInput: View {
                     maxDate: Date(),
                     placeholder: L10n.contractBirthDate,
                     title: L10n.contractBirthDate,
-                    showAsList: true
+                    showAsList: true,
+                    dateFormatter: .birthDate
                 ),
-                selectedDate: vm.birthday.localDateToDate
+                selectedDate: vm.birthday.localYYMMDDDateToDate
             ) { date in
-                vm.birthday = date.localDateString
+                vm.birthday = date.displayDateYYMMDDFormat ?? ""
             }
         }
         .sectionContainerStyle(.transparent)
@@ -613,7 +614,7 @@ public class IntentViewModel: ObservableObject {
                         firstName: coIn.firstName,
                         lastName: coIn.lastName,
                         ssn: coIn.formattedSSN,
-                        birthdate: coIn.birthDate
+                        birthdate: coIn.birthDate?.calculate10DigitBirthDate
                     )
                 }
                 let coinsuredInput = OctopusGraphQL.MidtermChangeIntentCreateInput(coInsuredInputs: coInsuredList)

--- a/Projects/Contracts/Sources/View/CoInsured/EditCoInsuredDisplayFields.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/EditCoInsuredDisplayFields.swift
@@ -91,7 +91,7 @@ struct CoInsuredField<Content: View>: View {
 
     var body: some View {
         let displayTitle = (coInsured?.fullName ?? title) ?? ""
-        let displaySubTitle = coInsured?.SSN ?? coInsured?.birthDate ?? subTitle ?? ""
+        let displaySubTitle = coInsured?.SSN ?? coInsured?.birthDate?.birtDateDisplayFormat ?? subTitle ?? ""
 
         VStack(alignment: .leading, spacing: 0) {
             HStack {
@@ -123,7 +123,7 @@ struct CoInsuredField<Content: View>: View {
         VStack {
             hText(
                 includeStatusPill?
-                    .text(date: date?.localDateToDate?.displayDateDDMMMYYYYFormat ?? "")
+                    .text(date: date?.calculate10DigitBirthDate ?? "")
                     ?? "",
                 style: .standardSmall
             )

--- a/Projects/hCore/Sources/Date+LocalDateString.swift
+++ b/Projects/hCore/Sources/Date+LocalDateString.swift
@@ -5,6 +5,10 @@ extension Date {
         return DateFormatters.localDateStringFormatter.string(from: self)
     }
 
+    public var localBirthDateString: String {
+        return DateFormatters.localbirthDateStringFormatter.string(from: self)
+    }
+
     public var localDateStringDayFirst: String? {
         return DateFormatters.localDateStringDayFirstFormatter.string(from: self)
     }
@@ -15,6 +19,10 @@ extension Date {
 
     public var displayDateDotFormat: String? {
         return DateFormatters.displayDateDotFormatFormatter.string(from: self)
+    }
+
+    public var displayDateYYMMDDFormat: String? {
+        return DateFormatters.displayDateYYMMDDFormatFormatter.string(from: self)
     }
 
     public var displayDateMMMDDYYYYFormat: String? {
@@ -41,6 +49,12 @@ private struct DateFormatters {
         return formatter
     }()
 
+    static let localbirthDateStringFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyMMDD"
+        return formatter
+    }()
+
     static let localDateStringDayFirstFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "dd.MM.yyyy"
@@ -56,6 +70,12 @@ private struct DateFormatters {
     static let displayDateDotFormatFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy.MM.dd"
+        return formatter
+    }()
+
+    static let displayDateYYMMDDFormatFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyMMdd"
         return formatter
     }()
 

--- a/Projects/hCore/Sources/Masking.swift
+++ b/Projects/hCore/Sources/Masking.swift
@@ -69,7 +69,7 @@ public struct Masking {
             return 15...130 ~= age
         case .birthDateCoInsured:
             let age = calculateAge(from: text) ?? 0
-            return 0...130 ~= age && text.count == 10
+            return 0...130 ~= age && text.count == 6
         case .personalNumberCoInsured:
             let age = calculateAge(from: text) ?? 0
             if text.prefix(2) == "19" || text.prefix(2) == "20" {

--- a/Projects/hCore/Sources/UIApplication+GetTopViewController.swift
+++ b/Projects/hCore/Sources/UIApplication+GetTopViewController.swift
@@ -4,7 +4,6 @@ import UIKit
 extension UIApplication {
     public func getTopViewController() -> UIViewController? {
         return UIApplication.shared.connectedScenes
-            //            .filter({ $0.activationState == .foregroundActive })
             .map({ $0 as? UIWindowScene })
             .compactMap({ $0 })
             .first?

--- a/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
@@ -138,17 +138,20 @@ public struct hDatePickerField: View {
         let maxDate: Date?
         let placeholder: String
         let title: String
+        let showAsList: Bool?
 
         public init(
             minDate: Date? = nil,
             maxDate: Date? = nil,
             placeholder: String,
-            title: String
+            title: String,
+            showAsList: Bool? = false
         ) {
             self.minDate = minDate
             self.maxDate = maxDate
             self.placeholder = placeholder
             self.title = title
+            self.showAsList = showAsList
         }
     }
 }
@@ -162,9 +165,18 @@ private struct DatePickerView: View {
     public var body: some View {
         hForm {
             hSection {
-                datePicker
-                    .datePickerStyle(.graphical)
-                    .frame(height: 340)
+                HStack {
+                    if config.showAsList ?? false {
+                        datePicker
+                            .datePickerStyle(.wheel)
+                            .padding(.trailing, 23)
+                            .padding(.bottom, 16)
+                    } else {
+                        datePicker
+                            .datePickerStyle(.graphical)
+                            .frame(height: 340)
+                    }
+                }
             }
             .sectionContainerStyle(.transparent)
         }
@@ -199,7 +211,7 @@ private struct DatePickerView: View {
             ToolbarItem(placement: .principal) {
                 VStack {
                     hText(config.title)
-                    if let subtitle = date.displayDateDotFormat {
+                    if let subtitle = date.displayDateDotFormat, !(config.showAsList ?? false) {
                         hText(subtitle).foregroundColor(hTextColor.secondary)
                     }
                 }

--- a/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
@@ -114,6 +114,9 @@ public struct hDatePickerField: View {
     private func showDatePicker() {
         let continueAction = ReferenceAction {}
         let cancelAction = ReferenceAction {}
+        if let initialySelectedValue = config.initialySelectedValue, selectedDate == nil {
+            date = initialySelectedValue
+        }
         let view = DatePickerView(
             continueAction: continueAction,
             cancelAction: cancelAction,
@@ -144,6 +147,7 @@ public struct hDatePickerField: View {
     public struct HDatePickerFieldConfig {
         let minDate: Date?
         let maxDate: Date?
+        let initialySelectedValue: Date?
         let placeholder: String
         let title: String
         let showAsList: Bool?
@@ -152,6 +156,7 @@ public struct hDatePickerField: View {
         public init(
             minDate: Date? = nil,
             maxDate: Date? = nil,
+            initialySelectedValue: Date? = nil,
             placeholder: String,
             title: String,
             showAsList: Bool? = false,
@@ -159,6 +164,7 @@ public struct hDatePickerField: View {
         ) {
             self.minDate = minDate
             self.maxDate = maxDate
+            self.initialySelectedValue = initialySelectedValue
             self.placeholder = placeholder
             self.title = title
             self.showAsList = showAsList

--- a/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hDatePickerField.swift
@@ -51,9 +51,7 @@ public struct hDatePickerField: View {
                     error: $error,
                     shouldMoveLabel: shouldMoveLabel
                 )
-                if (selectedDate?.displayDateDotFormat) != nil {
-                    getValueLabel()
-                }
+                getValueLabel()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, selectedDate?.localDateString.isEmpty ?? true ? 0 : 10)
@@ -87,9 +85,19 @@ public struct hDatePickerField: View {
 
     private func getValueLabel() -> some View {
         HStack {
-            Text((selectedDate?.displayDateDotFormat ?? placeholderText) ?? L10n.generalSelectButton)
-                .modifier(hFontModifier(style: .title3))
-                .foregroundColor(hTextColor.primary)
+            Group {
+                if config.dateFormatter == .dotFormat {
+                    if (selectedDate?.displayDateDotFormat) != nil {
+                        Text((selectedDate?.displayDateDotFormat ?? placeholderText) ?? L10n.generalSelectButton)
+                    }
+                } else if config.dateFormatter == .birthDate {
+                    if (selectedDate?.displayDateYYMMDDFormat) != nil {
+                        Text((selectedDate?.displayDateYYMMDDFormat ?? placeholderText) ?? L10n.generalSelectButton)
+                    }
+                }
+            }
+            .modifier(hFontModifier(style: .title3))
+            .foregroundColor(hTextColor.primary)
             Spacer()
         }
     }
@@ -139,19 +147,22 @@ public struct hDatePickerField: View {
         let placeholder: String
         let title: String
         let showAsList: Bool?
+        let dateFormatter: DateFormatter?
 
         public init(
             minDate: Date? = nil,
             maxDate: Date? = nil,
             placeholder: String,
             title: String,
-            showAsList: Bool? = false
+            showAsList: Bool? = false,
+            dateFormatter: DateFormatter? = .dotFormat
         ) {
             self.minDate = minDate
             self.maxDate = maxDate
             self.placeholder = placeholder
             self.title = title
             self.showAsList = showAsList
+            self.dateFormatter = dateFormatter
         }
     }
 }
@@ -274,4 +285,9 @@ class ReferenceAction {
     ) {
         self.execute = execute
     }
+}
+
+public enum DateFormatter {
+    case dotFormat
+    case birthDate
 }

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -12,6 +12,7 @@ let config = Config(
         .exact("14.2"),
         .exact("14.3"),
         .exact("14.3.1"),
+        .exact("15.0.1"),
     ]),
     cloud: nil,
     cache: nil,


### PR DESCRIPTION
## [APP-XXX]

- Added datepicker list for birth date instead of typing in text
- [Figma](https://www.figma.com/file/WlwFCAWywXNcXVgPfYVmWu/Final-Design?node-id=6900%3A10499&mode=dev)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
