### PR TITLE
Fixed edit co insured navigation not dismissing

### DIFF
--- a/Projects/EditCoInsured/Sources/Stores/EditCoInsuredStore.swift
+++ b/Projects/EditCoInsured/Sources/Stores/EditCoInsuredStore.swift
@@ -8,7 +8,7 @@ public final class EditCoInsuredStore: LoadingStateStore<
     EditCoInsuredState, EditCoInsuredAction, EditCoInsuredLoadingAction
 >
 {
-    @Inject var editCoInsuredService: EditCoInsuredClient
+    var editCoInsuredService = EditCoInsuredService()
     let coInsuredViewModel = InsuredPeopleNewScreenModel()
     let intentViewModel = IntentViewModel()
 

--- a/Projects/EditCoInsured/Sources/View/EditCoInsured+modifier.swift
+++ b/Projects/EditCoInsured/Sources/View/EditCoInsured+modifier.swift
@@ -50,7 +50,8 @@ struct EditCoInsured: ViewModifier {
     func getEditCoInsuredNavigation(coInsuredModel: EditCoInsuredNavigationModel) -> some View {
         if let contract = coInsuredModel.contractsSupportingCoInsured.first {
             EditCoInsuredNavigation(
-                config: contract
+                config: contract,
+                openSpecificScreen: coInsuredModel.openSpecificScreen
             )
             .environmentObject(vm)
         }

--- a/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
+++ b/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
@@ -73,11 +73,14 @@ public class EditCoInsuredViewModel: ObservableObject {
 
 public struct EditCoInsuredNavigationModel: Equatable, Identifiable {
     public var contractsSupportingCoInsured: [InsuredPeopleConfig]
-
+    public let openSpecificScreen: EditCoInsuredScreenType
     public init(
+        openSpecificScreen: EditCoInsuredScreenType = .none,
         contractsSupportingCoInsured: () -> [InsuredPeopleConfig]
     ) {
+        self.openSpecificScreen = openSpecificScreen
         self.contractsSupportingCoInsured = contractsSupportingCoInsured()
+
     }
 
     public var id: String = UUID().uuidString
@@ -85,4 +88,9 @@ public struct EditCoInsuredNavigationModel: Equatable, Identifiable {
 
 public enum EditCoInsuredRedirectType: Hashable {
     case checkForAlert
+}
+
+public enum EditCoInsuredScreenType {
+    case newInsurance
+    case none
 }

--- a/Projects/hCoreUI/Sources/DetentRouter.swift
+++ b/Projects/hCoreUI/Sources/DetentRouter.swift
@@ -111,13 +111,7 @@ private struct DetentSizeModifier<SwiftUIContent>: ViewModifier where SwiftUICon
     private func handle(isPresent: Bool) {
         if isPresent {
             var withDelay = false
-            if options.contains(.replaceCurrent) {
-                if let vc = presentationViewModel.rootVC?.presentingViewController {
-                    presentationViewModel.rootVC?.dismiss(animated: true)
-                    presentationViewModel.rootVC = vc
-                    withDelay = true
-                }
-            } else if !options.contains(.alwaysOpenOnTop) {
+            if !options.contains(.alwaysOpenOnTop) {
                 if let presentedVC = presentationViewModel.rootVC?.presentedViewController {
                     presentedVC.dismiss(animated: true)
                     withDelay = true
@@ -264,7 +258,6 @@ extension UIViewController {
 public struct DetentPresentationOption: OptionSet {
     public let rawValue: UInt
     public static let alwaysOpenOnTop = DetentPresentationOption(rawValue: 1 << 0)
-    public static let replaceCurrent = DetentPresentationOption(rawValue: 1 << 1)
     public static let withoutGrabber = DetentPresentationOption(rawValue: 1 << 2)
     public static let disableDismissOnScroll = DetentPresentationOption(rawValue: 1 << 3)
 

--- a/Projects/hCoreUI/Sources/ModallyRouter.swift
+++ b/Projects/hCoreUI/Sources/ModallyRouter.swift
@@ -87,13 +87,7 @@ private struct ModallySizeModifier<SwiftUIContent>: ViewModifier where SwiftUICo
     private func handle(isPresent: Bool) {
         if isPresent {
             var withDelay = false
-            if options.contains(.replaceCurrent) {
-                if let vc = presentationViewModel.rootVC?.presentingViewController {
-                    presentationViewModel.rootVC?.dismiss(animated: true)
-                    presentationViewModel.rootVC = vc
-                    withDelay = true
-                }
-            } else if !options.contains(.alwaysOpenOnTop) {
+            if !options.contains(.alwaysOpenOnTop) {
                 if let presentedVC = presentationViewModel.rootVC?.presentedViewController {
                     presentedVC.dismiss(animated: true)
                     withDelay = true


### PR DESCRIPTION
## [APP-XXX]

- Removed replaceCurrent - source of issues
- Reworked navigations for easier handing of whats going on

Steps to reproduce on the current main:

1. Add home and accident insurances with co insured
2. Add one insurance co insured
3. Alert will popup saying another insurance is missing co insured
4. After adding co insured the edit co insured navigation doesn't dismiss

That navigation in step 4 should dismiss now

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
