### PR TITLE
Disable device sleep on audio step

### DIFF
--- a/Projects/Claims/Sources/Views/SubmitClaim/AudioRecording/SubmitClaimAudioRecordingScreen.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/AudioRecording/SubmitClaimAudioRecordingScreen.swift
@@ -38,6 +38,12 @@ public struct SubmitClaimAudioRecordingScreen: View {
         if isAudioInput {
             audioInputForm
                 .claimErrorTrackerFor([.postAudioRecording])
+                .onAppear {
+                    UIApplication.shared.isIdleTimerDisabled = true
+                }
+                .onDisappear {
+                    UIApplication.shared.isIdleTimerDisabled = false
+                }
         } else {
             textInputForm
                 .claimErrorTrackerFor([.postAudioRecording])


### PR DESCRIPTION
## [APP-XXX]

- Prevent device to go asleep when audio step is presented

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
