### PR TITLE
Check for feature flags before executing notification

### DIFF
--- a/Projects/App/Sources/Journeys/MainNavigationJourney.swift
+++ b/Projects/App/Sources/Journeys/MainNavigationJourney.swift
@@ -77,7 +77,11 @@ struct MainNavigationJourney: App {
 }
 
 class MainNavigationViewModel: ObservableObject {
-    @Published var hasLaunchFinished = false
+    @Published var hasLaunchFinished = false {
+        didSet {
+            loggedInVm.hasLaunchFinished.send(hasLaunchFinished)
+        }
+    }
     @Published var showLaunchScreen = true
     @Published var shouldUpdateApp = false
     @Published var osVersionTooLow = false


### PR DESCRIPTION
Wait for the feature flags before executing notification (only when running app from the notification)

Some push notifications depend on the feature flags, so when opening app from the notification which depends on the feature flags would cause odd behaviour, checking if the feature flags are fetched is added.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
