### PR TITLE
Returned hAnalytics on app start

### DIFF
--- a/Projects/App/Sources/AppDelegate+hAnalytics.swift
+++ b/Projects/App/Sources/AppDelegate+hAnalytics.swift
@@ -22,8 +22,9 @@ extension AppDelegate {
         hAnalyticsNetworking.trackingId = { ApolloClient.getDeviceIdentifier() }
     }
 
-    func setupHAnalyticsExperiments() {
+    func setupHAnalyticsExperiments(onComplete: @escaping (_ success: Bool) -> Void) {
         hAnalyticsExperiment.retryingLoad { success in
+            onComplete(success)
             DefaultStyling.installCustom()
         }
     }

--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -275,11 +275,8 @@ import hGraphQL
                 Toasts.shared.displayToast(toast: toast)
             }
         }
-        bag += ApolloClient.initAndRegisterClient().valueSignal.map { _ in true }.plain()
-            .atValue { _ in
-                Dependencies.shared.add(module: Module { AnalyticsCoordinator() })
-                self.bag += self.window.present(AppJourney.main)
-            }
+        setupHAnalyticsExperiments()
+
         bag += ApplicationContext.shared.$isDemoMode.onValue { value in
             let store: UgglanStore = globalPresentableStoreContainer.get()
             TokenRefresher.shared.isDemoMode = value
@@ -292,6 +289,43 @@ import hGraphQL
         observeNotificationsSettings()
 
         return true
+    }
+
+    private func setupHAnalyticsExperiments() {
+        setupHAnalyticsExperiments { success in
+            DispatchQueue.main.async {
+                if success {
+                    self.bag += ApolloClient.initAndRegisterClient().valueSignal.map { _ in true }.plain()
+                        .atValue { _ in
+                            Dependencies.shared.add(module: Module { AnalyticsCoordinator() })
+                            self.bag += self.window.present(AppJourney.main)
+                        }
+                } else {
+                    let alert = Alert(
+                        title: L10n.somethingWentWrong,
+                        message: L10n.General.errorBody,
+                        actions: [
+                            Alert.Action(
+                                title: L10n.generalRetry,
+                                action: {
+                                    self.setupHAnalyticsExperiments()
+                                }
+                            )
+                        ]
+                    )
+
+                    self.bag += self.window.present(
+                        ActivityIndicator(style: .large, color: hTextColor.primary).disposableHostingJourney
+                            .onPresent({
+                                Journey(alert)
+                                    .onPresent {
+                                        Launch.shared.completeAnimationCallbacker.callAll()
+                                    }
+                            })
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Reintroduced hAnalytics on app start since we need to check for app version

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
