### PR TITLE
Fixes for change tier comparision screen

### DIFF
--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -214,7 +214,10 @@ public struct ChangeTierNavigation: View {
         }
         .modally(presented: $changeTierNavigationVm.isCompareTiersPresented) {
             CompareTierScreen(vm: changeTierNavigationVm.vm)
-                .configureTitle(L10n.tierFlowCompareButton)
+                .configureTitle(
+                    changeTierNavigationVm.vm.tiers.count == 1
+                        ? L10n.tierFlowShowCoverageButton : L10n.tierFlowCompareButton
+                )
                 .withDismissButton()
                 .embededInNavigation(
                     options: .navigationType(type: .large),

--- a/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
@@ -148,7 +148,7 @@ public struct ChangeTierLandingScreen: View {
                 hButton.LargeButton(type: .ghost) {
                     changeTierNavigationVm.isCompareTiersPresented = true
                 } content: {
-                    hText(L10n.tierFlowCompareButton, style: .body1)
+                    hText(vm.tiers.count == 1 ? L10n.tierFlowShowCoverage : L10n.tierFlowCompareButton, style: .body1)
                 }
                 hButton.LargeButton(type: .primary) {
                     switch vm.changeTierInput {

--- a/Projects/ChangeTier/Sources/Views/CompareTierScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/CompareTierScreen.swift
@@ -18,8 +18,11 @@ struct CompareTierScreen: View {
             uniqueKeysWithValues: vm.tiers.map({ ($0.id, $0.productVariant?.insurableLimits ?? []) })
         )
         self.perils = Dictionary(uniqueKeysWithValues: vm.tiers.map({ ($0.id, vm.getFilteredPerils(currentTier: $0)) }))
+        let pageModels: [PageModel] = vm.tiers.compactMap({ PageModel(id: $0.id, title: $0.name) })
+        let currentId = vm.tiers.first(where: { $0.id == vm.selectedTier?.name })?.id
         self.scrollableSegmentedViewModel = ScrollableSegmentedViewModel(
-            pageModels: vm.tiers.compactMap({ .init(id: $0.id, title: $0.name) })
+            pageModels: pageModels,
+            currentId: currentId
         )
     }
 

--- a/Projects/hCoreUI/Sources/Views/ScrollableSegmentedView.swift
+++ b/Projects/hCoreUI/Sources/Views/ScrollableSegmentedView.swift
@@ -32,19 +32,22 @@ public struct ScrollableSegmentedView<Content: View>: View {
         }
     }
 
+    @ViewBuilder
     var headerControl: some View {
-        hSection {
-            ZStack(alignment: .leading) {
-                selectedPageHeaderBackground
-                HStack(spacing: .padding4) {
-                    ForEach(vm.pageModels) { model in
-                        headerElement(for: model)
+        if vm.pageModels.count > 1 {
+            hSection {
+                ZStack(alignment: .leading) {
+                    selectedPageHeaderBackground
+                    HStack(spacing: .padding4) {
+                        ForEach(vm.pageModels) { model in
+                            headerElement(for: model)
+                        }
                     }
                 }
-            }
-            .padding(.padding4)
-            .background {
-                hSurfaceColor.Opaque.primary.clipShape(RoundedRectangle(cornerRadius: .cornerRadiusS))
+                .padding(.padding4)
+                .background {
+                    hSurfaceColor.Opaque.primary.clipShape(RoundedRectangle(cornerRadius: .cornerRadiusS))
+                }
             }
         }
     }
@@ -133,6 +136,9 @@ public class ScrollableSegmentedViewModel: NSObject, ObservableObject {
             horizontalScrollCancellable = horizontalScrollView?.publisher(for: \.contentOffset).removeDuplicates()
                 .sink(receiveValue: { [weak self] value in
                     guard let self = self else { return }
+                    if pageModels.count < 2 {
+                        return
+                    }
                     let allOffsets = self.getPagesOffset()
                     let titlePositions = self.titlesPositions.values.sorted(by: { $0.origin.x < $1.origin.x })
                     let sortedTitlePositions =

--- a/Projects/hCoreUI/Sources/Views/ScrollableSegmentedView.swift
+++ b/Projects/hCoreUI/Sources/Views/ScrollableSegmentedView.swift
@@ -30,7 +30,6 @@ public struct ScrollableSegmentedView<Content: View>: View {
                     }
             }
         }
-
     }
 
     var headerControl: some View {
@@ -130,6 +129,7 @@ public class ScrollableSegmentedViewModel: NSObject, ObservableObject {
     weak var horizontalScrollView: UIScrollView? {
         didSet {
             horizontalScrollView?.delegate = self
+            setSelectedTab(with: currentId, withAnimation: false)
             horizontalScrollCancellable = horizontalScrollView?.publisher(for: \.contentOffset).removeDuplicates()
                 .sink(receiveValue: { [weak self] value in
                     guard let self = self else { return }
@@ -205,10 +205,10 @@ public class ScrollableSegmentedViewModel: NSObject, ObservableObject {
         return offsetToScrollTo
     }
 
-    func setSelectedTab(with id: String) {
+    func setSelectedTab(with id: String, withAnimation animation: Bool = true) {
         if let index = pageModels.firstIndex(where: { $0.id == id }) {
             currentId = id
-            scrollTo(offset: CGFloat(index) * viewWidth + pageSpacing * CGFloat(index))
+            scrollTo(offset: CGFloat(index) * viewWidth + pageSpacing * CGFloat(index), withAnimation: animation)
             withAnimation {
                 currentHeight = (heights[id] ?? 0)
             }
@@ -219,11 +219,12 @@ public class ScrollableSegmentedViewModel: NSObject, ObservableObject {
         return pageModels.enumerated().compactMap({ CGFloat($0.offset) * viewWidth + pageSpacing * CGFloat($0.offset) })
     }
 
-    func scrollTo(offset: CGFloat) {
-        horizontalScrollView?.scrollRectToVisible(.init(x: offset, y: 1, width: viewWidth, height: 1), animated: true)
+    func scrollTo(offset: CGFloat, withAnimation: Bool = true) {
+        horizontalScrollView?
+            .scrollRectToVisible(.init(x: offset, y: 1, width: viewWidth, height: 1), animated: withAnimation)
     }
-    public init(pageModels: [PageModel]) {
-        self.currentId = pageModels.first?.id ?? ""
+    public init(pageModels: [PageModel], currentId: String? = nil) {
+        self.currentId = currentId ?? pageModels.first?.id ?? ""
         self.pageModels = pageModels
     }
 }


### PR DESCRIPTION
## [APP-XXX]

- Update button and title on comparison screen to be "show coverage" if we only have one tier
- Make selected tier preselected in comparision table

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
