### PR TITLE
Updated demo logic + analytics service

### DIFF
--- a/Projects/App/Sources/AnalyticsCoordinator.swift
+++ b/Projects/App/Sources/AnalyticsCoordinator.swift
@@ -5,20 +5,22 @@ import SwiftUI
 import hCore
 import hGraphQL
 
-protocol AnalyticsCoordinator {
-    func setUserId()
+protocol AnalyticsService {
+    func fetchAndSetUserId()
+    func setWith(userId: String)
 }
 
-struct AnalyticsCoordinatorDemo: AnalyticsCoordinator {
-    func setUserId() {}
+struct AnalyticsServiceDemo: AnalyticsService {
+    func fetchAndSetUserId() {}
+    func setWith(userId: String) {}
 }
 
-struct AnalyticsCoordinatorOctopus: AnalyticsCoordinator {
+struct AnalyticsServiceOctopus: AnalyticsService {
     @Inject private var octopus: hOctopus
 
     init() {}
 
-    func setUserId() {
+    func fetchAndSetUserId() {
         octopus.client.fetch(query: OctopusGraphQL.CurrentMemberIdQuery(), cachePolicy: .fetchIgnoringCacheCompletely)
             .compactMap { $0.currentMember.id }
             .onValue { id in
@@ -26,7 +28,7 @@ struct AnalyticsCoordinatorOctopus: AnalyticsCoordinator {
             }
     }
 
-    func setWith(userId: String?) {
+    func setWith(userId: String) {
         let deviceModel = UIDevice.modelName
         Datadog.setUserInfo(
             id: userId,

--- a/Projects/App/Sources/AppDelegate+DI.swift
+++ b/Projects/App/Sources/AppDelegate+DI.swift
@@ -9,6 +9,7 @@ import Foundation
 import Home
 import MoveFlow
 import Payment
+import Presentation
 import Profile
 import TerminateContracts
 import TravelCertificate
@@ -19,7 +20,8 @@ extension ApolloClient {
     public static func initAndRegisterClient() {
         let authorizationService = AuthentificationServiceAuthLib()
         Dependencies.shared.add(module: Module { () -> AuthentificationService in authorizationService })
-        if ApplicationContext.shared.isDemoMode {
+        let ugglanStore: UgglanStore = globalPresentableStoreContainer.get()
+        if ugglanStore.state.isDemoMode {
             let featureFlags = FeatureFlagsDemo()
             let hPaymentService = hPaymentServiceDemo()
             let fetchClaimService = FetchClaimServiceDemo()
@@ -28,7 +30,7 @@ extension ApolloClient {
             let foreverService = ForeverServiceDemo()
             let profileDemoService = ProfileDemoService()
             let homeServiceDemo = HomeServiceDemo()
-            let analyticsCoordinator = AnalyticsCoordinatorDemo()
+            let analyticsService = AnalyticsServiceDemo()
             let notificationClient = NotificationClientDemo()
             let submitClaimDemoService = SubmitClaimDemoService()
             Dependencies.shared.add(module: Module { () -> FeatureFlags in featureFlags })
@@ -39,7 +41,7 @@ extension ApolloClient {
             Dependencies.shared.add(module: Module { () -> ForeverService in foreverService })
             Dependencies.shared.add(module: Module { () -> ProfileService in profileDemoService })
             Dependencies.shared.add(module: Module { () -> HomeService in homeServiceDemo })
-            Dependencies.shared.add(module: Module { () -> AnalyticsCoordinator in analyticsCoordinator })
+            Dependencies.shared.add(module: Module { () -> AnalyticsService in analyticsService })
             Dependencies.shared.add(module: Module { () -> NotificationClient in notificationClient })
             Dependencies.shared.add(module: Module { () -> SubmitClaimService in submitClaimDemoService })
         } else {
@@ -59,7 +61,7 @@ extension ApolloClient {
             let hFetchClaimService = FetchClaimServiceOctopus()
             let travelInsuranceService = TravelInsuranceClientOctopus()
             let featureFlagsUnleash = FeatureFlagsUnleash(environment: Environment.current)
-            let analyticsCoordinator = AnalyticsCoordinatorOctopus()
+            let analyticsService = AnalyticsServiceOctopus()
             let notificationService = NotificationClientOctopus()
             let hFetchEntrypointsService = FetchEntrypointsServiceOctopus()
             let submitClaimService = SubmitClaimServiceOctopus()
@@ -84,7 +86,7 @@ extension ApolloClient {
                 Dependencies.shared.add(module: Module { () -> EditCoInsuredService in editCoInsuredService })
                 Dependencies.shared.add(module: Module { () -> HomeService in homeService })
                 Dependencies.shared.add(module: Module { () -> TerminateContractsService in terminateContractsService })
-                Dependencies.shared.add(module: Module { () -> AnalyticsCoordinator in analyticsCoordinator })
+                Dependencies.shared.add(module: Module { () -> AnalyticsService in analyticsService })
                 Dependencies.shared.add(module: Module { () -> NotificationClient in notificationService })
                 Dependencies.shared.add(module: Module { () -> hFetchEntrypointsService in hFetchEntrypointsService })
                 Dependencies.shared.add(module: Module { () -> SubmitClaimService in submitClaimService })
@@ -108,7 +110,7 @@ extension ApolloClient {
                 Dependencies.shared.add(module: Module { () -> EditCoInsuredService in editCoInsuredService })
                 Dependencies.shared.add(module: Module { () -> HomeService in homeService })
                 Dependencies.shared.add(module: Module { () -> TerminateContractsService in terminateContractsService })
-                Dependencies.shared.add(module: Module { () -> AnalyticsCoordinator in analyticsCoordinator })
+                Dependencies.shared.add(module: Module { () -> AnalyticsService in analyticsService })
                 Dependencies.shared.add(module: Module { () -> NotificationClient in notificationService })
                 Dependencies.shared.add(module: Module { () -> hFetchEntrypointsService in hFetchEntrypointsService })
                 Dependencies.shared.add(module: Module { () -> SubmitClaimService in submitClaimService })

--- a/Projects/App/Sources/AppDelegate+Tracking.swift
+++ b/Projects/App/Sources/AppDelegate+Tracking.swift
@@ -4,6 +4,8 @@ import DatadogLogs
 import DatadogRUM
 import DatadogTrace
 import Introspect
+import Presentation
+import Profile
 import SwiftUI
 import hCore
 import hCoreUI
@@ -29,7 +31,11 @@ extension AppDelegate {
             with: configuration,
             trackingConsent: .granted
         )
-
+        let store: ProfileStore = globalPresentableStoreContainer.get()
+        if let userId = store.state.memberDetails?.id {
+            let analyticsService: AnalyticsService = Dependencies.shared.resolve()
+            analyticsService.setWith(userId: userId)
+        }
         Logs.enable()
 
         RUM.enable(

--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -209,8 +209,8 @@ extension AppJourney {
             }
             .onPresent {
                 ApplicationState.preserveState(.loggedIn)
-                let coordinator: AnalyticsCoordinator = Dependencies.shared.resolve()
-                coordinator.setUserId()
+                let analyticsService: AnalyticsService = Dependencies.shared.resolve()
+                analyticsService.fetchAndSetUserId()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     ApplicationContext.shared.$isLoggedIn.value = true
                 }

--- a/Projects/App/Sources/Journeys/LoginJourney.swift
+++ b/Projects/App/Sources/Journeys/LoginJourney.swift
@@ -1,9 +1,11 @@
+import Apollo
 import Authentication
 import Market
 import Presentation
 import SwiftUI
 import hCore
 import hCoreUI
+import hGraphQL
 
 extension AppJourney {
     fileprivate static var loginCompleted: some JourneyPresentation {
@@ -13,7 +15,11 @@ extension AppJourney {
     fileprivate static var bankIDSweden: some JourneyPresentation {
         HostingJourney(
             AuthenticationStore.self,
-            rootView: BankIDLoginQRView(),
+            rootView: BankIDLoginQRView {
+                let store: UgglanStore = globalPresentableStoreContainer.get()
+                await store.sendAsync(.setIsDemoMode(to: true))
+                ApolloClient.initAndRegisterClient()
+            },
             style: .detented(.large)
         ) { action in
             if case .bankIdQrResultAction(.loggedIn) = action {

--- a/Projects/Authentication/Sources/SEBankID/BankIDLoginQRView.swift
+++ b/Projects/Authentication/Sources/SEBankID/BankIDLoginQRView.swift
@@ -8,8 +8,10 @@ import hGraphQL
 public struct BankIDLoginQRView: View {
     @PresentableStore var store: AuthenticationStore
     @StateObject var vm = BandIDViewModel()
-
-    public init() {}
+    private var onStartDemoMode: () async -> Void
+    public init(onStartDemoMode: @escaping () async -> Void) {
+        self.onStartDemoMode = onStartDemoMode
+    }
     public var body: some View {
         Group {
             if vm.isLoading {
@@ -44,9 +46,11 @@ public struct BankIDLoginQRView: View {
                                 message: nil,
                                 primaryButton: .cancel(Text(L10n.demoModeCancel)),
                                 secondaryButton: .destructive(Text(L10n.logoutAlertActionConfirm)) {
-                                    ApplicationContext.shared.$isDemoMode.value = true
-                                    store.send(.bankIdQrResultAction(action: .loggedIn))
-                                    vm.cancelLogin()
+                                    Task {
+                                        await onStartDemoMode()
+                                        store.send(.bankIdQrResultAction(action: .loggedIn))
+                                        vm.cancelLogin()
+                                    }
                                 }
                             )
                         }
@@ -235,6 +239,6 @@ class BandIDViewModel: ObservableObject {
 
 struct BankIDLoginQR_Previews: PreviewProvider {
     static var previews: some View {
-        BankIDLoginQRView()
+        BankIDLoginQRView {}
     }
 }

--- a/Projects/Home/Sources/HomeState.swift
+++ b/Projects/Home/Sources/HomeState.swift
@@ -109,22 +109,14 @@ public final class HomeStore: LoadingStateStore<HomeState, HomeAction, HomeLoadi
 
                 send(.setFutureStatus(status: memberData.futureState))
             } catch _ {
-                if ApplicationContext.shared.isDemoMode {
-                    send(.setQuickActions(quickActions: []))
-                } else {
-                    self.setError(L10n.General.errorBody, for: .fetchQuickActions)
-                }
+                self.setError(L10n.General.errorBody, for: .fetchQuickActions)
             }
         case .fetchQuickActions:
             do {
                 let quickActions = try await self.homeService.getQuickActions()
                 send(.setQuickActions(quickActions: quickActions))
             } catch {
-                if ApplicationContext.shared.isDemoMode {
-                    send(.setQuickActions(quickActions: []))
-                } else {
-                    self.setError(L10n.General.errorBody, for: .fetchQuickActions)
-                }
+                self.setError(L10n.General.errorBody, for: .fetchQuickActions)
             }
         case .fetchChatNotifications:
             do {

--- a/Projects/hCore/Sources/ApplicationContext.swift
+++ b/Projects/hCore/Sources/ApplicationContext.swift
@@ -5,5 +5,4 @@ public struct ApplicationContext {
     public static var shared = ApplicationContext()
     @ReadWriteState public var isLoggedIn = false
     @ReadWriteState public var hasFinishedBootstrapping = false
-    @ReadWriteState public var isDemoMode: Bool = false
 }

--- a/Projects/hGraphQL/Sources/TokenRefresher.swift
+++ b/Projects/hGraphQL/Sources/TokenRefresher.swift
@@ -5,7 +5,6 @@ import Foundation
 public class TokenRefresher {
     public static let shared = TokenRefresher()
     var isRefreshing: ReadWriteSignal<Bool> = ReadWriteSignal(false)
-    public var isDemoMode = false
     var needRefresh: Bool {
         guard let token = try? ApolloClient.retreiveToken() else {
             return false
@@ -17,12 +16,9 @@ public class TokenRefresher {
     public func refreshIfNeeded() async throws {
         let token = try ApolloClient.retreiveToken()
         guard let token = token else {
-            if !isDemoMode {
-                forceLogoutHook()
-                log.info("Access token refresh missing token", error: nil, attributes: nil)
-                throw AuthError.refreshTokenExpired
-            }
-            return
+            forceLogoutHook()
+            log.info("Access token refresh missing token", error: nil, attributes: nil)
+            throw AuthError.refreshTokenExpired
         }
 
         log.debug("Checking if access token refresh is needed")


### PR DESCRIPTION
We had strange handling of demo mode and now we are removing some flags so now we have clearer handing of demo mode.
Also we were setting memberId only after we fetch it from the service, now we set it immediately after we init DataDog ( if available from the profile store)

- Removed isDemoFlag from TokenRefresher
- Upgraded and renamed hAnalyticsCoordinator to AnalyticsService 
- Removed isDemoMode from context ApplicationContext

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
