### PR TITLE
GEN-3215: Add support for deeplinks from hedvig

### DIFF
--- a/Projects/App/Config/Production/Hedvig.entitlements
+++ b/Projects/App/Config/Production/Hedvig.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:hedvig.page.link</string>
+		<string>applinks:www.hedvig.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/Projects/App/Config/Test/Ugglan.entitlements
+++ b/Projects/App/Config/Test/Ugglan.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:hedvigtest.page.link</string>
+		<string>applinks:dev.hedvigit.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/Projects/App/Sources/Journeys/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Journeys/LoggedInNavigation.swift
@@ -554,11 +554,12 @@ class LoggedInNavigationViewModel: ObservableObject {
     }
 
     @objc func openDeepLinkNotification(notification: Notification) {
-        let deepLinkUrl = notification.object as? URL
-        if ApplicationState.currentState == .loggedIn {
-            self.handleDeepLinks(deepLinkUrl: deepLinkUrl)
-        } else {
-            self.deeplinkToBeOpenedAfterLogin = deepLinkUrl
+        if let deepLinkUrl = notification.object as? URL {
+            if ApplicationState.currentState == .loggedIn {
+                self.handleDeepLinks(deepLinkUrl: deepLinkUrl)
+            } else if !deepLinkUrl.absoluteString.contains("//bankid") {
+                self.deeplinkToBeOpenedAfterLogin = deepLinkUrl
+            }
         }
     }
 

--- a/Projects/App/Sources/Journeys/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Journeys/LoggedInNavigation.swift
@@ -739,13 +739,10 @@ class LoggedInNavigationViewModel: ObservableObject {
             case .addon:
                 handleAddon(url: url)
             case nil:
-                let rootUrls = [hGraphQL.Environment.staging.deepLinkUrl, Environment.production.deepLinkUrl]
-                    .compactMap({ $0.host })
-                guard rootUrls.contains(url.host ?? "") else {
+                let isDeeplink = hGraphQL.Environment.current.isDeeplink(url)
+                if !isDeeplink {
                     openUrl(url: url)
-                    return
                 }
-
             }
         }
     }

--- a/Projects/Home/Sources/Models/HelpCenterModel.swift
+++ b/Projects/Home/Sources/Models/HelpCenterModel.swift
@@ -36,10 +36,13 @@ public struct Question: Codable, Equatable, Hashable, Sendable {
                     of: Environment.production.webBaseURL.host!,
                     with: Environment.staging.webBaseURL.host!
                 )
-                .replacingOccurrences(
-                    of: Environment.production.deepLinkUrl.host!,
-                    with: Environment.staging.deepLinkUrl.host!
+            for deeplinkWithIndex in Environment.production.deepLinkUrls.enumerated() {
+                let index = deeplinkWithIndex.offset
+                answer = answer.replacingOccurrences(
+                    of: deeplinkWithIndex.element.host!,
+                    with: Environment.staging.deepLinkUrls[index].host!
                 )
+            }
         }
         self.questionEn = questionEn
         self.question = question

