### PR TITLE
Fixed crash when opening terms on claim details

### DIFF
--- a/Projects/App/Sources/Journeys/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Journeys/LoggedInNavigation.swift
@@ -322,12 +322,6 @@ struct HomeTab: View {
         ) {
             ClaimsJourneyMain(from: .generic)
         }
-        .detent(
-            item: $homeNavigationVm.document,
-            style: [.large]
-        ) { document in
-            PDFPreview(document: document)
-        }
         .modally(
             presented: $homeNavigationVm.isHelpCenterPresented
         ) {

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -15,7 +15,6 @@ public struct ClaimDetailView: View {
     @State var showFilePicker = false
     @State var showCamera = false
     @ObservedObject var vm: ClaimDetailViewModel
-    @EnvironmentObject var homeVm: HomeNavigationViewModel
     @EnvironmentObject var router: Router
 
     public init(
@@ -123,6 +122,12 @@ public struct ClaimDetailView: View {
             .configureTitle(L10n.ClaimStatusDetail.addedFiles)
             .embededInNavigation(tracking: ClaimDetailDetentType.fileUpload)
 
+        }
+        .detent(
+            item: $vm.document,
+            style: [.large]
+        ) { document in
+            PDFPreview(document: document)
         }
         .loading($vm.claimProcessingState)
         .hErrorViewButtonConfig(
@@ -247,7 +252,7 @@ public struct ClaimDetailView: View {
                     Image(uiImage: hCoreUIAssets.arrowNorthEast.image)
                 }
                 .onTap {
-                    homeVm.document = termsAndConditionsDocument
+                    vm.document = termsAndConditionsDocument
                 }
             }
         }
@@ -398,6 +403,7 @@ struct ClaimDetailView_Previews: PreviewProvider {
 @MainActor
 public class ClaimDetailViewModel: ObservableObject {
     @PresentableStore var store: ClaimsStore
+    @Published public var document: hPDFDocument? = nil
     @Published private(set) var claim: ClaimModel? {
         didSet {
             self.setupToolbarOptionType(for: claim)

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -65,9 +65,6 @@ public class HomeNavigationViewModel: ObservableObject {
     @Published public var isSubmitClaimPresented = false
     @Published public var isHelpCenterPresented = false
 
-    //claim details
-    @Published public var document: hPDFDocument? = nil
-
     @Published public var navBarItems = NavBarItems()
 
     @Published public var openChat: ChatConversation?


### PR DESCRIPTION
## [APP-XXX]

- reworked logic for open terms in claim details
- crash happened when you enter claim details from the conversation and try to open terms
-  [datadog crash ](https://app.datadoghq.eu/rum/sessions?query=%40type%3Aerror%20%40application.id%3A416e8fc0-c96a-4485-8c74-84412960a479%20%40error.is_crash%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZTLKqxIRhcwoAAAABhBWlRMS3dJTEFBQUFxMkF5QzFvdVRRQUIAAAAkMDE5NGNiMzEtNTI4My00ZTVhLWJhM2ItY2ZlYWI5NjQ0NGYzAAAIvQ&fromUser=false&track=rum&viz=stream&from_ts=1738493280166&to_ts=1738579680166&live=true)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
