### PR TITLE
CoInsured: Exclude alert check for updated contract

### DIFF
--- a/Projects/EditCoInsured/Sources/View/CoInsuredProcessingScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/CoInsuredProcessingScreen.swift
@@ -33,7 +33,7 @@ struct CoInsuredProcessingScreen: View {
                 editCoInsuredNavigation.showProgressScreenWithoutSuccess = false
                 editCoInsuredNavigation.editCoInsuredConfig = nil
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak editCoInsuredViewModel] in
-                    editCoInsuredViewModel?.checkForAlert()
+                    editCoInsuredViewModel?.checkForAlert(excludingContractId: intentViewModel.contractId)
                 }
                 EditCoInsuredViewModel.updatedCoInsuredForContractId.send(
                     intentViewModel.contractId
@@ -66,7 +66,7 @@ struct CoInsuredProcessingScreen: View {
                 editCoInsuredNavigation.showProgressScreenWithSuccess = false
                 editCoInsuredNavigation.showProgressScreenWithoutSuccess = false
                 editCoInsuredNavigation.editCoInsuredConfig = nil
-                editCoInsuredViewModel.checkForAlert()
+                editCoInsuredViewModel.checkForAlert(excludingContractId: intentViewModel.contractId)
                 EditCoInsuredViewModel.updatedCoInsuredForContractId.send(
                     intentViewModel.contractId
                 )

--- a/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
+++ b/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
@@ -65,7 +65,7 @@ public class EditCoInsuredViewModel: ObservableObject {
         }
     }
 
-    public func checkForAlert() {
+    public func checkForAlert(excludingContractId: String? = nil) {
         editCoInsuredModelDetent = nil
         editCoInsuredModelFullScreen = nil
         editCoInsuredModelMissingAlert = nil
@@ -73,6 +73,9 @@ public class EditCoInsuredViewModel: ObservableObject {
         Task { @MainActor in
             let activeContracts = try await editCoInsuredSharedService.fetchContracts()
             let missingContract = activeContracts.first { contract in
+                if contract.id == excludingContractId {
+                    return false
+                }
                 if contract.upcomingChangedAgreement != nil {
                     return false
                 } else {
@@ -82,8 +85,6 @@ public class EditCoInsuredViewModel: ObservableObject {
                         }) != nil
                 }
             }
-            try await Task.sleep(nanoseconds: 400_000_000)
-
             if let missingContract {
                 let missingContractConfig = InsuredPeopleConfig(
                     contract: missingContract,

--- a/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
+++ b/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
@@ -85,6 +85,9 @@ public class EditCoInsuredViewModel: ObservableObject {
                         }) != nil
                 }
             }
+
+            try await Task.sleep(nanoseconds: 400_000_000)
+
             if let missingContract {
                 let missingContractConfig = InsuredPeopleConfig(
                     contract: missingContract,


### PR DESCRIPTION
## [APP-XXX]

When checking for insurances that have missed co-insured, exclude insurance that has been updated at a moment of checking.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
