### PR TITLE
Updated how often we call for claims

### DIFF
--- a/Projects/App/Sources/Journeys/ClaimsJourney.swift
+++ b/Projects/App/Sources/Journeys/ClaimsJourney.swift
@@ -61,6 +61,10 @@ extension AppJourney {
     @JourneyBuilder
     static func startClaimsJourney(from origin: ClaimsOrigin) -> some JourneyPresentation {
         honestyPledge(from: origin)
+            .onDismiss {
+                let claimsStore: ClaimsStore = globalPresentableStoreContainer.get()
+                claimsStore.send(.fetchClaims)
+            }
     }
 
     private static func honestyPledge(from origin: ClaimsOrigin) -> some JourneyPresentation {

--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -200,7 +200,6 @@ extension AppJourney {
             )
             .sendActionImmediately(ContractStore.self, .fetch)
             .sendActionImmediately(ForeverStore.self, .fetch)
-            .sendActionImmediately(ClaimsStore.self, .fetchClaims)
             .syncTabIndex()
             .onAction(UgglanStore.self) { action in
                 if action == .openChat {

--- a/Projects/Claims/Sources/Claims.swift
+++ b/Projects/Claims/Sources/Claims.swift
@@ -44,6 +44,9 @@ extension Claims: View {
         .onAppear {
             vm.fetch()
         }
+        .onDisappear {
+            vm.stopTimer()
+        }
     }
 }
 
@@ -51,13 +54,13 @@ class ClaimsViewModel: ObservableObject {
     @PresentableStore private var store: ClaimsStore
     private var pollTimerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>?
     private var pollTimerCancellable: AnyCancellable?
-    private var claimsCountCancellable: AnyCancellable?
     private let refreshOn = 60
 
-    public init() {
-        configureTimerForFetchClaims()
+    func stopTimer() {
+        pollTimerCancellable?.cancel()
     }
-    private func configureTimerForFetchClaims() {
+
+    func configureTimer() {
         pollTimerPublisher = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common).autoconnect()
         pollTimerCancellable = pollTimerPublisher?
             .sink(receiveValue: { [weak self] _ in
@@ -67,7 +70,6 @@ class ClaimsViewModel: ObservableObject {
                     self?.fetch()
                 } else {
                     self?.pollTimerCancellable?.cancel()
-                    self?.claimsCountCancellable?.cancel()
                 }
             })
     }
@@ -75,6 +77,7 @@ class ClaimsViewModel: ObservableObject {
     func fetch() {
         store.send(.fetchClaims)
         //added this to reset timer after we fetch becausae we could fetch from other places so we dont fetch too often
-        configureTimerForFetchClaims()
+        configureTimer()
     }
+
 }

--- a/Projects/Claims/Sources/Claims.swift
+++ b/Projects/Claims/Sources/Claims.swift
@@ -48,7 +48,7 @@ extension Claims: View {
 }
 
 class ClaimsViewModel: ObservableObject {
-    @PresentableStore var store: ClaimsStore
+    @PresentableStore private var store: ClaimsStore
     private var pollTimerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>?
     private var pollTimerCancellable: AnyCancellable?
     private var claimsCountCancellable: AnyCancellable?

--- a/Projects/Claims/Sources/Claims.swift
+++ b/Projects/Claims/Sources/Claims.swift
@@ -41,35 +41,40 @@ extension Claims: View {
         ) { claims, _ in
             claimsSection(claims)
         }
-        .onReceive(vm.pollTimer) { _ in
-            if ApplicationContext.shared.isLoggedIn {
-                vm.fetch()
-            } else {
-                vm.pollTimer.upstream.connect().cancel()
-            }
+        .onAppear {
+            vm.fetch()
         }
     }
 }
 
 class ClaimsViewModel: ObservableObject {
     @PresentableStore var store: ClaimsStore
-    let pollTimer: Publishers.Autoconnect<Timer.TimerPublisher>
+    private var pollTimerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>?
+    private var pollTimerCancellable: AnyCancellable?
+    private var claimsCountCancellable: AnyCancellable?
+    private let refreshOn = 60
 
     public init() {
-        let store: ClaimsStore = globalPresentableStoreContainer.get()
-        let count = store.state.claims?.count ?? 1
-        let refreshOn: Int = {
-            if count == 0 {
-                return 5
-            } else {
-                return min(count * 5, 20)
-            }
-        }()
-        pollTimer = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common).autoconnect()
-        fetch()
+        configureTimerForFetchClaims()
+    }
+    private func configureTimerForFetchClaims() {
+        pollTimerPublisher = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common).autoconnect()
+        pollTimerCancellable = pollTimerPublisher?
+            .sink(receiveValue: { [weak self] _ in
+                //added this check here because we have major memory leak in the tabjourney so when we logout this vm is still alive
+                //TODO: remove after we fix memory leak
+                if ApplicationContext.shared.isLoggedIn {
+                    self?.fetch()
+                } else {
+                    self?.pollTimerCancellable?.cancel()
+                    self?.claimsCountCancellable?.cancel()
+                }
+            })
     }
 
     func fetch() {
         store.send(.fetchClaims)
+        //added this to reset timer after we fetch becausae we could fetch from other places so we dont fetch too often
+        configureTimerForFetchClaims()
     }
 }

--- a/Projects/Claims/Sources/Claims.swift
+++ b/Projects/Claims/Sources/Claims.swift
@@ -52,7 +52,6 @@ extension Claims: View {
 
 class ClaimsViewModel: ObservableObject {
     @PresentableStore private var store: ClaimsStore
-    private var pollTimerPublisher: Publishers.Autoconnect<Timer.TimerPublisher>?
     private var pollTimerCancellable: AnyCancellable?
     private let refreshOn = 60
 
@@ -61,8 +60,8 @@ class ClaimsViewModel: ObservableObject {
     }
 
     private func configureTimer() {
-        pollTimerPublisher = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common).autoconnect()
-        pollTimerCancellable = pollTimerPublisher?
+        pollTimerCancellable = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common)
+            .autoconnect()
             .sink(receiveValue: { [weak self] _ in
                 //added this check here because we have major memory leak in the tabjourney so when we logout this vm is still alive
                 //TODO: remove after we fix memory leak

--- a/Projects/Claims/Sources/Claims.swift
+++ b/Projects/Claims/Sources/Claims.swift
@@ -60,7 +60,7 @@ class ClaimsViewModel: ObservableObject {
         pollTimerCancellable?.cancel()
     }
 
-    func configureTimer() {
+    private func configureTimer() {
         pollTimerPublisher = Timer.publish(every: TimeInterval(refreshOn), on: .main, in: .common).autoconnect()
         pollTimerCancellable = pollTimerPublisher?
             .sink(receiveValue: { [weak self] _ in


### PR DESCRIPTION
Looking at [graphQL metrics](https://studio.apollographql.com/graph/Octopus-fxevz/variant/production/clients?clientName=iOS%3Acom.hedvig.app&clientVersion=12.4.14) we are calling too ofter for claims. Lets rework it a little bit so we don't call it so often. 

Lets move to call them every 60s and see how that will work.

- Removed calling fetchClaims when the app starts
- Added fetch claims when we finish with submit claims flow
- Reworked how and when we fetchClaims

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
