### PR TITLE
Fixed issue with setting currentTier and currentDeductible

### DIFF
--- a/Projects/ChangeTier/Sources/Service/OctopusImplementation/ChangeTierClientOctopus.swift
+++ b/Projects/ChangeTier/Sources/Service/OctopusImplementation/ChangeTierClientOctopus.swift
@@ -50,13 +50,13 @@ public class ChangeTierClientOctopus: ChangeTierClient {
 
             /* get current tier if any matching */
             let currentTier: Tier? = filteredTiers.first(where: {
-                $0.name == intent.currentTierName && $0.level == intent.currentTierLevel
+                $0.name.lowercased() == intent.currentTierName?.lowercased()
             })
 
             /* get current deductible if any matching */
             let deductible = currentContract.currentAgreement.deductible
             let currentDeductible: Quote? = {
-                if let deductible = deductible {
+                if let deductible = deductible, currentTier != nil {
                     return Quote(
                         id: "current",
                         quoteAmount: .init(fragment: deductible.amount.fragments.moneyFragment),


### PR DESCRIPTION
Matching tier wasn't working and its not smart to have currentDeductible if we don't have current tier, so better leave it empty instead populating it

- setting current tier
- setting current deductible

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
