### PR TITLE
Replace Document with InsuranceTerm to use same one

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Journeys/LoggedInNavigation.swift
@@ -114,7 +114,7 @@ struct LoggedInNavigation: View {
             case .movingFlow:
                 MovingFlowNavigation()
             case let .pdf(document):
-                PDFPreview(document: .init(url: document.url, title: document.title))
+                PDFPreview(document: document)
             case let .changeTier(input):
                 ChangeTierNavigation(input: input)
             }
@@ -300,9 +300,7 @@ struct HomeTab: View {
             item: $homeNavigationVm.document,
             style: [.large]
         ) { document in
-            if let url = URL(string: document.url) {
-                PDFPreview(document: .init(url: url, title: document.displayName))
-            }
+            PDFPreview(document: document)
         }
         .modally(
             presented: $homeNavigationVm.isHelpCenterPresented

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -9,7 +9,7 @@ public class ChangeTierNavigationViewModel: ObservableObject {
     @Published public var isEditDeductiblePresented = false
     @Published public var isCompareTiersPresented = false
     @Published public var isInsurableLimitPresented: InsurableLimits?
-    @Published public var document: InsuranceTerm?
+    @Published public var document: PDFDocument?
     let useOwnNavigation: Bool
     let router: Router
 

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -9,7 +9,7 @@ public class ChangeTierNavigationViewModel: ObservableObject {
     @Published public var isEditDeductiblePresented = false
     @Published public var isCompareTiersPresented = false
     @Published public var isInsurableLimitPresented: InsurableLimits?
-    @Published public var document: PDFDocument?
+    @Published public var document: hPDFDocument?
     let useOwnNavigation: Bool
     let router: Router
     var onChangedTier: () -> Void = {}

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -9,7 +9,7 @@ public class ChangeTierNavigationViewModel: ObservableObject {
     @Published public var isEditDeductiblePresented = false
     @Published public var isCompareTiersPresented = false
     @Published public var isInsurableLimitPresented: InsurableLimits?
-    @Published public var document: Document?
+    @Published public var document: InsuranceTerm?
     let useOwnNavigation: Bool
     let router: Router
 
@@ -241,7 +241,7 @@ public struct ChangeTierNavigation: View {
             item: $changeTierNavigationVm.document,
             style: [.large]
         ) { document in
-            PDFPreview(document: .init(url: document.url, title: document.title))
+            PDFPreview(document: document)
         }
     }
 

--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -35,9 +35,7 @@ extension ChangeTierViewModel {
                     currentPremium: self.currentPremium,
                     documents: self.selectedQuote?.productVariant?.documents ?? [],
                     onDocumentTap: { [weak self] document in
-                        if let url = URL(string: document.url) {
-                            changeTierNavigationVm.document = .init(url: url, title: document.displayName)
-                        }
+                        changeTierNavigationVm.document = document
                     },
                     displayItems: displayItems,
                     insuranceLimits: self.selectedQuote?.productVariant?.insurableLimits ?? [],

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -157,7 +157,7 @@ public class ChangeTierViewModel: ObservableObject {
             } catch let error {
                 withAnimation {
                     self.viewState = .error(
-                        errorMessage: error.localizedDescription ?? L10n.tierFlowCommitProcessingErrorDescription
+                        errorMessage: error.localizedDescription
                     )
                 }
             }

--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -120,7 +120,7 @@ public class ContractsNavigationViewModel: ObservableObject {
     public let contractsRouter = Router()
     let terminateInsuranceVm = TerminateInsuranceViewModel()
     @Published public var insurableLimit: InsurableLimits?
-    @Published public var document: InsuranceTerm?
+    @Published public var document: PDFDocument?
     @Published public var editCoInsuredConfig: InsuredPeopleConfig?
     @Published public var editCoInsuredMissingAlert: InsuredPeopleConfig?
     @Published public var changeYourInformationContract: Contract?
@@ -138,7 +138,7 @@ public class ContractsNavigationViewModel: ObservableObject {
 public enum RedirectType {
     case chat
     case movingFlow
-    case pdf(document: InsuranceTerm)
+    case pdf(document: PDFDocument)
     case changeTier(input: ChangeTierInput)
 }
 

--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -120,7 +120,7 @@ public class ContractsNavigationViewModel: ObservableObject {
     public let contractsRouter = Router()
     let terminateInsuranceVm = TerminateInsuranceViewModel()
     @Published public var insurableLimit: InsurableLimits?
-    @Published public var document: Document?
+    @Published public var document: InsuranceTerm?
     @Published public var editCoInsuredConfig: InsuredPeopleConfig?
     @Published public var editCoInsuredMissingAlert: InsuredPeopleConfig?
     @Published public var changeYourInformationContract: Contract?
@@ -138,7 +138,7 @@ public class ContractsNavigationViewModel: ObservableObject {
 public enum RedirectType {
     case chat
     case movingFlow
-    case pdf(document: Document)
+    case pdf(document: InsuranceTerm)
     case changeTier(input: ChangeTierInput)
 }
 

--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -120,7 +120,7 @@ public class ContractsNavigationViewModel: ObservableObject {
     public let contractsRouter = Router()
     let terminateInsuranceVm = TerminateInsuranceViewModel()
     @Published public var insurableLimit: InsurableLimits?
-    @Published public var document: PDFDocument?
+    @Published public var document: hPDFDocument?
     @Published public var editCoInsuredConfig: InsuredPeopleConfig?
     @Published public var editCoInsuredMissingAlert: InsuredPeopleConfig?
     @Published public var changeYourInformationContract: Contract?
@@ -138,7 +138,7 @@ public class ContractsNavigationViewModel: ObservableObject {
 public enum RedirectType {
     case chat
     case movingFlow
-    case pdf(document: PDFDocument)
+    case pdf(document: hPDFDocument)
     case changeTier(input: ChangeTierInput)
 }
 

--- a/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
@@ -24,9 +24,7 @@ struct ContractDocumentsView: View {
                 InsuranceTermView(
                     documents: getDocumentsToDisplay(contract: contract)
                 ) { document in
-                    if let url = URL(string: document.url) {
-                        contractsNavigationViewModel.document = .init(url: url, title: document.displayName)
-                    }
+                    contractsNavigationViewModel.document = document
                 }
             }
         }

--- a/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
@@ -30,13 +30,13 @@ struct ContractDocumentsView: View {
         }
     }
 
-    func getDocumentsToDisplay(contract: Contract) -> [PDFDocument] {
-        var documents: [PDFDocument] = []
+    func getDocumentsToDisplay(contract: Contract) -> [hPDFDocument] {
+        var documents: [hPDFDocument] = []
         contract.currentAgreement?.productVariant.documents
             .forEach { document in
                 documents.append(document)
             }
-        let certficateUrl = PDFDocument(
+        let certficateUrl = hPDFDocument(
             displayName: L10n.myDocumentsInsuranceCertificate,
             url: contract.currentAgreement?.certificateUrl ?? "",
             type: .unknown

--- a/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractDocuments.swift
@@ -30,13 +30,13 @@ struct ContractDocumentsView: View {
         }
     }
 
-    func getDocumentsToDisplay(contract: Contract) -> [InsuranceTerm] {
-        var documents: [InsuranceTerm] = []
+    func getDocumentsToDisplay(contract: Contract) -> [PDFDocument] {
+        var documents: [PDFDocument] = []
         contract.currentAgreement?.productVariant.documents
             .forEach { document in
                 documents.append(document)
             }
-        let certficateUrl = InsuranceTerm(
+        let certficateUrl = PDFDocument(
             displayName: L10n.myDocumentsInsuranceCertificate,
             url: contract.currentAgreement?.certificateUrl ?? "",
             type: .unknown

--- a/Projects/Contracts/Sources/Journeys/ContractInformation.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractInformation.swift
@@ -234,7 +234,7 @@ struct ContractInformationView: View {
                     .init(
                         buttonTitle: L10n.dashboardRenewalPrompterBodyButton,
                         buttonAction: {
-                            contractsNavigationVm.document = PDFDocument(
+                            contractsNavigationVm.document = hPDFDocument(
                                 displayName: L10n.insuranceCertificateTitle,
                                 url: upcomingRenewal.certificateUrl ?? "",
                                 type: .unknown
@@ -264,7 +264,7 @@ struct ContractInformationView: View {
                             .init(
                                 buttonTitle: L10n.contractViewCertificateButton,
                                 buttonAction: {
-                                    contractsNavigationVm.document = PDFDocument(
+                                    contractsNavigationVm.document = hPDFDocument(
                                         displayName: L10n.myDocumentsInsuranceCertificate,
                                         url: upcomingChangedAgreement.certificateUrl ?? "",
                                         type: .unknown

--- a/Projects/Contracts/Sources/Journeys/ContractInformation.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractInformation.swift
@@ -7,6 +7,7 @@ import TerminateContracts
 import UnleashProxyClientSwift
 import hCore
 import hCoreUI
+import hGraphQL
 
 struct ContractInformationView: View {
     @PresentableStore var store: ContractStore
@@ -233,9 +234,10 @@ struct ContractInformationView: View {
                     .init(
                         buttonTitle: L10n.dashboardRenewalPrompterBodyButton,
                         buttonAction: {
-                            contractsNavigationVm.document = Document(
-                                url: url,
-                                title: L10n.insuranceCertificateTitle
+                            contractsNavigationVm.document = InsuranceTerm(
+                                displayName: L10n.insuranceCertificateTitle,
+                                url: upcomingRenewal.certificateUrl ?? "",
+                                type: .unknown
                             )
                         }
                     )
@@ -262,9 +264,10 @@ struct ContractInformationView: View {
                             .init(
                                 buttonTitle: L10n.contractViewCertificateButton,
                                 buttonAction: {
-                                    contractsNavigationVm.document = Document(
-                                        url: url,
-                                        title: L10n.myDocumentsInsuranceCertificate
+                                    contractsNavigationVm.document = InsuranceTerm(
+                                        displayName: L10n.myDocumentsInsuranceCertificate,
+                                        url: upcomingChangedAgreement.certificateUrl ?? "",
+                                        type: .unknown
                                     )
                                 }
                             )

--- a/Projects/Contracts/Sources/Journeys/ContractInformation.swift
+++ b/Projects/Contracts/Sources/Journeys/ContractInformation.swift
@@ -234,7 +234,7 @@ struct ContractInformationView: View {
                     .init(
                         buttonTitle: L10n.dashboardRenewalPrompterBodyButton,
                         buttonAction: {
-                            contractsNavigationVm.document = InsuranceTerm(
+                            contractsNavigationVm.document = PDFDocument(
                                 displayName: L10n.insuranceCertificateTitle,
                                 url: upcomingRenewal.certificateUrl ?? "",
                                 type: .unknown
@@ -264,7 +264,7 @@ struct ContractInformationView: View {
                             .init(
                                 buttonTitle: L10n.contractViewCertificateButton,
                                 buttonAction: {
-                                    contractsNavigationVm.document = InsuranceTerm(
+                                    contractsNavigationVm.document = PDFDocument(
                                         displayName: L10n.myDocumentsInsuranceCertificate,
                                         url: upcomingChangedAgreement.certificateUrl ?? "",
                                         type: .unknown

--- a/Projects/Home/Sources/Components/RenewalCard.swift
+++ b/Projects/Home/Sources/Components/RenewalCard.swift
@@ -11,7 +11,7 @@ public struct RenewalCardView: View {
     @PresentableStore var store: HomeStore
     @State private var showMultipleAlert = false
     @State private var showFailedToOpenUrlAlert = false
-    @State private var document: PDFDocument?
+    @State private var document: hPDFDocument?
     let showCoInsured: Bool?
 
     public init(
@@ -34,7 +34,7 @@ public struct RenewalCardView: View {
         if let draftCertificateUrl = contract.upcomingRenewal?.draftCertificateUrl,
             URL(string: draftCertificateUrl) != nil
         {
-            self.document = PDFDocument(
+            self.document = hPDFDocument(
                 displayName: contract.displayName,
                 url: contract.upcomingRenewal?.draftCertificateUrl ?? "",
                 type: .unknown

--- a/Projects/Home/Sources/Components/RenewalCard.swift
+++ b/Projects/Home/Sources/Components/RenewalCard.swift
@@ -11,7 +11,7 @@ public struct RenewalCardView: View {
     @PresentableStore var store: HomeStore
     @State private var showMultipleAlert = false
     @State private var showFailedToOpenUrlAlert = false
-    @State private var document: InsuranceTerm?
+    @State private var document: PDFDocument?
     let showCoInsured: Bool?
 
     public init(
@@ -34,7 +34,7 @@ public struct RenewalCardView: View {
         if let draftCertificateUrl = contract.upcomingRenewal?.draftCertificateUrl,
             URL(string: draftCertificateUrl) != nil
         {
-            self.document = InsuranceTerm(
+            self.document = PDFDocument(
                 displayName: contract.displayName,
                 url: contract.upcomingRenewal?.draftCertificateUrl ?? "",
                 type: .unknown

--- a/Projects/Home/Sources/Components/RenewalCard.swift
+++ b/Projects/Home/Sources/Components/RenewalCard.swift
@@ -143,9 +143,7 @@ public struct RenewalCardView: View {
             )
         }
         .detent(item: $document, style: [.large]) { document in
-            if let url = URL(string: document.url) {
-                PDFPreview(document: .init(url: url, title: document.displayName))
-            }
+            PDFPreview(document: document)
         }
     }
 }

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -63,7 +63,7 @@ public class HomeNavigationViewModel: ObservableObject {
     @Published public var isHelpCenterPresented = false
 
     //claim details
-    @Published public var document: InsuranceTerm? = nil
+    @Published public var document: PDFDocument? = nil
 
     @Published public var navBarItems = NavBarItems()
 

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -63,7 +63,7 @@ public class HomeNavigationViewModel: ObservableObject {
     @Published public var isHelpCenterPresented = false
 
     //claim details
-    @Published public var document: PDFDocument? = nil
+    @Published public var document: hPDFDocument? = nil
 
     @Published public var navBarItems = NavBarItems()
 

--- a/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
+++ b/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
@@ -9,7 +9,7 @@ import hGraphQL
 public class MovingFlowNavigationViewModel: ObservableObject {
     public init() {}
     @Published var isAddExtraBuildingPresented = false
-    @Published public var document: InsuranceTerm? = nil
+    @Published public var document: PDFDocument? = nil
 }
 
 enum MovingFlowRouterWithHiddenBackButtonActions {

--- a/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
+++ b/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
@@ -4,11 +4,12 @@ import PresentableStore
 import SwiftUI
 import hCore
 import hCoreUI
+import hGraphQL
 
 public class MovingFlowNavigationViewModel: ObservableObject {
     public init() {}
     @Published var isAddExtraBuildingPresented = false
-    @Published public var document: Document? = nil
+    @Published public var document: InsuranceTerm? = nil
 }
 
 enum MovingFlowRouterWithHiddenBackButtonActions {
@@ -115,7 +116,7 @@ public struct MovingFlowNavigation: View {
             item: $movingFlowVm.document,
             style: [.large]
         ) { document in
-            PDFPreview(document: .init(url: document.url, title: document.title))
+            PDFPreview(document: document)
         }
     }
 

--- a/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
+++ b/Projects/MoveFlow/Sources/MovingFlowNavigationViewModel.swift
@@ -9,7 +9,7 @@ import hGraphQL
 public class MovingFlowNavigationViewModel: ObservableObject {
     public init() {}
     @Published var isAddExtraBuildingPresented = false
-    @Published public var document: PDFDocument? = nil
+    @Published public var document: hPDFDocument? = nil
 }
 
 enum MovingFlowRouterWithHiddenBackButtonActions {

--- a/Projects/MoveFlow/Sources/View/MovingFlowConfirm.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowConfirm.swift
@@ -30,9 +30,7 @@ struct MovingFlowConfirm: View {
                                 .init(displayName: $0.displayName, url: $0.url, type: .unknown)
                             }),
                             onDocumentTap: { document in
-                                if let url = URL(string: document.url) {
-                                    movingFlowNavigationVm.document = .init(url: url, title: document.displayName)
-                                }
+                                movingFlowNavigationVm.document = document
                             },
                             displayItems: $0.displayItems.map({ .init(title: $0.displayTitle, value: $0.displayValue) }
                             ),

--- a/Projects/TravelCertificate/Sources/TravelCertificateNavigation.swift
+++ b/Projects/TravelCertificate/Sources/TravelCertificateNavigation.swift
@@ -113,7 +113,7 @@ public struct TravelCertificateNavigation: View {
             options: .constant(.withoutGrabber)
         ) { model in
             PDFPreview(
-                document: .init(url: model.url, title: model.title)
+                document: .init(displayName: model.title, url: model.url.absoluteString, type: .unknown)
             )
         }
         .modally(

--- a/Projects/hCore/Sources/Models/ProductVariant.swift
+++ b/Projects/hCore/Sources/Models/ProductVariant.swift
@@ -6,7 +6,7 @@ public struct ProductVariant: Codable, Hashable {
     let partner: String?
     public let perils: [Perils]
     public let insurableLimits: [InsurableLimits]
-    public let documents: [InsuranceTerm]
+    public let documents: [PDFDocument]
     public let displayName: String
     public let displayNameTier: String?
     public let tierDescription: String?
@@ -17,7 +17,7 @@ public struct ProductVariant: Codable, Hashable {
         partner: String?,
         perils: [Perils],
         insurableLimits: [InsurableLimits],
-        documents: [InsuranceTerm],
+        documents: [PDFDocument],
         displayName: String,
         displayNameTier: String?,
         tierDescription: String?

--- a/Projects/hCore/Sources/Models/ProductVariant.swift
+++ b/Projects/hCore/Sources/Models/ProductVariant.swift
@@ -6,7 +6,7 @@ public struct ProductVariant: Codable, Hashable {
     let partner: String?
     public let perils: [Perils]
     public let insurableLimits: [InsurableLimits]
-    public let documents: [PDFDocument]
+    public let documents: [hPDFDocument]
     public let displayName: String
     public let displayNameTier: String?
     public let tierDescription: String?
@@ -17,7 +17,7 @@ public struct ProductVariant: Codable, Hashable {
         partner: String?,
         perils: [Perils],
         insurableLimits: [InsurableLimits],
-        documents: [PDFDocument],
+        documents: [hPDFDocument],
         displayName: String,
         displayNameTier: String?,
         tierDescription: String?

--- a/Projects/hCoreUI/Sources/Document.swift
+++ b/Projects/hCoreUI/Sources/Document.swift
@@ -10,7 +10,7 @@ public struct PDFPreview: View {
     @StateObject fileprivate var vm: PDFPreviewViewModel
 
     public init(
-        document: PDFDocument
+        document: hPDFDocument
     ) {
         _vm = StateObject(wrappedValue: PDFPreviewViewModel(document: document))
     }
@@ -53,11 +53,11 @@ public struct PDFPreview: View {
 }
 
 private class PDFPreviewViewModel: ObservableObject {
-    let document: PDFDocument
+    let document: hPDFDocument
     @Published var isLoading = false
     @Published var data: Data?
     weak var navItem: UIBarButtonItem?
-    init(document: PDFDocument) {
+    init(document: hPDFDocument) {
         self.document = document
         Task {
             await self.getData()

--- a/Projects/hCoreUI/Sources/Document.swift
+++ b/Projects/hCoreUI/Sources/Document.swift
@@ -10,7 +10,7 @@ public struct PDFPreview: View {
     @StateObject fileprivate var vm: PDFPreviewViewModel
 
     public init(
-        document: InsuranceTerm
+        document: PDFDocument
     ) {
         _vm = StateObject(wrappedValue: PDFPreviewViewModel(document: document))
     }
@@ -53,11 +53,11 @@ public struct PDFPreview: View {
 }
 
 private class PDFPreviewViewModel: ObservableObject {
-    let document: InsuranceTerm
+    let document: PDFDocument
     @Published var isLoading = false
     @Published var data: Data?
     weak var navItem: UIBarButtonItem?
-    init(document: InsuranceTerm) {
+    init(document: PDFDocument) {
         self.document = document
         Task {
             await self.getData()

--- a/Projects/hCoreUI/Sources/Views/InsuranceTermView.swift
+++ b/Projects/hCoreUI/Sources/Views/InsuranceTermView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import hGraphQL
 
 public struct InsuranceTermView: View {
-    let documents: [InsuranceTerm]
-    let onDocumentTap: (_ document: InsuranceTerm) -> Void
+    let documents: [PDFDocument]
+    let onDocumentTap: (_ document: PDFDocument) -> Void
 
     public init(
-        documents: [InsuranceTerm],
-        onDocumentTap: @escaping (_: InsuranceTerm) -> Void
+        documents: [PDFDocument],
+        onDocumentTap: @escaping (_: PDFDocument) -> Void
     ) {
         self.documents = documents
         self.onDocumentTap = onDocumentTap

--- a/Projects/hCoreUI/Sources/Views/InsuranceTermView.swift
+++ b/Projects/hCoreUI/Sources/Views/InsuranceTermView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import hGraphQL
 
 public struct InsuranceTermView: View {
-    let documents: [PDFDocument]
-    let onDocumentTap: (_ document: PDFDocument) -> Void
+    let documents: [hPDFDocument]
+    let onDocumentTap: (_ document: hPDFDocument) -> Void
 
     public init(
-        documents: [PDFDocument],
-        onDocumentTap: @escaping (_: PDFDocument) -> Void
+        documents: [hPDFDocument],
+        onDocumentTap: @escaping (_: hPDFDocument) -> Void
     ) {
         self.documents = documents
         self.onDocumentTap = onDocumentTap

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
@@ -15,8 +15,8 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
         let newPremium: MonetaryAmount?
         let currentPremium: MonetaryAmount?
         let displayItems: [QuoteDisplayItem]
-        let documents: [PDFDocument]
-        let onDocumentTap: (_ document: PDFDocument) -> Void
+        let documents: [hPDFDocument]
+        let onDocumentTap: (_ document: hPDFDocument) -> Void
         let insuranceLimits: [InsurableLimits]
         let typeOfContract: TypeOfContract?
         let shouldShowDetails: Bool
@@ -27,8 +27,8 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
             exposureName: String,
             newPremium: MonetaryAmount?,
             currentPremium: MonetaryAmount?,
-            documents: [PDFDocument],
-            onDocumentTap: @escaping (_ document: PDFDocument) -> Void,
+            documents: [hPDFDocument],
+            onDocumentTap: @escaping (_ document: hPDFDocument) -> Void,
             displayItems: [QuoteDisplayItem],
             insuranceLimits: [InsurableLimits],
             typeOfContract: TypeOfContract?
@@ -255,7 +255,7 @@ public struct QuoteSummaryScreen: View {
         .foregroundColor(hTextColor.Opaque.secondary)
     }
 
-    func documentItem(for document: PDFDocument) -> some View {
+    func documentItem(for document: hPDFDocument) -> some View {
         HStack {
             hAttributedTextView(
                 text: AttributedPDF().attributedPDFString(for: document.displayName),
@@ -412,7 +412,7 @@ public struct FAQ: Codable, Equatable, Hashable {
 }
 
 #Preview(body: {
-    let documents: [PDFDocument] = [
+    let documents: [hPDFDocument] = [
         .init(displayName: "document 1", url: "https//hedvig.com", type: .generalTerms),
         .init(displayName: "document 2", url: "https//hedvig.com", type: .preSaleInfo),
     ]

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
@@ -15,8 +15,8 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
         let newPremium: MonetaryAmount?
         let currentPremium: MonetaryAmount?
         let displayItems: [QuoteDisplayItem]
-        let documents: [InsuranceTerm]
-        let onDocumentTap: (_ document: InsuranceTerm) -> Void
+        let documents: [PDFDocument]
+        let onDocumentTap: (_ document: PDFDocument) -> Void
         let insuranceLimits: [InsurableLimits]
         let typeOfContract: TypeOfContract?
         let shouldShowDetails: Bool
@@ -27,8 +27,8 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
             exposureName: String,
             newPremium: MonetaryAmount?,
             currentPremium: MonetaryAmount?,
-            documents: [InsuranceTerm],
-            onDocumentTap: @escaping (_ document: InsuranceTerm) -> Void,
+            documents: [PDFDocument],
+            onDocumentTap: @escaping (_ document: PDFDocument) -> Void,
             displayItems: [QuoteDisplayItem],
             insuranceLimits: [InsurableLimits],
             typeOfContract: TypeOfContract?
@@ -255,7 +255,7 @@ public struct QuoteSummaryScreen: View {
         .foregroundColor(hTextColor.Opaque.secondary)
     }
 
-    func documentItem(for document: InsuranceTerm) -> some View {
+    func documentItem(for document: PDFDocument) -> some View {
         HStack {
             hAttributedTextView(
                 text: AttributedPDF().attributedPDFString(for: document.displayName),
@@ -412,7 +412,7 @@ public struct FAQ: Codable, Equatable, Hashable {
 }
 
 #Preview(body: {
-    let documents: [InsuranceTerm] = [
+    let documents: [PDFDocument] = [
         .init(displayName: "document 1", url: "https//hedvig.com", type: .generalTerms),
         .init(displayName: "document 2", url: "https//hedvig.com", type: .preSaleInfo),
     ]

--- a/Projects/hGraphQL/Sources/Models/PDFDocument.swift
+++ b/Projects/hGraphQL/Sources/Models/PDFDocument.swift
@@ -1,4 +1,4 @@
-public struct InsuranceTerm: Codable, Equatable, Hashable, Identifiable {
+public struct PDFDocument: Codable, Equatable, Hashable, Identifiable {
     public var id: String?
     public var displayName: String
     public var url: String

--- a/Projects/hGraphQL/Sources/Models/hPDFDocument.swift
+++ b/Projects/hGraphQL/Sources/Models/hPDFDocument.swift
@@ -1,4 +1,4 @@
-public struct PDFDocument: Codable, Equatable, Hashable, Identifiable {
+public struct hPDFDocument: Codable, Equatable, Hashable, Identifiable {
     public var id: String?
     public var displayName: String
     public var url: String


### PR DESCRIPTION
## [APP-XXX]

- I have really been confused about those Insurance Terms and Documents since they contain the same thing. I therefore decided to remove Document and only use InsuranceTerm.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
