### PR TITLE
Updated logic to check deeplink after login

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Journeys/LoggedInNavigation.swift
@@ -476,6 +476,7 @@ class LoggedInNavigationViewModel: ObservableObject {
     @Published var isEuroBonusPresented = false
     @Published var isUrlPresented: URL?
 
+    private var deeplinkToBeOpenedAfterLogin: URL?
     private var cancellables = Set<AnyCancellable>()
     weak var tabBar: UITabBarController?
     init() {
@@ -530,7 +531,11 @@ class LoggedInNavigationViewModel: ObservableObject {
 
     @objc func openDeepLinkNotification(notification: Notification) {
         let deepLinkUrl = notification.object as? URL
-        self.handleDeepLinks(deepLinkUrl: deepLinkUrl)
+        if ApplicationState.currentState == .loggedIn {
+            self.handleDeepLinks(deepLinkUrl: deepLinkUrl)
+        } else {
+            self.deeplinkToBeOpenedAfterLogin = deepLinkUrl
+        }
     }
 
     @objc func registerForPushNotification(notification: Notification) {
@@ -593,6 +598,13 @@ class LoggedInNavigationViewModel: ObservableObject {
                 let contractId = userInfo?["contractId"] as? String
                 handleChangeTier(contractId: contractId)
             }
+        }
+    }
+
+    func actionAfterLogin() {
+        if let deeplinkToBeOpenedAfterLogin {
+            handleDeepLinks(deepLinkUrl: deeplinkToBeOpenedAfterLogin)
+            self.deeplinkToBeOpenedAfterLogin = nil
         }
     }
 

--- a/Projects/App/Sources/Journeys/MainNavigationJourney.swift
+++ b/Projects/App/Sources/Journeys/MainNavigationJourney.swift
@@ -112,6 +112,7 @@ class MainNavigationViewModel: ObservableObject {
                     withAnimation {
                         hasLaunchFinished = true
                     }
+                    loggedInVm.actionAfterLogin()
                 case .notLoggedIn:
                     await ApplicationContext.shared.setValue(to: false)
                     notLoggedInVm = .init()


### PR DESCRIPTION
## [APP-XXX]

- Handle deeplink after successful login instead immediately 

Why?
Some deeplinks will not work because of missing data


## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
