### PR TITLE
Update connect payment info card

### DIFF
--- a/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPaymentCard.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPaymentCard.swift
@@ -15,22 +15,7 @@ public struct ConnectPaymentCardView: View {
                 state.paymentStatusData
             }
         ) { paymentStatusData in
-            if let nextChargeDate = paymentStatusData?.nextChargeDate?.displayDate,
-                paymentStatusData?.status == .needsSetup
-            {
-                InfoCard(
-                    text: L10n.InfoCardMissingPayment.bodyWithDate(nextChargeDate),
-                    type: .attention
-                )
-                .buttons([
-                    .init(
-                        buttonTitle: L10n.PayInExplainer.buttonText,
-                        buttonAction: {
-                            store.send(.navigation(to: .openConnectPayments))
-                        }
-                    )
-                ])
-            } else if paymentStatusData?.status == .needsSetup {
+            if paymentStatusData?.status == .needsSetup {
                 InfoCard(
                     text: L10n.InfoCardMissingPayment.body,
                     type: .attention


### PR DESCRIPTION
After conversation with the android team, we decide to:
- always show connect payment card without date
[slack](https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1712129401412549)
## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
