### PR TITLE
Added active status for the insurance

### DIFF
--- a/Projects/Contracts/Sources/View/ContractRow.swift
+++ b/Projects/Contracts/Sources/View/ContractRow.swift
@@ -142,6 +142,10 @@ private struct ContractRowButtonStyle: SwiftUI.ButtonStyle {
                         )
                     )
                     .padding(.trailing, .padding4)
+                } else {
+                    StatusPill(
+                        text: L10n.dashboardInsuranceStatusActive
+                    )
                 }
                 Spacer()
                 logo


### PR DESCRIPTION
According to the [figma](https://www.figma.com/design/5kmmDdh6StpXzbEfr7WevV/Hedvig-UI-Kit?node-id=15991-41631&node-type=FRAME&t=BZtZ5PCHYlJhDZpm-0), we need to show statuses for the active insurance

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
