### PR TITLE
redirect directly to edit coinsured if moving flow is off

### DIFF
--- a/Projects/Contracts/Sources/Journeys/ContractInformation.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractInformation.swift
@@ -50,9 +50,22 @@ struct ContractInformationView: View {
                             VStack(spacing: 8) {
                                 hSection {
                                     hButton.LargeButton(type: .secondary) {
-                                        store.send(.contractEditInfo(id: id))
+                                        if onlyCoInsured(contract) {
+                                            store.send(
+                                                .openEditCoInsured(
+                                                    contractId: contract.id,
+                                                    fromInfoCard: false
+                                                )
+                                            )
+                                        } else {
+                                            store.send(.contractEditInfo(id: id))
+                                        }
                                     } content: {
-                                        hText(L10n.contractEditInfoLabel)
+                                        if onlyCoInsured(contract) {
+                                            hText(L10n.contractEditCoinsured)
+                                        } else {
+                                            hText(L10n.contractEditInfoLabel)
+                                        }
                                     }
                                 }
                                 displayTerminationButton
@@ -64,6 +77,11 @@ struct ContractInformationView: View {
             }
         }
         .sectionContainerStyle(.transparent)
+    }
+    
+    func onlyCoInsured(_ contract: Contract) -> Bool {
+        let editTypes: [EditType] = EditType.getTypes(for: contract)
+        return editTypes.count == 1 && editTypes.first == .coInsured
     }
 
     @ViewBuilder

--- a/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
@@ -307,8 +307,8 @@ class InsuredPeopleNewScreenModel: ObservableObject {
                 let nbOfUpcomingCoInsured = upComingList?.count
                 if coInsuredDeleted.count > 0 {
                     var num: Int {
-                        if nbOfUpcomingCoInsured ?? 0 < nbOfCoInsured && !(upComingList?.isEmpty ?? false) {
-                            return nbOfUpcomingCoInsured ?? 0 - coInsuredDeleted.count
+                        if let nbOfUpcomingCoInsured, nbOfUpcomingCoInsured < nbOfCoInsured, !(upComingList?.isEmpty ?? false) {
+                            return nbOfUpcomingCoInsured - coInsuredDeleted.count
                         } else {
                             return nbOfCoInsured - coInsuredDeleted.count
                         }

--- a/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
+++ b/Projects/Contracts/Sources/View/CoInsured/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
@@ -317,7 +317,7 @@ class InsuredPeopleNewScreenModel: ObservableObject {
                         filterList.append(CoInsuredModel())
                     }
                     return filterList
-                } else if !(upComingList?.isEmpty ?? false) {
+                } else if !(upComingList?.isEmpty ?? false) && coInsuredAdded.isEmpty {
                     filterList = upComingList ?? []
                 }
             } else if nbOfCoInsured > 0 {

--- a/Projects/Contracts/Tests/EditCoInsuredTests.swift
+++ b/Projects/Contracts/Tests/EditCoInsuredTests.swift
@@ -129,6 +129,70 @@ final class ContractsEditInsuredCompleteListTests: XCTestCase {
         let list = viewModel.completeList()
         assert(list.count == 2)
     }
+    
+    func testInitialSSNBirthday() {
+        let viewModel = InsuredPeopleNewScreenModel()
+        
+        viewModel.currentAgreementCoInsured = [
+            CoInsuredModel.mockMissingData(),
+            CoInsuredModel.mockMissingData(),
+        ]
+
+        viewModel.upcomingAgreementCoInsured = [
+            CoInsuredModel.testMemberWithSSN1,
+            CoInsuredModel.testMemberWithBirthdate1,
+        ]
+        
+        viewModel.coInsuredAdded = []
+            
+        viewModel.coInsuredDeleted = []
+        let list = viewModel.completeList()
+        assert(list.count == 2)
+    }
+    
+    func testRemovedWithoutDataAddingSSNBirthdate() {
+        let viewModel = InsuredPeopleNewScreenModel()
+        
+        viewModel.currentAgreementCoInsured = [
+            CoInsuredModel.mockMissingData(),
+            CoInsuredModel.mockMissingData(),
+        ]
+
+        viewModel.upcomingAgreementCoInsured = [
+            CoInsuredModel.mockMissingData(),
+        ]
+        
+        viewModel.coInsuredAdded = [
+            CoInsuredModel.testMemberWithSSN1,
+            CoInsuredModel.testMemberWithBirthdate1
+        ]
+            
+        viewModel.coInsuredDeleted = []
+        let list = viewModel.completeList()
+        assert(list.count == 2)
+    }
+    
+    func testAddCoInsuredToEmptyCurrentUpcomingValues() {
+        let viewModel = InsuredPeopleNewScreenModel()
+        
+        viewModel.currentAgreementCoInsured = [
+            CoInsuredModel.mockMissingData(),
+            CoInsuredModel.mockMissingData(),
+        ]
+
+        viewModel.upcomingAgreementCoInsured = [
+            CoInsuredModel.testMemberWithSSN1,
+        ]
+        
+        viewModel.coInsuredAdded = [
+            CoInsuredModel.testMemberWithBirthdate1
+        ]
+            
+        viewModel.coInsuredDeleted = []
+        let list = viewModel.completeList()
+        assert(list.count == 2)
+    }
+    
 }
 
 extension CoInsuredModel {
@@ -137,6 +201,10 @@ extension CoInsuredModel {
     static let testMemberWithSSN3 = CoInsuredModel(firstName: "A", lastName: "B", SSN: "199209016830", birthDate: "1992-09-01")
     static let testMemberWithSSN4 = CoInsuredModel(firstName: "B", lastName: "A", SSN: "199309016830", birthDate: "1993-09-01")
     static let testMemberWithSSN5 = CoInsuredModel(firstName: "C", lastName: "D", SSN: "199409016830", birthDate: "1994-09-01")
+    
+    static let testMemberWithBirthdate1 = CoInsuredModel(firstName: "Test", lastName: "Testsson", SSN: nil, birthDate: "1990-09-01")
+    static let testMemberWithBirthdate2 = CoInsuredModel(firstName: "Test", lastName: "Testsson", SSN: nil, birthDate: "1991-09-01")
+    static let testMemberWithBirthdate3 = CoInsuredModel(firstName: "Test", lastName: "Testsson", SSN: nil, birthDate: "1992-09-01")
     
     static func mock(withSSN ssn: String) -> CoInsuredModel {
         CoInsuredModel(


### PR DESCRIPTION
## [APP-XXX]

- Redirect directly to edit co-insured if it's the only option

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
