### PR TITLE
Align moving flow content to bottom

### DIFF
--- a/Projects/MoveFlow/Sources/View/MovingFlowAddressView.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowAddressView.swift
@@ -46,61 +46,62 @@ struct MovingFlowAddressView: View {
     }
 
     var form: some View {
-        hForm {
-            VStack(spacing: 16) {
-                VStack(spacing: 4) {
-                    hSection {
-                        addressField()
-                    }
-                    hSection {
-                        postalField()
-                    }
-                    hSection {
-                        squareField()
-                    }
-                    hSection {
-                        numberOfCoinsuredField()
-                    }
-                    hSection {
-                        accessDateField()
-                    }
-                    if vm.isStudentEnabled {
-                        isStudentField()
-                    }
-                }
-                .disableOn(MoveFlowStore.self, [.requestMoveIntent])
-                hSection {
-                    InfoCard(text: L10n.changeAddressCoverageInfoText, type: .info)
-                }
-                hSection {
-                    hButton.LargeButton(type: .primary) {
-                        continuePressed()
-                    } content: {
-                        hText(vm.continueButtonTitle, style: .body1)
-                    }
-                }
-
-            }
-            .padding(.bottom, .padding8)
-            .padding(.top, .padding16)
-
-        }
-        .hFormTitle(
-            title: .init(
-                .small,
-                .heading2,
-                L10n.movingEmbarkTitle,
-                alignment: .leading
-            ),
-            subTitle: .init(
-                .standard,
-                .heading2,
-                L10n.changeAddressEnterNewAddressTitle
+        hForm {}
+            .hDisableScroll
+            .hFormTitle(
+                title: .init(
+                    .small,
+                    .heading2,
+                    L10n.movingEmbarkTitle,
+                    alignment: .leading
+                ),
+                subTitle: .init(
+                    .standard,
+                    .heading2,
+                    L10n.changeAddressEnterNewAddressTitle
+                )
             )
-        )
-        .sectionContainerStyle(.transparent)
-        .presentableStoreLensAnimation(.default)
-        .trackLoading(MoveFlowStore.self, action: .requestMoveIntent)
+            .hFormAttachToBottom {
+                VStack(spacing: 16) {
+                    VStack(spacing: 4) {
+                        hSection {
+                            addressField()
+                        }
+                        hSection {
+                            postalField()
+                        }
+                        hSection {
+                            squareField()
+                        }
+                        hSection {
+                            numberOfCoinsuredField()
+                        }
+                        hSection {
+                            accessDateField()
+                        }
+                        if vm.isStudentEnabled {
+                            isStudentField()
+                        }
+                    }
+                    .disableOn(MoveFlowStore.self, [.requestMoveIntent])
+                    hSection {
+                        InfoCard(text: L10n.changeAddressCoverageInfoText, type: .info)
+                    }
+                    hSection {
+                        hButton.LargeButton(type: .primary) {
+                            continuePressed()
+                        } content: {
+                            hText(vm.continueButtonTitle, style: .body1)
+                        }
+                    }
+
+                }
+                .padding(.bottom, .padding8)
+                .padding(.top, .padding16)
+            }
+            .sectionContainerStyle(.transparent)
+            .presentableStoreLensAnimation(.default)
+            .trackLoading(MoveFlowStore.self, action: .requestMoveIntent)
     }
 
     func addressField() -> some View {

--- a/Projects/MoveFlow/Sources/View/MovingFlowHouseView.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowHouseView.swift
@@ -35,50 +35,51 @@ struct MovingFlowHouseView: View {
     }
 
     var form: some View {
-        hForm {
-            VStack {
-                VStack(spacing: 16) {
-                    VStack(spacing: 8) {
-                        yearOfConstructionField
-                        ancillaryAreaField
-                        bathroomsField
-                        isSubleted
-                        extraBuildingTypes
-                    }
-                    .disableOn(MoveFlowStore.self, [.requestMoveIntent])
-                    hSection {
-                        InfoCard(text: L10n.changeAddressCoverageInfoText, type: .info)
-                    }
-                    hSection {
-                        hButton.LargeButton(type: .primary) {
-                            vm.continuePressed()
-                        } content: {
-                            hText(L10n.saveAndContinueButtonLabel, style: .body1)
+        hForm {}
+            .trackLoading(MoveFlowStore.self, action: .requestMoveIntent)
+            .hDisableScroll
+            .hFormAttachToBottom({
+                VStack {
+                    VStack(spacing: 16) {
+                        VStack(spacing: 8) {
+                            yearOfConstructionField
+                            ancillaryAreaField
+                            bathroomsField
+                            isSubleted
+                            extraBuildingTypes
                         }
+                        .disableOn(MoveFlowStore.self, [.requestMoveIntent])
+                        hSection {
+                            InfoCard(text: L10n.changeAddressCoverageInfoText, type: .info)
+                        }
+                        hSection {
+                            hButton.LargeButton(type: .primary) {
+                                vm.continuePressed()
+                            } content: {
+                                hText(L10n.saveAndContinueButtonLabel, style: .body1)
+                            }
+                        }
+
                     }
-
                 }
-            }
-            .padding(.bottom, .padding8)
-            .padding(.top, .padding16)
-
-        }
-        .trackLoading(MoveFlowStore.self, action: .requestMoveIntent)
-        .hFormTitle(
-            title: .init(
-                .small,
-                .heading2,
-                L10n.movingEmbarkTitle,
-                alignment: .leading
-            ),
-            subTitle: .init(
-                .standard,
-                .heading2,
-                L10n.changeAddressInformationAboutYourHouse
+                .padding(.bottom, .padding8)
+                .padding(.top, .padding16)
+            })
+            .hFormTitle(
+                title: .init(
+                    .small,
+                    .heading2,
+                    L10n.movingEmbarkTitle,
+                    alignment: .leading
+                ),
+                subTitle: .init(
+                    .standard,
+                    .heading2,
+                    L10n.changeAddressInformationAboutYourHouse
+                )
             )
-        )
-        .sectionContainerStyle(.transparent)
-        .presentableStoreLensAnimation(.default)
+            .sectionContainerStyle(.transparent)
+            .presentableStoreLensAnimation(.default)
     }
 
     private var yearOfConstructionField: some View {

--- a/Projects/hCore/Sources/Masking.swift
+++ b/Projects/hCore/Sources/Masking.swift
@@ -241,7 +241,7 @@ public struct Masking {
     }
     public var spellCheckingType: UITextSpellCheckingType {
         switch type {
-        case .none, .disabledSuggestion:
+        case .none, .disabledSuggestion, .address:
             return .no
         default: return .yes
         }

--- a/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
+++ b/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
@@ -15,27 +15,23 @@ public struct CheckboxToggleStyle: ToggleStyle {
     }
 
     public func makeBody(configuration: Configuration) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: .cornerRadiusL).fill(getBackgroundColor)
-                .padding(.horizontal, 16)
-            hSection {
-                hRow {
-                    configuration.label
-                }
-                .verticalPadding(0)
-                .hWithoutHorizontalPadding
-                .padding(.top, getTopPadding)
-                .padding(.bottom, getBottomPadding)
-                .padding(.horizontal, getHorizontalPadding)
+        hSection {
+            hRow {
+                configuration.label
             }
-            .sectionContainerStyle(.transparent)
-            .onUpdate(of: configuration.isOn) { newValue in
-                withAnimation {
-                    animate = true
-                }
-                withAnimation(.default.delay(0.4)) {
-                    animate = false
-                }
+            .verticalPadding(0)
+            .hWithoutHorizontalPadding
+            .padding(.top, getTopPadding)
+            .padding(.bottom, getBottomPadding)
+            .padding(.horizontal, getHorizontalPadding)
+        }
+        .sectionContainerStyle(.opaque)
+        .onUpdate(of: configuration.isOn) { newValue in
+            withAnimation {
+                animate = true
+            }
+            withAnimation(.default.delay(0.4)) {
+                animate = false
             }
         }
     }


### PR DESCRIPTION
## [APP-XXX]

-  Related to [this ticket](https://www.notion.so/hedviginsurance/Moving-flow-ndra-adress-Button-placement-is-off-according-to-Design-Should-be-bottom-aligned-128c3f71cb0a801c8487f03a9bd82410)
- Had to make some changes to CheckBoxToggleStyle to not crash view

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
