### PR TITLE
Removed info for addons when changing tiers

### DIFF
--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -58,13 +58,7 @@ extension ChangeTierViewModel {
                     },
                     displayItems: addon.displayItems.compactMap({ .init(title: $0.title, value: $0.value) }),
                     insuranceLimits: addon.addonVariant.insurableLimits,
-                    typeOfContract: nil,
-                    onInfoClick: {
-                        changeTierNavigationVm.isInfoViewPresented = .init(
-                            title: addon.displayName,
-                            description: L10n.movingFlowTravelAddonSummaryDescription
-                        )
-                    }
+                    typeOfContract: nil
                 )
             )
         }


### PR DESCRIPTION
## [APP-XXX]

- We are not supposed to show info button for addons when doing change tier

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
