### PR TITLE
Missing last character in the chat when sending a mesage

### DIFF
--- a/Projects/Chat/Sources/Views/ChatInputView.swift
+++ b/Projects/Chat/Sources/Views/ChatInputView.swift
@@ -262,7 +262,7 @@ private class CustomTextView: UITextView, UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             self?.inputText = textView.text
             self?.updateHeight()
             self?.updateColors()


### PR DESCRIPTION
## [APP-XXX]

- Adding some additional delay should fix it.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
