### PR TITLE
Added fix not to show "Input view" when not needed

### DIFF
--- a/Projects/Contracts/Sources/Journeys/EditCoInsuredJourney.swift
+++ b/Projects/Contracts/Sources/Journeys/EditCoInsuredJourney.swift
@@ -43,7 +43,7 @@ public class EditCoInsuredJourney {
             ContractStore.self,
             rootView: InsuredPeopleScreen(contractId: id),
             style: .modally(presentationStyle: .overFullScreen),
-            options: [.defaults, .withAdditionalSpaceForProgressBar]
+            options: [.defaults, .withAdditionalSpaceForProgressBar, .ignoreActionWhenNotOnTop]
         ) { action in
             getScreen(for: action)
         }


### PR DESCRIPTION
- Fixed showing "Input view" when not neede

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
