### PR TITLE
Changed alignment of hRow to fix Device ID alignment

### DIFF
--- a/Projects/Profile/Sources/Views/Screens/AppInfo/AppInfoView.swift
+++ b/Projects/Profile/Sources/Views/Screens/AppInfo/AppInfoView.swift
@@ -91,7 +91,7 @@ public struct AppInfoView: View {
                     .minimumScaleFactor(0.2)
                     .lineLimit(1)
                     .foregroundColor(hTextColor.Opaque.secondary)
-
+                    .frame(maxHeight: .infinity, alignment: .center)
             }
         }
         .onTap {

--- a/Projects/hCoreUI/Sources/hForm/hRow.swift
+++ b/Projects/hCoreUI/Sources/hForm/hRow.swift
@@ -85,7 +85,7 @@ public struct hRow<Content: View, Accessory: View>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading) {
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     content
                     accessory
                 }

--- a/Projects/hCoreUI/Sources/hForm/hRow.swift
+++ b/Projects/hCoreUI/Sources/hForm/hRow.swift
@@ -85,7 +85,7 @@ public struct hRow<Content: View, Accessory: View>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading) {
-                HStack(alignment: .center) {
+                HStack(alignment: .top) {
                     content
                     accessory
                 }


### PR DESCRIPTION
## [None]

- Fixed a minor bug where the device ID was top aligned instead of being vertically centered

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