--- a/Projects/TerminateContracts/Sources/Navigation/TerminationFlowNavigationViewModel.swift
+++ b/Projects/TerminateContracts/Sources/Navigation/TerminationFlowNavigationViewModel.swift
@@ -93,7 +93,7 @@ public class TerminationFlowNavigationViewModel: ObservableObject, @preconcurren
             switch redirectAction {
             case .updateAddress:
                 self.router.dismiss()
-                var url = Environment.current.deepLinkUrl
+                var url = Environment.current.deepLinkUrls.last!
                 url.appendPathComponent(DeepLink.moveContract.rawValue)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     NotificationCenter.default.post(name: .openDeepLink, object: url)

--- a/Projects/hCore/Sources/DeepLink.swift
+++ b/Projects/hCore/Sources/DeepLink.swift
@@ -68,18 +68,17 @@ public enum DeepLink: String, Codable, CaseIterable {
     }
     @MainActor
     public static func getType(from url: URL) -> DeepLink? {
-        let rootUrls = [Environment.staging.deepLinkUrl, Environment.production.deepLinkUrl].compactMap({ $0.host })
-        guard rootUrls.contains(url.host ?? "") else { return nil }
-
-        guard let type = url.pathComponents.compactMap({ DeepLink(rawValue: $0) }).first else {
+        guard Environment.staging.isDeeplink(url) || Environment.production.isDeeplink(url) else { return nil }
+        guard let type = url.pathComponents.compactMap({ DeepLink(rawValue: $0) }).last else {
             return nil
         }
         return type
     }
 
     public static func getUrl(from deeplink: DeepLink) -> URL? {
-        let path = Environment.current.deepLinkUrl.absoluteString + "/" + deeplink.rawValue
-        guard let url = URL(string: path) else {
+        let paths = Environment.current.deepLinkUrls.compactMap({ $0.absoluteString + "/" + deeplink.rawValue })
+        let url = paths.compactMap({ URL.init(string: $0) }).last
+        guard let url else {
             return nil
         }
         return url

--- a/Projects/hCore/Sources/String+isDeepLink.swift
+++ b/Projects/hCore/Sources/String+isDeepLink.swift
@@ -7,7 +7,10 @@ extension String {
         if let match = detector?
             .firstMatch(in: self, options: [], range: NSRange(location: 0, length: utf16.count))
         {
-            return match.range.length == utf16.count && contains(Environment.current.deepLinkUrl.host!)
+            if let url = URL(string: self), Environment.current.isDeeplink(url) {
+                return match.range.length == utf16.count
+            }
+            return false
         } else {
             return false
         }

--- a/Projects/hGraphQL/Sources/Environment.swift
+++ b/Projects/hGraphQL/Sources/Environment.swift
@@ -137,12 +137,25 @@ public enum Environment: Hashable {
         }
     }
 
-    public var deepLinkUrl: URL {
+    public var deepLinkUrls: [URL] {
         switch self {
-        case .staging: return URL(string: "https://hedvigtest.page.link")!
-        case .production: return URL(string: "https://hedvig.page.link")!
-        case .custom(_, _, _, _): return URL(string: "https://hedvig.page.link")!
+        case .staging:
+            return [URL(string: "https://hedvigtest.page.link")!, URL(string: "https://dev.hedvigit.com/deeplink/")!]
+        case .production:
+            return [URL(string: "https://hedvig.page.link")!, URL(string: "https://www.hedvig.com/deeplink/")!]
+        case .custom(_, _, _, _):
+            return [URL(string: "https://hedvig.page.link")!, URL(string: "https://www.hedvig.com/deeplink/")!]
         }
+    }
+
+    public func isDeeplink(_ url: URL) -> Bool {
+        if deepLinkUrls[0].host == url.host {
+            return true
+        }
+        if deepLinkUrls[1].host == url.host {
+            return url.pathComponents.contains("deeplink")
+        }
+        return false
     }
 
     public var appStoreURL: URL {


### PR DESCRIPTION
## [APP-XXX]

- Added support for deeplink for dev.hedvigit.com/deeplink/ for stage and www.hedvig.com/deeplink/

Ugglan:
https://hedvigtest.page.link/forever -> should open the app
https://dev.hedvigit.com/deeplink/forever -> should open the app
https://dev.hedvigit.com/forever -> should open web

Hedvig:
https://hedvig.page.link/forever -> should open the app
https://www.hedvig.com/deeplink/forever -> should open the app
https://www.hedvig.com/forever -> should open web

Since we recently added  .well-known to our web sometimes it doesn't work until the app is deleted and the phone is restarted. So in the case its not working thats what needs to be done. I am preatty sure that apple reset this when new version is released and check for new associated domains so release should be fine


## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
