### PR TITLE
fix for iPad padding in help center

### DIFF
--- a/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
@@ -135,6 +135,7 @@ public struct HelpCenterStartView: View {
                     .withChevronAccessory
                 }
                 .withoutHorizontalPadding
+                .hSectionMinimumPadding
                 .sectionContainerStyle(.opaque)
                 .onTapGesture {
                     store.send(.openHelpCenterTopicView(commonTopic: item))

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
@@ -132,6 +132,7 @@ struct QuestionsItems: View {
                     }
                 }
                 .withoutHorizontalPadding
+                .hSectionMinimumPadding
                 .sectionContainerStyle(.transparent)
                 .padding(.leading, 2)
             }

--- a/Projects/TerminateContracts/Sources/Views/ReusableComponents.swift
+++ b/Projects/TerminateContracts/Sources/Views/ReusableComponents.swift
@@ -56,8 +56,11 @@ struct DisplayQuestionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            hText(L10n.terminateContractCommonQuestions)
-                .padding(.leading, 16)
+            hSection {
+                hText(L10n.terminateContractCommonQuestions)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .sectionContainerStyle(.transparent)
             VStack(spacing: 4) {
                 ForEach(
                     (store.state.config?.isDeletion ?? false) ? deletionQuestions : terminationQuestions,

--- a/Projects/hCoreUI/Sources/hForm/hSection.swift
+++ b/Projects/hCoreUI/Sources/hForm/hSection.swift
@@ -224,6 +224,23 @@ extension View {
     }
 }
 
+private struct EnvironmentHSectionMinimumPadding: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    public var minimumPadding: Bool {
+        get { self[EnvironmentHSectionMinimumPadding.self] }
+        set { self[EnvironmentHSectionMinimumPadding.self] = newValue }
+    }
+}
+
+extension View {
+    public var hSectionMinimumPadding: some View {
+        self.environment(\.minimumPadding, true)
+    }
+}
+
 private struct EnvironmentHWithoutHorizontalPadding: EnvironmentKey {
     static let defaultValue = false
 }
@@ -272,6 +289,7 @@ struct hSectionContainer<Content: View>: View {
 
 public struct hSection<Header: View, Content: View, Footer: View>: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.minimumPadding) var minimumPadding
 
     var header: Header?
     var content: Content
@@ -299,7 +317,6 @@ public struct hSection<Header: View, Content: View, Footer: View>: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-
             if header != nil {
                 VStack(alignment: .leading) {
                     header
@@ -322,7 +339,7 @@ public struct hSection<Header: View, Content: View, Footer: View>: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding([.leading, .trailing], horizontalSizeClass == .regular ? 60 : 16)
+        .padding([.leading, .trailing], minimumPadding ? 16 : (horizontalSizeClass == .regular ? 60 : 16))
     }
 
     /// removes hSection leading and trailing padding


### PR DESCRIPTION
## [APP-XXX]

- iPad fix for help center (hSection)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
