### PR TITLE
GEN-1993-added-missed-connect-payments

### DIFF
--- a/Projects/App/Sources/AppDelegate+Deeplinks.swift
+++ b/Projects/App/Sources/AppDelegate+Deeplinks.swift
@@ -155,6 +155,15 @@ extension AppDelegate {
                     let disposeBag = DisposeBag()
                     disposeBag += fromVC.present(vc)
                 }
+
+        } else if path == .openChat {
+            deepLinkDisposeBag += ApplicationContext.shared.$hasFinishedBootstrapping.atOnce().filter { $0 }
+                .onValue { [weak self] _ in
+                    self?.deepLinkDisposeBag.dispose()
+                    let vc = AppJourney.freeTextChat().withDismissButton
+                    let disposeBag = DisposeBag()
+                    disposeBag += fromVC.present(vc)
+                }
         } else {
             deepLinkDisposeBag += ApplicationContext.shared.$hasFinishedBootstrapping.atOnce().filter { $0 }
                 .onValue { [weak self] _ in

--- a/Projects/App/Sources/Journeys/LoggedInJourney.swift
+++ b/Projects/App/Sources/Journeys/LoggedInJourney.swift
@@ -304,8 +304,17 @@ extension JourneyPresentation {
             if case let .navigation(navigateTo) = action {
                 if case .openConnectPayments = navigateTo {
                     DirectDebitSetup(setupType: .initial).journey()
-                } else if case let .openUrl(url) = navigateTo {
-                    AppJourney.urlHandledBySystem(url: url)
+                } else if case let .openUrl(url, handledBySystem) = navigateTo {
+                    if handledBySystem {
+                        AppJourney.urlHandledBySystem(url: url)
+                    } else {
+                        ContinueJourney()
+                            .onPresent {
+                                if let vc = UIApplication.shared.getTopViewController() {
+                                    UIApplication.shared.appDelegate.handleDeepLink(url, fromVC: vc)
+                                }
+                            }
+                    }
                 }
             }
         }

--- a/Projects/Payment/GraphQL/Octopus/PaymentInformation.graphql
+++ b/Projects/Payment/GraphQL/Octopus/PaymentInformation.graphql
@@ -7,11 +7,9 @@ query PaymentInformation {
       }
       status
     }
-    futureCharge {
-      date
-    }
-    chargeHistory {
-      status
+    activeContracts {
+      terminationDueToMissedPayments
+      terminationDate
     }
   }
 }

