### PR TITLE
Reworked medium, small, mini buttons so they default behaviour

### DIFF
--- a/Projects/Addons/Sources/Views/AddonCardView.swift
+++ b/Projects/Addons/Sources/Views/AddonCardView.swift
@@ -34,6 +34,7 @@ public struct AddonCardView: View {
                     } content: {
                         hText(L10n.addonFlowSeePriceButton)
                     }
+                    .hButtonTakeFullWidth(true)
                 }
             }
         }

--- a/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
+++ b/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
@@ -36,7 +36,6 @@ struct AskForPushNotifications: View {
     var mainContent: some View {
         hSection {
             VStack(spacing: 24) {
-                Spacer()
                 hCoreUIAssets.infoFilled.view
                     .resizable()
                     .frame(width: 24, height: 24)
@@ -56,9 +55,6 @@ struct AskForPushNotifications: View {
                 } content: {
                     hText(L10n.claimsActivateNotificationsCta, style: .body1)
                 }
-                .fixedSize()
-
-                Spacer()
                 hButton.LargeButton(type: .ghost) {
                     onActionExecuted()
                     let store: ProfileStore = globalPresentableStoreContainer.get()

--- a/Projects/Chat/Sources/Views/ImagesView.swift
+++ b/Projects/Chat/Sources/Views/ImagesView.swift
@@ -157,7 +157,6 @@ struct PHPAssetPreview: View {
                         }
                     }
                     .opacity(selected ? 1 : 0)
-                    .fixedSize()
                 }
             } else {
                 ProgressView()

--- a/Projects/Chat/Sources/Views/MessageView.swift
+++ b/Projects/Chat/Sources/Views/MessageView.swift
@@ -157,6 +157,7 @@ struct LinkView: View {
                     } content: {
                         hText(L10n.ImportantMessage.readMore)
                     }
+                    .hButtonTakeFullWidth(true)
 
                 }
                 .padding([.horizontal, .bottom], .padding16)
@@ -221,6 +222,7 @@ struct ActionView: View {
             } content: {
                 hText(action.buttonTitle)
             }
+            hButtonTakeFullWidth(true)
         }
         .environment(\.colorScheme, .light)
     }

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -309,7 +309,6 @@ public struct ClaimDetailView: View {
                         } content: {
                             hText(L10n.ClaimStatus.UploadedFiles.uploadButton)
                         }
-                        .fixedSize()
                     }
                     .padding(.vertical, .padding32)
                 }

--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -45,6 +45,7 @@ struct ClaimStatus: View {
                         } content: {
                             hText(L10n.ClaimStatus.ClaimDetails.button)
                         }
+                        .hButtonTakeFullWidth(true)
                     }
                     extendedBottomView
                 }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Emergency/SumitClaimEmergencySelectView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Emergency/SumitClaimEmergencySelectView.swift
@@ -67,7 +67,7 @@ struct SumitClaimEmergencySelectView: View {
                                 hColorScheme(light: hTextColor.Opaque.primary, dark: hTextColor.Opaque.negative)
                             )
                     }
-                    .fixedSize(horizontal: false, vertical: true)
+                    .hButtonTakeFullWidth(true)
                 } else {
                     hButton.MediumButton(type: .secondary) {
                         withAnimation(.spring()) {
@@ -76,7 +76,7 @@ struct SumitClaimEmergencySelectView: View {
                     } content: {
                         hText(option.displayName)
                     }
-                    .fixedSize(horizontal: false, vertical: true)
+                    .hButtonTakeFullWidth(true)
                 }
             }
         }

--- a/Projects/Claims/Sources/Views/SubmitClaim/SubViews/ClaimContactCard.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/SubViews/ClaimContactCard.swift
@@ -49,6 +49,7 @@ struct ClaimContactCard: View {
                                 .foregroundColor(hTextColor.Opaque.primary)
                         }
                         .colorScheme(.light)
+                        .hButtonTakeFullWidth(true)
                     }
                 }
                 if let phoneNumber = model.phoneNumber, let url = URL(string: "tel://" + phoneNumber) {
@@ -61,6 +62,7 @@ struct ClaimContactCard: View {
                                 .foregroundColor(hTextColor.Opaque.primary)
                         }
                         .colorScheme(getPhoneNumberSchema())
+                        .hButtonTakeFullWidth(true)
                     }
                 }
                 if let info = model.info {

--- a/Projects/Claims/Sources/Views/SubmitClaim/SubViews/SupportView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/SubViews/SupportView.swift
@@ -25,7 +25,6 @@ struct SupportView: View {
                 } content: {
                     hText(L10n.CrossSell.Info.faqChatButton)
                 }
-                .fixedSize(horizontal: true, vertical: true)
             }
             .padding(.top, .padding32)
             .padding(.bottom, .padding56)

