### PR TITLE
GEN-2461: Updated change bank account button in PaymentsView

### DIFF
--- a/Projects/Payment/Sources/Models/PaymentStatusData.swift
+++ b/Projects/Payment/Sources/Models/PaymentStatusData.swift
@@ -48,18 +48,16 @@ public enum PayinMethodStatus: Equatable {
         switch self {
         case .active, .pending:
             return L10n.myPaymentDirectDebitReplaceButton
-        case .needsSetup, .unknown, .noNeedToConnect:
+        case .needsSetup, .unknown, .noNeedToConnect, .contactUs:
             return L10n.myPaymentDirectDebitButton
-        case .contactUs:
-            return L10n.General.chatButton
         }
     }
 
     public var showConnectPayment: Bool {
         switch self {
-        case .contactUs, .needsSetup:
+        case .needsSetup:
             return true
-        case .noNeedToConnect, .pending, .active, .unknown:
+        case .noNeedToConnect, .pending, .active, .unknown, .contactUs:
             return false
         }
     }


### PR DESCRIPTION
## [GEN-2461]

- Changed bank account button when user has failed payment

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