--- a/Projects/Payment/GraphQL/Octopus/PaymentInformation.graphql
+++ b/Projects/Payment/GraphQL/Octopus/PaymentInformation.graphql
@@ -1,15 +1,18 @@
 query PaymentInformation {
-  currentMember {
-    paymentInformation {
-      connection {
-        displayName
-        descriptor
-      }
-      status
+    currentMember {
+        paymentInformation {
+            connection {
+            displayName
+            descriptor
+            }
+            status
+        }
+        activeContracts {
+            terminationDueToMissedPayments
+            terminationDate
+        }
+        pendingContracts {
+            id
+        }
     }
-    activeContracts {
-      terminationDueToMissedPayments
-      terminationDate
-    }
-  }
 }

--- a/Projects/Payment/Sources/PaymentStore.swift
+++ b/Projects/Payment/Sources/PaymentStore.swift
@@ -31,7 +31,7 @@ public enum PaymentAction: ActionProtocol {
 }
 
 public enum PaymentNavigation: ActionProtocol {
-    case openUrl(url: URL)
+    case openUrl(url: URL, handledBySystem: Bool)
     case openHistory
     case openDiscounts
     case openConnectPayments

--- a/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPaymentCard.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPaymentCard.swift
@@ -15,27 +15,41 @@ public struct ConnectPaymentCardView: View {
                 state.paymentStatusData
             }
         ) { paymentStatusData in
-            if let nextChargeDate = paymentStatusData?.nextChargeDate?.displayDate,
-                paymentStatusData?.status == .needsSetup
-            {
-                InfoCard(
-                    text: L10n.InfoCardMissingPayment.bodyWithDate(nextChargeDate),
-                    type: .attention
-                )
-                .buttons([
+            if let status = paymentStatusData?.status {
+                getStatusInfoView(from: status)
+            }
+        }
+        .onAppear {
+            store.send(.fetchPaymentStatus)
+        }
+    }
+
+    @ViewBuilder
+    func getStatusInfoView(from status: PayinMethodStatus) -> some View {
+        if case let .contactUs(date) = status {
+            InfoCard(
+                text: L10n.InfoCardMissingPayment.missingPaymentsBody(date),
+                type: .attention
+            )
+            .buttons(
+                [
                     .init(
-                        buttonTitle: L10n.PayInExplainer.buttonText,
+                        buttonTitle: L10n.General.chatButton,
                         buttonAction: {
-                            store.send(.navigation(to: .openConnectPayments))
+                            if let url = DeepLink.getUrl(from: .openChat) {
+                                store.send(.navigation(to: .openUrl(url: url, handledBySystem: false)))
+                            }
                         }
                     )
-                ])
-            } else if paymentStatusData?.status == .needsSetup {
-                InfoCard(
-                    text: L10n.InfoCardMissingPayment.body,
-                    type: .attention
-                )
-                .buttons([
+                ]
+            )
+        } else if case .needsSetup = status {
+            InfoCard(
+                text: L10n.InfoCardMissingPayment.body,
+                type: .attention
+            )
+            .buttons(
+                [
                     .init(
                         buttonTitle: L10n.PayInExplainer.buttonText,
                         buttonAction: {
@@ -43,11 +57,8 @@ public struct ConnectPaymentCardView: View {
                         }
                     )
                 ]
-                )
-            }
-        }
-        .onAppear {
-            store.send(.fetchPaymentStatus)
+            )
         }
     }
+
 }

--- a/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
@@ -339,7 +339,7 @@ extension DirectDebitSetup {
                         let paymentServcice: AdyenService = Dependencies.shared.resolve()
                         do {
                             let url = try await paymentServcice.getAdyenUrl()
-                            paymentStore.send(.navigation(to: .openUrl(url: url)))
+                            paymentStore.send(.navigation(to: .openUrl(url: url, handledBySystem: true)))
                         } catch {
                             //we are not so concern about this
                         }

--- a/Projects/Payment/Sources/Screens/PaymentsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsView.swift
@@ -180,7 +180,7 @@ public struct PaymentsView: View {
                 state.paymentStatusData?.status
             }
         ) { statusData in
-            if let statusData, statusData != .needsSetup {
+            if let statusData, !statusData.showConnectPayment {
                 hSection {
                     VStack(spacing: 16) {
                         if statusData == .pending {

--- a/Projects/Payment/Sources/Services/PaymentService/PaymentServiceDemo.swift
+++ b/Projects/Payment/Sources/Services/PaymentService/PaymentServiceDemo.swift
@@ -85,8 +85,7 @@ public class hPaymentServiceDemo: hPaymentService {
     public func getPaymentStatusData() async throws -> PaymentStatusData {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         return PaymentStatusData(
-            status: .active,
-            nextChargeDate: "2023-11-29",
+            status: .needsSetup,
             displayName: "Connected bank",
             descriptor: "****1234"
         )

--- a/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
+++ b/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
@@ -1,11 +1,6 @@
 import Foundation
 import hGraphQL
 
-struct TestConnect {
-    let terminationDueToMissedPayments: Bool
-    let terminationDate: String?
-}
-
 extension PaymentStatusData {
     init(data: OctopusGraphQL.PaymentInformationQuery.Data) {
         self.status = {

--- a/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
+++ b/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
@@ -1,0 +1,33 @@
+import Foundation
+import hGraphQL
+
+struct TestConnect {
+    let terminationDueToMissedPayments: Bool
+    let terminationDate: String?
+}
+
+extension PaymentStatusData {
+    init(data: OctopusGraphQL.PaymentInformationQuery.Data) {
+        self.status = {
+            if data.currentMember.activeContracts.isEmpty {
+                return .noNeedToConnect
+            }
+
+            let missedPaymentsContracts = data.currentMember.activeContracts.filter({
+                $0.terminationDueToMissedPayments
+            })
+            if !missedPaymentsContracts.isEmpty {
+                if let date = missedPaymentsContracts.compactMap({ $0.terminationDate?.localDateToDate }).sorted()
+                    .first?
+                    .displayDateDDMMMYYYYFormat
+                {
+                    return .contactUs(date: date)
+                }
+            }
+
+            return data.currentMember.paymentInformation.status.asPayinMethodStatus
+        }()
+        self.displayName = data.currentMember.paymentInformation.connection?.displayName
+        self.descriptor = data.currentMember.paymentInformation.connection?.descriptor
+    }
+}

--- a/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
+++ b/Projects/Payment/Sources/Services/PaymentService/PaymentStatusData+octopus.swift
@@ -9,7 +9,7 @@ struct TestConnect {
 extension PaymentStatusData {
     init(data: OctopusGraphQL.PaymentInformationQuery.Data) {
         self.status = {
-            if data.currentMember.activeContracts.isEmpty {
+            if data.currentMember.activeContracts.isEmpty && data.currentMember.pendingContracts.isEmpty {
                 return .noNeedToConnect
             }
 

--- a/Projects/hCore/Sources/DeepLink.swift
+++ b/Projects/hCore/Sources/DeepLink.swift
@@ -14,6 +14,7 @@ public enum DeepLink: String, Codable {
     case helpCenter = "help-center"
     case moveContract = "move-contract"
     case terminateContract = "terminate-contract"
+    case openChat = "open-chat"
 
     public func wholeText(displayText: String) -> String {
         return L10n.generalGoTo(displayText)
@@ -45,35 +46,8 @@ public enum DeepLink: String, Codable {
             return L10n.InsuranceDetails.changeAddressButton
         case .terminateContract:
             return L10n.hcQuickActionsTerminationTitle
-        }
-    }
-
-    private var getName: String {
-        switch self {
-        case .forever:
-            return "forever"
-        case .directDebit:
-            return "direct-debit"
-        case .profile:
-            return "profile"
-        case .insurances:
-            return "insurances"
-        case .home:
-            return "home"
-        case .sasEuroBonus:
-            return "eurobonus"
-        case .payments:
-            return "payments"
-        case .contract:
-            return "contract"
-        case .travelCertificate:
-            return "travelCertificate"
-        case .helpCenter:
-            return "help-center"
-        case .moveContract:
-            return "move-contract"
-        case .terminateContract:
-            return "terminate-contract"
+        case .openChat:
+            return L10n.chatTitle
         }
     }
 
@@ -85,7 +59,7 @@ public enum DeepLink: String, Codable {
     }
 
     public static func getUrl(from deeplink: DeepLink) -> URL? {
-        let path = Environment.current.deepLinkUrl.absoluteString + "/" + deeplink.getName
+        let path = Environment.current.deepLinkUrl.absoluteString + "/" + deeplink.rawValue
         guard let url = URL(string: path) else {
             return nil
         }


### PR DESCRIPTION
- Added new payment statuses: noNeedToConnect and contactUs
- noNeedToConnect status when we dont have any active and pending contracts
- contactUs when we have termination reason because of missed payments
- Changed GraphQL query for payment status
- Added open-chat deep link so we can open it on the top wherever we are located in the app

[Notion](https://www.notion.so/hedviginsurance/a4c35052b6794b36a4b0d58b537cc325?v=c74a8cb958ab4ba6ba4c904d8540b106&p=2b2316d35ab34dcea505aea7fb07bcbd&pm=s)
No Figma

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
