### PR TITLE
GEN-3279: add ConfirmChangeTierScreen

### DIFF
--- a/Projects/Addons/Sources/Views/ConfirmChangeAddonScreen.swift
+++ b/Projects/Addons/Sources/Views/ConfirmChangeAddonScreen.swift
@@ -6,43 +6,31 @@ public struct ConfirmChangeAddonScreen: View {
     @EnvironmentObject var addonNavigationVm: ChangeAddonNavigationViewModel
 
     public var body: some View {
-        hForm {}
-            .hFormContentPosition(.compact)
-            .hFormAttachToBottom {
-                hSection {
-                    VStack(spacing: .padding32) {
-                        VStack(alignment: .leading, spacing: 0) {
-                            hText(L10n.addonFlowConfirmationTitle)
-                            hText(
-                                L10n.addonFlowConfirmationDescription(
-                                    addonNavigationVm.changeAddonVm!.addonOffer?.activationDate?
-                                        .displayDateDDMMMYYYYFormat ?? ""
-                                )
-                            )
-                            .foregroundColor(hTextColor.Translucent.secondary)
-                        }
-                        VStack(spacing: .padding8) {
-                            hButton.LargeButton(type: .primary) {
-                                addonNavigationVm.isAddonProcessingPresented = true
-                                addonNavigationVm.isConfirmAddonPresented = false
-                                Task {
-                                    await addonNavigationVm.changeAddonVm!.submitAddons()
-                                }
-                            } content: {
-                                hText(L10n.addonFlowConfirmationButton)
-                            }
-
-                            hButton.LargeButton(type: .ghost) {
-                                addonNavigationVm.isConfirmAddonPresented = false
-                            } content: {
-                                hText(L10n.generalCloseButton)
-                            }
+        ConfirmChangesScreen(
+            title: L10n.addonFlowConfirmationTitle,
+            subTitle: L10n.addonFlowConfirmationDescription(
+                addonNavigationVm.changeAddonVm!.addonOffer?.activationDate?
+                    .displayDateDDMMMYYYYFormat ?? ""
+            ),
+            buttons: .init(
+                mainButton: .init(
+                    buttonTitle: L10n.addonFlowConfirmationButton,
+                    buttonAction: {
+                        addonNavigationVm.isAddonProcessingPresented = true
+                        addonNavigationVm.isConfirmAddonPresented = false
+                        Task {
+                            await addonNavigationVm.changeAddonVm!.submitAddons()
                         }
                     }
-                    .padding(.top, .padding24)
-                }
-                .sectionContainerStyle(.transparent)
-            }
+                ),
+                dismissButton: .init(
+                    buttonTitle: L10n.generalCloseButton,
+                    buttonAction: {
+                        addonNavigationVm.isConfirmAddonPresented = false
+                    }
+                )
+            )
+        )
     }
 }
 

--- a/Projects/Addons/Sources/Views/ConfirmChangeAddonScreen.swift
+++ b/Projects/Addons/Sources/Views/ConfirmChangeAddonScreen.swift
@@ -9,7 +9,7 @@ public struct ConfirmChangeAddonScreen: View {
         ConfirmChangesScreen(
             title: L10n.addonFlowConfirmationTitle,
             subTitle: L10n.addonFlowConfirmationDescription(
-                addonNavigationVm.changeAddonVm!.addonOffer?.activationDate?
+                addonNavigationVm.changeAddonVm?.addonOffer?.activationDate?
                     .displayDateDDMMMYYYYFormat ?? ""
             ),
             buttons: .init(
@@ -19,7 +19,7 @@ public struct ConfirmChangeAddonScreen: View {
                         addonNavigationVm.isAddonProcessingPresented = true
                         addonNavigationVm.isConfirmAddonPresented = false
                         Task {
-                            await addonNavigationVm.changeAddonVm!.submitAddons()
+                            await addonNavigationVm.changeAddonVm?.submitAddons()
                         }
                     }
                 ),

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -12,6 +12,7 @@ public class ChangeTierNavigationViewModel: ObservableObject {
     @Published public var isInsurableLimitPresented: InsurableLimits?
     @Published public var document: hPDFDocument?
     @Published public var isInfoViewPresented: InfoViewDataModel? = nil
+    @Published public var isConfirmTierPresented = false
     let useOwnNavigation: Bool
     let router: Router
     var onChangedTier: () -> Void = {}
@@ -269,6 +270,19 @@ public struct ChangeTierNavigation: View {
                 description: info.description ?? ""
             )
         }
+        .detent(
+            presented: $changeTierNavigationVm.isConfirmTierPresented,
+            style: [.height],
+            options: .constant(.alwaysOpenOnTop),
+            content: {
+                ConfirmChangeTierScreen()
+                    .embededInNavigation(
+                        options: .navigationBarHidden,
+                        tracking: ChangeTierTrackingType.confirmTier
+                    )
+                    .environmentObject(changeTierNavigationVm)
+            }
+        )
     }
 
     private var wrapperHost: some View {
@@ -319,6 +333,8 @@ private enum ChangeTierTrackingType: TrackingViewNameProtocol {
             return .init(describing: EditDeductibleScreen.self)
         case .compareTier:
             return .init(describing: CompareTierScreen.self)
+        case .confirmTier:
+            return .init(describing: ConfirmChangeTierScreen.self)
         case .info:
             return "Addon Info"
         }
@@ -328,5 +344,6 @@ private enum ChangeTierTrackingType: TrackingViewNameProtocol {
     case editTier
     case editDeductible
     case compareTier
+    case confirmTier
     case info
 }

--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -67,8 +67,7 @@ extension ChangeTierViewModel {
         let vm = QuoteSummaryViewModel(
             contract: contracts,
             onConfirmClick: {
-                self.commitTier()
-                changeTierNavigationVm.router.push(ChangeTierRouterActionsWithoutBackButton.commitTier)
+                changeTierNavigationVm.isConfirmTierPresented = true
             }
         )
 

--- a/Projects/ChangeTier/Sources/Views/ConfirmChangeTierScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ConfirmChangeTierScreen.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+public struct ConfirmChangeTierScreen: View {
+    @EnvironmentObject var changeTierNavigationVm: ChangeTierNavigationViewModel
+
+    public var body: some View {
+        ConfirmChangesScreen(
+            title: L10n.confirmChangesTitle,
+            subTitle: L10n.confirmChangesSubtitle(
+                changeTierNavigationVm.vm.activationDate?.displayDateDDMMMYYYYFormat ?? ""
+            ),
+            buttons: .init(
+                mainButton: .init(
+                    buttonTitle: L10n.generalConfirm,
+                    buttonAction: {
+                        changeTierNavigationVm.isConfirmTierPresented = false
+                        changeTierNavigationVm.vm.commitTier()
+                        changeTierNavigationVm.router.push(ChangeTierRouterActionsWithoutBackButton.commitTier)
+                    }
+                ),
+                dismissButton: .init(
+                    buttonTitle: L10n.generalCloseButton,
+                    buttonAction: {
+                        changeTierNavigationVm.isConfirmTierPresented = false
+                    }
+                )
+            )
+        )
+    }
+}
+
+#Preview {
+    Dependencies.shared.add(module: Module { () -> ChangeTierClient in ChangeTierClientDemo() })
+    Dependencies.shared.add(module: Module { () -> DateService in DateService() })
+    return ConfirmChangeTierScreen()
+        .environmentObject(
+            ChangeTierNavigationViewModel(
+                changeTierContractsInput: .init(source: .changeTier, contracts: []),
+                onChangedTier: {}
+            )
+        )
+}

--- a/Projects/hCoreUI/Sources/Views/ConfirmChangesScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/ConfirmChangesScreen.swift
@@ -21,12 +21,13 @@ public struct ConfirmChangesScreen: View {
             .hFormContentPosition(.compact)
             .hFormAttachToBottom {
                 hSection {
-                    VStack(spacing: .padding32) {
+                    VStack(alignment: .leading, spacing: .padding32) {
                         VStack(alignment: .leading, spacing: 0) {
                             hText(title)
                             hText(subTitle)
                                 .foregroundColor(hTextColor.Translucent.secondary)
                         }
+                        .padding(.leading, .padding8)
                         VStack(spacing: .padding8) {
                             hButton.LargeButton(type: .primary) {
                                 buttons.mainButton.buttonAction()
@@ -69,4 +70,12 @@ public struct ConfirmChangesButtonConfig {
             self.buttonAction = buttonAction
         }
     }
+}
+
+#Preview {
+    ConfirmChangesScreen(
+        title: "title",
+        subTitle: "sub title",
+        buttons: .init(mainButton: .init(buttonAction: {}), dismissButton: .init(buttonAction: {}))
+    )
 }

--- a/Projects/hCoreUI/Sources/Views/ConfirmChangesScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/ConfirmChangesScreen.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import hCore
+
+public struct ConfirmChangesScreen: View {
+    let title: String
+    let subTitle: String
+    let buttons: ConfirmChangesButtonConfig
+
+    public init(
+        title: String,
+        subTitle: String,
+        buttons: ConfirmChangesButtonConfig
+    ) {
+        self.title = title
+        self.subTitle = subTitle
+        self.buttons = buttons
+    }
+
+    public var body: some View {
+        hForm {}
+            .hFormContentPosition(.compact)
+            .hFormAttachToBottom {
+                hSection {
+                    VStack(spacing: .padding32) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            hText(title)
+                            hText(subTitle)
+                                .foregroundColor(hTextColor.Translucent.secondary)
+                        }
+                        VStack(spacing: .padding8) {
+                            hButton.LargeButton(type: .primary) {
+                                buttons.mainButton.buttonAction()
+                            } content: {
+                                hText(buttons.mainButton.buttonTitle ?? L10n.generalConfirm)
+                            }
+
+                            hButton.LargeButton(type: .ghost) {
+                                buttons.dismissButton.buttonAction()
+                            } content: {
+                                hText(buttons.dismissButton.buttonTitle ?? L10n.generalCloseButton)
+                            }
+                        }
+                    }
+                    .padding(.top, .padding24)
+                }
+                .sectionContainerStyle(.transparent)
+            }
+    }
+}
+
+public struct ConfirmChangesButtonConfig {
+    let mainButton: ConfirmChangeButton
+    let dismissButton: ConfirmChangeButton
+
+    public init(
+        mainButton: ConfirmChangeButton,
+        dismissButton: ConfirmChangeButton
+    ) {
+        self.mainButton = mainButton
+        self.dismissButton = dismissButton
+    }
+
+    public struct ConfirmChangeButton {
+        let buttonTitle: String?
+        let buttonAction: () -> Void
+
+        public init(buttonTitle: String? = nil, buttonAction: @escaping () -> Void) {
+            self.buttonTitle = buttonTitle
+            self.buttonAction = buttonAction
+        }
+    }
+}


### PR DESCRIPTION
## [APP-XXX]

- Added confirmation step before committing tier change
- Made this view generic to be reused for addons and maybe other places in the future
- [Figma](https://www.figma.com/design/SNVLvLq7ztclXiDqqMNXgY/Tiers-%26-Addons-(App)?node-id=3345-32241&p=f&t=lKG4NKkeptejJgEH-0)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
