### PR TITLE
Use consistent L10n for tab names

### DIFF
--- a/Projects/Contracts/Sources/ContractsTabBarItemConfiguration.swift
+++ b/Projects/Contracts/Sources/ContractsTabBarItemConfiguration.swift
@@ -8,7 +8,7 @@ extension JourneyPresentation {
         configureTabBarItemWithDot(
             ContractStore.self,
             tabBarItem: UITabBarItem(
-                title: L10n.InsurancesTab.title,
+                title: L10n.tabInsurancesTitle,
                 image: hCoreUIAssets.contractTab.image,
                 selectedImage: hCoreUIAssets.contractTabActive.image
             )

--- a/Projects/Home/Sources/Screens/Home.swift
+++ b/Projects/Home/Sources/Screens/Home.swift
@@ -245,7 +245,7 @@ extension HomeView {
             }
         }
         .configureTabBarItem(
-            title: L10n.HomeTab.title,
+            title: L10n.tabHomeTitle,
             image: hCoreUIAssets.homeTab.image,
             selectedImage: hCoreUIAssets.homeTabActive.image
         )

--- a/Projects/hCore/Sources/DeepLink.swift
+++ b/Projects/hCore/Sources/DeepLink.swift
@@ -27,9 +27,9 @@ public enum DeepLink: String, Codable {
         case .profile:
             return L10n.tabProfileTitle
         case .insurances:
-            return L10n.InsurancesTab.title
+            return L10n.tabInsurancesTitle
         case .home:
-            return L10n.HomeTab.title
+            return L10n.tabHomeTitle
         case .sasEuroBonus:
             return L10n.SasIntegration.title
         case .payments:


### PR DESCRIPTION
Context:
https://hedviginsurance.slack.com/archives/C05TQ9TFQ6M/p1710850325979789?thread_ts=1710844864.449339&cid=C05TQ9TFQ6M

Should work when CI pulls the latest strings from lokalise.
They live here https://app.lokalise.com/project/743091915e9da969db9340.20943733/?view=multi&filter=tag_fd9160bbd656f75ab74e8935e4330d9e
