### PR TITLE
Added padding for empty refferal lists

### DIFF
--- a/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
@@ -93,7 +93,7 @@ struct PaymentsDiscountsView: View {
                     .foregroundColor(hTextColor.Opaque.secondary)
                 }
             }
-            .padding(.bottom, -16)
+            .padding(.bottom, data.referralsData.referrals.isEmpty ? 0 : -16)
         }
         hSection {
             InfoCard(


### PR DESCRIPTION
## [None]

- Fixed the padding between the monthly discount and referral information for members without referrals.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
