### PR TITLE
GEN-2498 fix issue when sending empty intentId on edit co insured

### DIFF
--- a/Projects/EditCoInsured/Sources/View/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
@@ -236,7 +236,12 @@ class InsuredPeopleNewScreenModel: ObservableObject {
     var config: InsuredPeopleConfig = InsuredPeopleConfig()
 
     @PresentableStore var store: EditCoInsuredStore
-    func completeList() -> [CoInsuredModel] {
+    func completeList(
+        coInsuredAdded: [CoInsuredModel]? = nil,
+        coInsuredDeleted: [CoInsuredModel]? = nil
+    ) -> [CoInsuredModel] {
+        let coInsuredAdded = coInsuredAdded ?? self.coInsuredAdded
+        let coInsuredDeleted = coInsuredDeleted ?? self.coInsuredDeleted
         var filterList: [CoInsuredModel] = []
         let existingList = config.contractCoInsured
         let nbOfCoInsured = config.numberOfMissingCoInsuredWithoutTermination
@@ -269,6 +274,26 @@ class InsuredPeopleNewScreenModel: ObservableObject {
             } + coInsuredAdded
 
         return finalList.filter({ $0.terminatesOn == nil })
+    }
+
+    func listForGettingIntentFor(addCoInsured: CoInsuredModel) -> [CoInsuredModel] {
+        var coInsuredAdded = self.coInsuredAdded
+        coInsuredAdded.append(addCoInsured)
+        return completeList(coInsuredAdded: coInsuredAdded)
+    }
+
+    func listForGettingIntentFor(removedCoInsured: CoInsuredModel) -> [CoInsuredModel] {
+        var coInsuredAdded = self.coInsuredAdded
+        var coInsuredDeleted = self.coInsuredDeleted
+        if let index = coInsuredAdded.firstIndex(where: { coInsured in
+            coInsured == removedCoInsured
+        }) {
+            coInsuredAdded.remove(at: index)
+        } else {
+            coInsuredDeleted.append(removedCoInsured)
+        }
+
+        return completeList(coInsuredAdded: coInsuredAdded, coInsuredDeleted: coInsuredDeleted)
     }
 
     func initializeCoInsured(with config: InsuredPeopleConfig) {

--- a/Projects/EditCoInsured/Sources/View/CoInusuredInput.swift
+++ b/Projects/EditCoInsured/Sources/View/CoInusuredInput.swift
@@ -85,35 +85,34 @@ struct CoInusuredInput: View {
                         if vm.actionType == .delete {
                             hButton.LargeButton(type: .alert) {
                                 Task {
-                                    if vm.personalData.firstName == "" && vm.SSN == "" {
-                                        store.coInsuredViewModel.removeCoInsured(.init())
-                                    } else if vm.SSN != "" {
-                                        store.coInsuredViewModel.removeCoInsured(
-                                            .init(
+                                    let coInsuredToDelete: CoInsuredModel = {
+                                        if vm.personalData.firstName == "" && vm.SSN == "" {
+                                            return .init()
+                                        } else if vm.SSN != "" {
+                                            return .init(
                                                 firstName: vm.personalData.firstName,
                                                 lastName: vm.personalData.lastName,
                                                 SSN: vm.SSN,
                                                 needsMissingInfo: false
                                             )
-                                        )
-                                    } else {
-                                        store.coInsuredViewModel.removeCoInsured(
-                                            .init(
+                                        } else {
+                                            return .init(
                                                 firstName: vm.personalData.firstName,
                                                 lastName: vm.personalData.lastName,
                                                 birthDate: vm.birthday,
                                                 needsMissingInfo: false
                                             )
+                                        }
+                                    }()
+                                    await intentVm.getIntent(
+                                        contractId: vm.contractId,
+                                        origin: .coinsuredInput,
+                                        coInsured: insuredPeopleVm.listForGettingIntentFor(
+                                            removedCoInsured: coInsuredToDelete
                                         )
-                                    }
-                                    if insuredPeopleVm.coInsuredDeleted.count > 0 {
-                                        await intentVm.getIntent(
-                                            contractId: vm.contractId,
-                                            origin: .coinsuredInput,
-                                            coInsured: insuredPeopleVm.completeList()
-                                        )
-                                    }
+                                    )
                                     if !intentVm.showErrorViewForCoInsuredInput {
+                                        store.coInsuredViewModel.removeCoInsured(coInsuredToDelete)
                                         router.push(CoInsuredAction.delete)
                                     } else {
                                         // add back
@@ -172,32 +171,42 @@ struct CoInusuredInput: View {
                                                         )
                                                     )
                                                 }
+                                                await intentVm.getIntent(
+                                                    contractId: vm.contractId,
+                                                    origin: .coinsuredInput,
+                                                    coInsured: insuredPeopleVm.completeList()
+                                                )
                                             } else {
-                                                if vm.noSSN {
-                                                    store.coInsuredViewModel.addCoInsured(
-                                                        .init(
+                                                let coInsuredToAdd: CoInsuredModel = {
+                                                    if vm.noSSN {
+                                                        return .init(
                                                             firstName: vm.personalData.firstName,
                                                             lastName: vm.personalData.lastName,
                                                             birthDate: vm.birthday,
                                                             needsMissingInfo: false
                                                         )
-                                                    )
-                                                } else {
-                                                    store.coInsuredViewModel.addCoInsured(
-                                                        .init(
+                                                    } else {
+                                                        return .init(
                                                             firstName: vm.personalData.firstName,
                                                             lastName: vm.personalData.lastName,
                                                             SSN: vm.SSN,
                                                             needsMissingInfo: false
                                                         )
+                                                    }
+                                                }()
+
+                                                await intentVm.getIntent(
+                                                    contractId: vm.contractId,
+                                                    origin: .coinsuredInput,
+                                                    coInsured: insuredPeopleVm.listForGettingIntentFor(
+                                                        addCoInsured: coInsuredToAdd
                                                     )
+                                                )
+                                                if !intentVm.showErrorViewForCoInsuredInput {
+                                                    insuredPeopleVm.addCoInsured(coInsuredToAdd)
                                                 }
                                             }
-                                            await intentVm.getIntent(
-                                                contractId: vm.contractId,
-                                                origin: .coinsuredInput,
-                                                coInsured: insuredPeopleVm.completeList()
-                                            )
+
                                             if !intentVm.showErrorViewForCoInsuredInput {
                                                 router.push(CoInsuredAction.add)
                                             } else {


### PR DESCRIPTION
Add/remove co insured localy only when we get intentId from the service

How it used to work:
1. App delete/add co insured
2. Request to the service is sent
3. If the request fails, we don't get intent id and the local list is off

How it works now:
1.  We send request for the intent
2. When we get response from the service, we remove/add co insured to the local list


- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
