### PR TITLE
GEN-1889: Towing deflect screens

### DIFF
--- a/Projects/Claims/GraphQL/Octopus/StartClaimsFlow.graphql
+++ b/Projects/Claims/GraphQL/Octopus/StartClaimsFlow.graphql
@@ -26,6 +26,7 @@ fragment FlowClaimFragment on Flow {
     ...FlowClaimDeflectEmergencyStepFragment
     ...FlowClaimConfirmEmergencyStepFragment
     ...FlowClaimDeflectGlassDamageStepFragment
+    ...FlowClaimDeflectTowingStepFragment
     ...FlowClaimDeflectPestsStepFragment
     ...FlowClaimFileUploadStepFragment
   }
@@ -86,6 +87,13 @@ fragment FlowClaimConfirmEmergencyStepFragment on FlowClaimConfirmEmergencyStep 
 }
 
 fragment FlowClaimDeflectGlassDamageStepFragment on FlowClaimDeflectGlassDamageStep {
+    id
+    partners {
+        ...FlowClaimDeflectPartnerFragment
+    }
+}
+
+fragment FlowClaimDeflectTowingStepFragment on FlowClaimDeflectTowingStep {
     id
     partners {
         ...FlowClaimDeflectPartnerFragment

--- a/Projects/Claims/Sources/ClaimMutation+Actions.swift
+++ b/Projects/Claims/Sources/ClaimMutation+Actions.swift
@@ -76,6 +76,8 @@ extension OctopusGraphQL.FlowClaimFragment.CurrentStep: Into {
             return .stepModelAction(action: .setDeflectModel(model: .init(with: step)))
         } else if let step = self.asFlowClaimDeflectGlassDamageStep?.fragments.flowClaimDeflectGlassDamageStepFragment {
             return .stepModelAction(action: .setDeflectModel(model: .init(with: step)))
+        } else if let step = self.asFlowClaimDeflectTowingStep?.fragments.flowClaimDeflectTowingStepFragment {
+            return .stepModelAction(action: .setDeflectModel(model: .init(with: step)))
         } else if let step = self.asFlowClaimFileUploadStep?.fragments.flowClaimFileUploadStepFragment {
             return .stepModelAction(action: .setFileUploadStep(model: .init(with: step)))
         } else {

--- a/Projects/Claims/Sources/Models/FlowClaimDeflectStepModel.swift
+++ b/Projects/Claims/Sources/Models/FlowClaimDeflectStepModel.swift
@@ -18,7 +18,7 @@ enum FlowClaimDeflectStepType: Decodable, Encodable {
         case .FlowClaimDeflectEmergencyStep:
             return L10n.commonClaimEmergencyTitle
         case .FlowClaimDeflectTowingStep:
-            return "Towing"
+            return L10n.submitClaimTowingTitle
         case .Unknown:
             return ""
         }
@@ -29,9 +29,11 @@ public struct FlowClaimDeflectConfig {
     let infoText: String
     let infoSectionText: String
     let infoSectionTitle: String
-    let cardTitle: String
+    let cardTitle: String?
     let cardText: String
     let buttonText: String?
+    let infoViewTitle: String?
+    let infoViewText: String?
     let questions: [DeflectQuestion]
 }
 
@@ -51,9 +53,11 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
                 infoText: L10n.submitClaimGlassDamageInfoLabel,
                 infoSectionText: L10n.submitClaimGlassDamageHowItWorksLabel,
                 infoSectionTitle: L10n.submitClaimHowItWorksTitle,
-                cardTitle: L10n.submitClaimPartnerTitle,
+                cardTitle: nil,
                 cardText: L10n.submitClaimGlassDamageOnlineBookingLabel,
                 buttonText: L10n.submitClaimGlassDamageOnlineBookingButton,
+                infoViewTitle: L10n.submitClaimGlassDamageTitle,
+                infoViewText: L10n.submitClaimGlassDamageInfoLabel,
                 questions: [
                     .init(question: L10n.submitClaimWhatCostTitle, answer: L10n.submitClaimGlassDamageWhatCostLabel),
                     .init(question: L10n.submitClaimHowBookTitle, answer: L10n.submitClaimGlassDamageHowBookLabel),
@@ -68,6 +72,8 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
                 cardTitle: L10n.submitClaimEmergencyGlobalAssistanceTitle,
                 cardText: L10n.submitClaimEmergencyGlobalAssistanceLabel,
                 buttonText: nil,
+                infoViewTitle: nil,
+                infoViewText: nil,
                 questions: [
                     .init(question: L10n.submitClaimEmergencyFaq1Title, answer: L10n.submitClaimEmergencyFaq1Label),
                     .init(question: L10n.submitClaimEmergencyFaq2Title, answer: L10n.submitClaimEmergencyFaq2Label),
@@ -83,20 +89,28 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
                 infoText: L10n.submitClaimPestsInfoLabel,
                 infoSectionText: L10n.submitClaimPestsHowItWorksLabel,
                 infoSectionTitle: L10n.submitClaimHowItWorksTitle,
-                cardTitle: L10n.submitClaimPartnerTitle,
+                cardTitle: nil,
                 cardText: L10n.submitClaimPestsCustomerServiceLabel,
                 buttonText: L10n.submitClaimPestsCustomerServiceButton,
+                infoViewTitle: L10n.submitClaimPestsTitle,
+                infoViewText: L10n.submitClaimPestsInfoLabel,
                 questions: []
             )
         } else if id == .FlowClaimDeflectTowingStep {
             return FlowClaimDeflectConfig(
-                infoText: "",
-                infoSectionText: "",
-                infoSectionTitle: "",
-                cardTitle: "",
-                cardText: "",
-                buttonText: "",
-                questions: []
+                infoText: L10n.submitClaimTowingInfoLabel,
+                infoSectionText: L10n.submitClaimTowingHowItWorksLabel,
+                infoSectionTitle: L10n.submitClaimHowItWorksTitle,
+                cardTitle: nil,
+                cardText: L10n.submitClaimTowingOnlineBookingLabel,
+                buttonText: L10n.submitClaimTowingOnlineBookingButton,
+                infoViewTitle: L10n.submitClaimTowingTitle,
+                infoViewText: L10n.submitClaimTowingInfoLabel,
+                questions: [
+                    .init(question: L10n.submitClaimTowingQ1, answer: L10n.submitClaimTowingA1),
+                    .init(question: L10n.submitClaimTowingQ2, answer: L10n.submitClaimTowingA2),
+                    .init(question: L10n.submitClaimTowingQ3, answer: L10n.submitClaimTowingA3),
+                ]
             )
         }
         return nil

--- a/Projects/Claims/Sources/Models/FlowClaimDeflectStepModel.swift
+++ b/Projects/Claims/Sources/Models/FlowClaimDeflectStepModel.swift
@@ -6,6 +6,7 @@ enum FlowClaimDeflectStepType: Decodable, Encodable {
     case FlowClaimDeflectGlassDamageStep
     case FlowClaimDeflectPestsStep
     case FlowClaimDeflectEmergencyStep
+    case FlowClaimDeflectTowingStep
     case Unknown
 
     var title: String {
@@ -16,6 +17,8 @@ enum FlowClaimDeflectStepType: Decodable, Encodable {
             return L10n.submitClaimPestsTitle
         case .FlowClaimDeflectEmergencyStep:
             return L10n.commonClaimEmergencyTitle
+        case .FlowClaimDeflectTowingStep:
+            return "Towing"
         case .Unknown:
             return ""
         }
@@ -85,6 +88,16 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
                 buttonText: L10n.submitClaimPestsCustomerServiceButton,
                 questions: []
             )
+        } else if id == .FlowClaimDeflectTowingStep {
+            return FlowClaimDeflectConfig(
+                infoText: "",
+                infoSectionText: "",
+                infoSectionTitle: "",
+                cardTitle: "",
+                cardText: "",
+                buttonText: "",
+                questions: []
+            )
         }
         return nil
     }
@@ -114,6 +127,14 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
     }
 
     init(
+        with data: OctopusGraphQL.FlowClaimDeflectTowingStepFragment
+    ) {
+        self.id = (Self.setDeflectType(idIn: data.id))
+        self.partners = data.partners.map({ .init(with: $0.fragments.flowClaimDeflectPartnerFragment) })
+        self.isEmergencyStep = false
+    }
+
+    init(
         id: FlowClaimDeflectStepType,
         partners: [Partner]? = [],
         isEmergencyStep: Bool
@@ -131,6 +152,8 @@ public struct FlowClaimDeflectStepModel: FlowClaimStepModel {
             return .FlowClaimDeflectPestsStep
         case "FlowClaimDeflectEmergencyStep":
             return .FlowClaimDeflectEmergencyStep
+        case "FlowClaimDeflectTowingStep":
+            return .FlowClaimDeflectTowingStep
         default:
             return .Unknown
         }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Deflect/SubmitClaimDeflectScreen.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Deflect/SubmitClaimDeflectScreen.swift
@@ -37,14 +37,19 @@ public struct SubmitClaimDeflectScreen: View {
                         )
                     }
                 } else {
+                    let title =
+                        model?.partners.count == 1 ? L10n.submitClaimPartnerSingularTitle : L10n.submitClaimPartnerTitle
+
                     VStack(spacing: 8) {
                         ForEach(Array((model?.partners ?? []).enumerated()), id: \.element) { index, partner in
                             ClaimContactCard(
                                 imageUrl: partner.imageUrl,
                                 label: model?.config?.cardText ?? "",
                                 url: partner.url ?? "",
-                                title: index == 0 ? model?.config?.cardTitle : nil,
-                                buttonText: model?.config?.buttonText ?? ""
+                                title: index == 0 ? title : nil,
+                                buttonText: model?.config?.buttonText ?? "",
+                                infoViewTitle: model?.config?.infoViewTitle ?? "",
+                                infoViewText: model?.config?.infoSectionText ?? ""
                             )
                         }
                     }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Deflect/SubmitClaimDeflectScreen.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Deflect/SubmitClaimDeflectScreen.swift
@@ -44,12 +44,10 @@ public struct SubmitClaimDeflectScreen: View {
                         ForEach(Array((model?.partners ?? []).enumerated()), id: \.element) { index, partner in
                             ClaimContactCard(
                                 imageUrl: partner.imageUrl,
-                                label: model?.config?.cardText ?? "",
                                 url: partner.url ?? "",
+                                phoneNumber: partner.phoneNumber,
                                 title: index == 0 ? title : nil,
-                                buttonText: model?.config?.buttonText ?? "",
-                                infoViewTitle: model?.config?.infoViewTitle ?? "",
-                                infoViewText: model?.config?.infoSectionText ?? ""
+                                model: model
                             )
                         }
                     }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Subviews/ClaimContactCard.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Subviews/ClaimContactCard.swift
@@ -7,30 +7,24 @@ import hCoreUI
 
 struct ClaimContactCard: View {
     @PresentableStore var store: SubmitClaimStore
+    var model: FlowClaimDeflectStepModel
     var title: String?
     var imageUrl: String
-    var label: String
     var url: String?
-    var buttonText: String
-    var infoViewTitle: String
-    var infoViewText: String
+    var phoneNumber: String?
 
     init(
         imageUrl: String,
-        label: String,
         url: String,
+        phoneNumber: String?,
         title: String? = nil,
-        buttonText: String,
-        infoViewTitle: String,
-        infoViewText: String
+        model: FlowClaimDeflectStepModel?
     ) {
         self.imageUrl = imageUrl
-        self.label = label
         self.url = url
+        self.phoneNumber = phoneNumber
         self.title = title
-        self.buttonText = buttonText
-        self.infoViewTitle = infoViewTitle
-        self.infoViewText = infoViewText
+        self.model = model ?? .init(id: .Unknown, isEmergencyStep: false)
     }
 
     var body: some View {
@@ -43,8 +37,8 @@ struct ClaimContactCard: View {
                     hText(title)
                     Spacer()
                     InfoViewHolder(
-                        title: infoViewTitle,
-                        description: infoViewText
+                        title: model.config?.infoViewTitle ?? "",
+                        description: model.config?.infoViewText ?? ""
                     )
                 }
             })
@@ -69,7 +63,7 @@ struct ClaimContactCard: View {
                     .padding(.vertical, 16)
             }
 
-            hText(label)
+            hText(model.config?.cardText ?? "")
                 .fixedSize()
                 .multilineTextAlignment(.center)
                 .foregroundColor(hTextColor.tertiary)
@@ -80,9 +74,15 @@ struct ClaimContactCard: View {
                 hButton.MediumButton(type: .secondaryAlt) {
                     if let url = URL(string: url) {
                         UIApplication.shared.open(url)
+                    } else if let phoneNumber {
+                        let tel = "tel://"
+                        let formattedString = tel + phoneNumber
+                        if let url = URL(string: formattedString) {
+                            UIApplication.shared.open(url)
+                        }
                     }
                 } content: {
-                    hText(buttonText)
+                    hText(model.config?.buttonText ?? "")
                         .multilineTextAlignment(.center)
                         .foregroundColor(hTextColor.primary)
                         .colorScheme(.light)
@@ -186,27 +186,21 @@ struct ClaimContactCard_Previews: PreviewProvider {
         return VStack {
             ClaimContactCard(
                 imageUrl: "",
-                label: "LABEL",
                 url: "BUTTON TEXT",
-                buttonText: "",
-                infoViewTitle: "",
-                infoViewText: ""
+                phoneNumber: "",
+                model: nil
             )
             ClaimContactCard(
                 imageUrl: "",
-                label: "VERY LONG LABEL TEXT VERY LONG LABEL TEXT VERY LONG LABEL TEXT VERY LONG LABEL TEXT",
                 url: "BUTTON TEXT",
-                buttonText: "",
-                infoViewTitle: "",
-                infoViewText: ""
+                phoneNumber: "",
+                model: nil
             )
             ClaimContactCard(
                 imageUrl: "",
-                label: "LABEL",
                 url: "VERY LONG BUTTON TEXT VERY LONG BUTTON TEXT VERY LONG BUTTON TEXT",
-                buttonText: "",
-                infoViewTitle: "",
-                infoViewText: ""
+                phoneNumber: "",
+                model: nil
             )
 
         }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Subviews/ClaimContactCard.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Subviews/ClaimContactCard.swift
@@ -12,19 +12,25 @@ struct ClaimContactCard: View {
     var label: String
     var url: String?
     var buttonText: String
+    var infoViewTitle: String
+    var infoViewText: String
 
     init(
         imageUrl: String,
         label: String,
         url: String,
         title: String? = nil,
-        buttonText: String
+        buttonText: String,
+        infoViewTitle: String,
+        infoViewText: String
     ) {
         self.imageUrl = imageUrl
         self.label = label
         self.url = url
         self.title = title
         self.buttonText = buttonText
+        self.infoViewTitle = infoViewTitle
+        self.infoViewText = infoViewText
     }
 
     var body: some View {
@@ -35,6 +41,11 @@ struct ClaimContactCard: View {
             .withHeader({
                 HStack {
                     hText(title)
+                    Spacer()
+                    InfoViewHolder(
+                        title: infoViewTitle,
+                        description: infoViewText
+                    )
                 }
             })
             .sectionContainerStyle(.black)
@@ -173,18 +184,29 @@ struct ClaimContactCard_Previews: PreviewProvider {
     static var previews: some View {
         Localization.Locale.currentLocale = .en_SE
         return VStack {
-            ClaimContactCard(imageUrl: "", label: "LABEL", url: "BUTTON TEXT", buttonText: "")
+            ClaimContactCard(
+                imageUrl: "",
+                label: "LABEL",
+                url: "BUTTON TEXT",
+                buttonText: "",
+                infoViewTitle: "",
+                infoViewText: ""
+            )
             ClaimContactCard(
                 imageUrl: "",
                 label: "VERY LONG LABEL TEXT VERY LONG LABEL TEXT VERY LONG LABEL TEXT VERY LONG LABEL TEXT",
                 url: "BUTTON TEXT",
-                buttonText: ""
+                buttonText: "",
+                infoViewTitle: "",
+                infoViewText: ""
             )
             ClaimContactCard(
                 imageUrl: "",
                 label: "LABEL",
                 url: "VERY LONG BUTTON TEXT VERY LONG BUTTON TEXT VERY LONG BUTTON TEXT",
-                buttonText: ""
+                buttonText: "",
+                infoViewTitle: "",
+                infoViewText: ""
             )
 
         }


### PR DESCRIPTION
## [GEN-1889]

- Add deflect model for towing.
- Some design edits. Added info button which we had on design but didn't add before.
- [Figma](https://www.figma.com/file/LlJgc0axJygj5FxLdYgevj/Car-Claims-2024?type=design&node-id=3701-1558&mode=design&t=9mha49QYCyauC45j-0)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