--- a/Projects/Contracts/Sources/View/CrossSellingItem.swift
+++ b/Projects/Contracts/Sources/View/CrossSellingItem.swift
@@ -48,7 +48,6 @@ struct CrossSellingItem: View {
                         hText(L10n.crossSellGetPrice)
                             .foregroundColor(hTextColor.Opaque.primary).colorScheme(.light)
                     }
-                    .fixedSize(horizontal: true, vertical: true)
                 }
             }
             .onTapGesture {

--- a/Projects/Home/Sources/CommonClaims/FirstVetView.swift
+++ b/Projects/Home/Sources/CommonClaims/FirstVetView.swift
@@ -38,6 +38,7 @@ public struct FirstVetView: View {
                                 } content: {
                                     hText(L10n.commonClaimButton)
                                 }
+                                .hButtonTakeFullWidth(true)
                             }
                         }
                     }
@@ -56,6 +57,6 @@ public struct FirstVetView: View {
     }
 }
 
-#Preview{
+#Preview {
     FirstVetView(partners: [])
 }

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
@@ -111,7 +111,7 @@ struct SupportView: View {
     @SwiftUI.Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
-        HStack {
+        hSection {
             VStack(spacing: 0) {
                 hText(L10n.hcChatQuestion)
                     .foregroundColor(hTextColor.Translucent.primary)
@@ -128,7 +128,6 @@ struct SupportView: View {
                             } content: {
                                 hText(L10n.hcChatGoToInbox)
                             }
-                            .fixedSize(horizontal: sizeCategory <= .large, vertical: false)
                         }
                         hButton.MediumButton(type: hasSentOrRecievedAtLeastOneMessage ? .ghost : .primary) {
                             NotificationCenter.default.post(
@@ -138,12 +137,12 @@ struct SupportView: View {
                         } content: {
                             hText(L10n.hcChatButton)
                         }
-                        .fixedSize(horizontal: sizeCategory <= .large, vertical: false)
                     }
                     .padding(.top, .padding24)
                 }
                 .presentableStoreLensAnimation(.default)
             }
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.vertical, .padding32)
             .padding(.bottom, .padding24)
         }

--- a/Projects/MoveFlow/Sources/View/MovingFlowHouseScreen.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowHouseScreen.swift
@@ -165,7 +165,6 @@ struct MovingFlowHouseScreen: View {
                         }
                     }
                     .hButtonDontShowLoadingWhenDisabled(true)
-                    .fixedSize(horizontal: true, vertical: false)
                     .hUseLightMode
                     .padding(.top, .padding8)
 

--- a/Projects/hCoreUI/Sources/Views/InfoCard/InfoCard.swift
+++ b/Projects/hCoreUI/Sources/Views/InfoCard/InfoCard.swift
@@ -43,6 +43,7 @@ public struct InfoCard: View {
         .padding(.horizontal, .padding16)
         .modifier(NotificationStyle(type: type))
         .fixedSize(horizontal: false, vertical: true)
+        .hButtonTakeFullWidth(true)
     }
 
     private var buttonsView: some View {
@@ -60,14 +61,12 @@ public struct InfoCard: View {
                                     config.buttonAction()
                                 } content: {
                                     hText(config.buttonTitle, style: .label)
-                                        .frame(maxWidth: .infinity)
                                 }
                             } else {
                                 hButton.SmallButton(type: .secondaryAlt) {
                                     config.buttonAction()
                                 } content: {
                                     hText(config.buttonTitle, style: .label)
-                                        .frame(maxWidth: .infinity)
                                 }
                                 .hUseLightMode
                             }
