### PR TITLE
Fix loading view to be same height as success and error screen

### DIFF
--- a/Projects/hCoreUI/Sources/Views/ProcessingStateView.swift
+++ b/Projects/hCoreUI/Sources/Views/ProcessingStateView.swift
@@ -148,8 +148,9 @@ public struct ProcessingStateView: View {
 
     @ViewBuilder
     private var loadingView: some View {
-        hSection {
-            VStack(spacing: 20) {
+        ZStack(alignment: .bottom) {
+            BackgroundView().ignoresSafeArea()
+            VStack {
                 Spacer()
                 hText(loadingViewText)
                 ProgressView(value: vm.progress)
@@ -167,10 +168,8 @@ public struct ProcessingStateView: View {
                     }
                     .progressViewStyle(hProgressViewStyle())
                 Spacer()
-                Spacer()
             }
         }
-        .sectionContainerStyle(.transparent)
     }
 }
 
@@ -178,6 +177,22 @@ public struct ProcessingStateView: View {
     ProcessingStateView(
         loadingViewText: "loading...",
         state: .constant(.error(errorMessage: "error message"))
+    )
+})
+
+#Preview(body: {
+    ProcessingStateView(
+        loadingViewText: "loading...",
+        state: .constant(.loading)
+    )
+})
+
+#Preview(body: {
+    ProcessingStateView(
+        loadingViewText: "loading...",
+        successViewTitle: "Success!",
+        successViewBody: "Your contract was successfully updated.",
+        state: .constant(.success)
     )
 })
 


### PR DESCRIPTION
## [APP-XXX]

- Fix height of processing screen to be same as success and error screen
- [This bug task ](https://www.notion.so/hedviginsurance/Addons-E2E-test-18fc3f71cb0a80a797f7e4bc3c85974b?p=18fc3f71cb0a814ca33dd2aef0191273&pm=s)from addon test session

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
