### PR TITLE
fix ChatInputView being cut off/missing padding on iPad

### DIFF
--- a/Projects/Chat/Sources/Views/ChatScreen.swift
+++ b/Projects/Chat/Sources/Views/ChatScreen.swift
@@ -20,10 +20,9 @@ struct ChatScreen: View {
             infoCard
                 .padding(.bottom, -8)
             ChatInputView(vm: vm.chatInputVm)
-                .padding(.bottom, 32)
+                .padding(.bottom, 16)
         }
         .dismissKeyboard()
-        .edgesIgnoringSafeArea(.bottom)
     }
 
     @ViewBuilder

--- a/Projects/Chat/Sources/Views/ChatScreen.swift
+++ b/Projects/Chat/Sources/Views/ChatScreen.swift
@@ -20,8 +20,10 @@ struct ChatScreen: View {
             infoCard
                 .padding(.bottom, -8)
             ChatInputView(vm: vm.chatInputVm)
+                .padding(.bottom, 32)
         }
         .dismissKeyboard()
+        .edgesIgnoringSafeArea(.bottom)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## [APP-XXX]

- fix ChatInputView being cut off/missing padding on iPad

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