@@ -80,14 +79,12 @@ public struct InfoCard: View {
                                 config.buttonAction()
                             } content: {
                                 hText(config.buttonTitle, style: .label)
-                                    .frame(maxWidth: .infinity)
                             }
                         } else {
                             hButton.SmallButton(type: .secondaryAlt) {
                                 config.buttonAction()
                             } content: {
                                 hText(config.buttonTitle, style: .label)
-                                    .frame(maxWidth: .infinity)
                             }
                             .hUseLightMode
                         }

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen.swift
@@ -178,6 +178,7 @@ public struct QuoteSummaryScreen: View {
                     )
                 }
             }
+            .hButtonTakeFullWidth(true)
             .hFormAttachToBottom {
                 VStack {
                     if vm.showNoticeCard {

--- a/Projects/hCoreUI/Sources/Views/StateView.swift
+++ b/Projects/hCoreUI/Sources/Views/StateView.swift
@@ -40,8 +40,6 @@ struct StateView: View {
                     } content: {
                         hText(button.buttonTitle ?? type.buttonText)
                     }
-                    .fixedSize()
-
                 }
             }
         }

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -343,38 +343,39 @@ private struct LargeButtonModifier: ViewModifier {
 }
 
 private struct MediumButtonModifier: ViewModifier {
+    @Environment(\.hButtonTakeFullWidth) var hButtonTakeFullWidth
+
     func body(content: Content) -> some View {
-        hSection {
-            content
-                .padding(.top, 7)
-                .padding(.bottom, 9)
-                .frame(maxWidth: .infinity)
-        }
-        .sectionContainerStyle(.transparent)
+        content
+            .padding(.top, 7)
+            .padding(.bottom, 9)
+            .padding(.horizontal, .padding16)
+            .frame(maxWidth: hButtonTakeFullWidth ? .infinity : nil)
     }
 }
 
 private struct SmallButtonModifier: ViewModifier {
+    @Environment(\.hButtonTakeFullWidth) var hButtonTakeFullWidth
     func body(content: Content) -> some View {
-        hSection {
-            content
-                .padding(.top, 6.5)
-                .padding(.bottom, 7.5)
-                .frame(minHeight: 32)
-        }
-        .sectionContainerStyle(.transparent)
+        content
+            .padding(.top, 6.5)
+            .padding(.bottom, 7.5)
+            .frame(minHeight: 32)
+            .padding(.horizontal, .padding16)
+            .frame(maxWidth: hButtonTakeFullWidth ? .infinity : nil)
     }
 }
 
 private struct MiniButtonModifier: ViewModifier {
+    @Environment(\.hButtonTakeFullWidth) var hButtonTakeFullWidth
     func body(content: Content) -> some View {
-        hSection {
-            content
-                .padding(.vertical, 3)
-                .padding(.horizontal, .padding8)
-                .frame(minHeight: 24)
-        }
-        .sectionContainerStyle(.transparent)
+        content
+            .padding(.vertical, 3)
+            .padding(.horizontal, .padding8)
+            .frame(minHeight: 24)
+            .padding(.horizontal, .padding16)
+            .frame(maxWidth: hButtonTakeFullWidth ? .infinity : nil)
+
     }
 }
 
@@ -524,6 +525,23 @@ extension EnvironmentValues {
 extension View {
     public func hButtonDontShowLoadingWhenDisabled(_ show: Bool) -> some View {
         self.environment(\.hButtonDontShowLoadingWhenDisabled, show)
+    }
+}
+
+private struct EnvironmentHButtonTakeFullWidth: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var hButtonTakeFullWidth: Bool {
+        get { self[EnvironmentHButtonTakeFullWidth.self] }
+        set { self[EnvironmentHButtonTakeFullWidth.self] = newValue }
+    }
+}
+
+extension View {
+    public func hButtonTakeFullWidth(_ takeFullWidth: Bool) -> some View {
+        self.environment(\.hButtonTakeFullWidth, takeFullWidth)
     }
 }
 

--- a/Projects/hCoreUI/Sources/hForm/hTextView.swift
+++ b/Projects/hCoreUI/Sources/hForm/hTextView.swift
@@ -341,6 +341,7 @@ private struct FreeTextInputView: View, KeyboardReadableHeight {
                             .disabled(value.count > maxCharacters)
                         }
                         .padding(.bottom, .padding8)
+                        .hButtonTakeFullWidth(true)
                     }
                     .colorScheme(.dark)
                     .sectionContainerStyle(.transparent)


### PR DESCRIPTION
## [APP-XXX]

- Default behaviour for medium, small and mini buttons is to take as small width as needed
- Added modifier to expend width if need

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
