### PR TITLE
GEN-3287: Move address to quick actions

### DIFF
--- a/Projects/Home/Sources/Service/OctopusImplementation/HomeClientOctopus.swift
+++ b/Projects/Home/Sources/Service/OctopusImplementation/HomeClientOctopus.swift
@@ -50,9 +50,7 @@ public class HomeClientOctopus: HomeClient {
         var quickActions = [QuickAction]()
         let actions = data.currentMember.memberActions
         var contractAction = [QuickAction]()
-        if actions?.isMovingEnabled == true && featureFlags.isMovingFlowEnabled {
-            contractAction.append(.changeAddress)
-        }
+
         if actions?.isEditCoInsuredEnabled == true && featureFlags.isEditCoInsuredEnabled {
             contractAction.append(.editCoInsured)
         }
@@ -68,6 +66,11 @@ public class HomeClientOctopus: HomeClient {
         if !contractAction.isEmpty {
             quickActions.append(.editInsurance(actions: .init(quickActions: contractAction)))
         }
+
+        if actions?.isMovingEnabled == true && featureFlags.isMovingFlowEnabled {
+            quickActions.append(.changeAddress)
+        }
+
         if actions?.isConnectPaymentEnabled == true {
             quickActions.append(.connectPayments)
         }


### PR DESCRIPTION
## [GEN-3287]

- Moved address to quick actions and removed from edit insurance in help center
- [Figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/Retention-UX-Improvements-App?node-id=5-8974&t=iDNAaZcU3PVEKdCR-0)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
