### PR TITLE
Try to create the .netrc file for the CI runner

### DIFF
--- a/.github/workflows/ProductionDeploy.yml
+++ b/.github/workflows/ProductionDeploy.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "15.1"
+      - name: Setup .netrc file
+        run: |
+          echo -e "machine maven.pkg.github.com\n  login ${{ secrets.HEDVIG_GITHUB_PACKAGES_USER }}\n  password ${{ secrets.HEDVIG_GITHUB_PACKAGES_TOKEN }}" > ~/.netrc
       - name: Post checkout
         run: PATH=$PATH":$GITHUB_WORKSPACE/.tuist-bin" scripts/post-checkout.sh
       - name: Bump version


### PR DESCRIPTION
Create the `.netrc` file which contains the right credentials to be able to download authlib which is behind authentication, just like we have to do on our local machines to be able to build the project