### PR TITLE
GEN-3289: Update moving/cancellation buttons in insurance details

### DIFF
--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -73,13 +73,22 @@ public struct ContractsNavigation<Content: View>: View {
                             fromInfoCard: false
                         )
                         contractsNavigationVm.editCoInsuredVm.start(fromContract: configContract)
-                    case .changeAddress:
-                        contractsNavigationVm.isChangeAddressPresented = true
                     case .changeTier:
                         contractsNavigationVm.changeTierInput = .contractWithSource(
                             data: .init(source: .changeTier, contractId: contract.id)
                         )
                     case .cancellation:
+                        let config = TerminationConfirmConfig(contract: contract)
+                        Task {
+                            do {
+                                try await contractsNavigationVm.terminateInsuranceVm.start(with: [config])
+                            } catch let exception {
+                                Toasts.shared.displayToastBar(
+                                    toast: .init(type: .error, text: exception.localizedDescription)
+                                )
+                            }
+                        }
+                    case .changeAddress:
                         break
                     }
                 }

--- a/Projects/Contracts/Sources/Stores/ContractAction.swift
+++ b/Projects/Contracts/Sources/Stores/ContractAction.swift
@@ -36,19 +36,17 @@ extension EditType {
     public static func getTypes(for contract: Contract) -> [EditType] {
         var editTypes: [EditType] = []
 
-        let contractStore: ContractStore = globalPresentableStoreContainer.get()
-        let contractsThatSupportsMoving = contractStore.state.activeContracts.filter({ $0.supportsAddressChange })
-        if Dependencies.featureFlags().isMovingFlowEnabled && contract.supportsAddressChange
-            && contractsThatSupportsMoving.count < 2
-        {
-            editTypes.append(.changeAddress)
-        }
         if contract.supportsChangeTier {
             editTypes.append(.changeTier)
         }
         if Dependencies.featureFlags().isEditCoInsuredEnabled && contract.supportsCoInsured {
             editTypes.append(.coInsured)
         }
+
+        if Dependencies.featureFlags().isTerminationFlowEnabled && contract.canTerminate {
+            editTypes.append(.cancellation)
+        }
+
         return editTypes
     }
 }

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -54,7 +54,7 @@ struct ContractInformationView: View {
                             VStack(spacing: 8) {
                                 if contract.showEditInfo {
                                     hSection {
-                                        hButton.LargeButton(type: .primary) {
+                                        hButton.LargeButton(type: .secondary) {
                                             if contract.onlyCoInsured()
                                                 && Dependencies.featureFlags().isEditCoInsuredEnabled
                                             {
@@ -312,7 +312,7 @@ struct ContractInformationView: View {
             && contractsThatSupportsMoving.count < 2
         {
             hSection {
-                hButton.LargeButton(type: .secondary) {
+                hButton.LargeButton(type: .ghost) {
                     contractsNavigationVm.isChangeAddressPresented = true
                 } content: {
                     hText(L10n.InsuranceDetails.moveButton, style: .body1)

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -54,7 +54,7 @@ struct ContractInformationView: View {
                             VStack(spacing: 8) {
                                 if contract.showEditInfo {
                                     hSection {
-                                        hButton.LargeButton(type: .secondary) {
+                                        hButton.LargeButton(type: .primary) {
                                             if contract.onlyCoInsured()
                                                 && Dependencies.featureFlags().isEditCoInsuredEnabled
                                             {
@@ -78,9 +78,7 @@ struct ContractInformationView: View {
                                         }
                                     }
                                 }
-                                if contract.canTerminate {
-                                    displayTerminationButton
-                                }
+                                moveAddressButton(contract: contract)
                             }
                             .padding(.bottom, .padding16)
                         }
@@ -308,44 +306,19 @@ struct ContractInformationView: View {
     }
 
     @ViewBuilder
-    private var displayTerminationButton: some View {
-        if Dependencies.featureFlags().isTerminationFlowEnabled {
-            PresentableStoreLens(
-                ContractStore.self,
-                getter: { state in
-                    state.contractForId(id)
-                }
-            ) { contract in
-                if contract?.canTerminate ?? false {
-                    hSection {
-                        hButton.LargeButton(type: .ghost) {
-                            if let contract {
-                                let config = TerminationConfirmConfig(contract: contract)
-                                Task {
-                                    withAnimation {
-                                        vm.cancelInsuranceState = .loading
-                                    }
-                                    do {
-                                        try await contractsNavigationVm.terminateInsuranceVm.start(with: [config])
-                                    } catch let exception {
-                                        Toasts.shared.displayToastBar(
-                                            toast: .init(type: .error, text: exception.localizedDescription)
-                                        )
-                                    }
-                                    withAnimation {
-                                        vm.cancelInsuranceState = .success
-                                    }
-                                }
-                            }
-                        } content: {
-                            hText(L10n.terminationButton, style: .body1)
-                                .foregroundColor(hTextColor.Opaque.secondary)
-                        }
-                    }
-                    .sectionContainerStyle(.transparent)
-                    .hButtonIsLoading(vm.cancelInsuranceState == .loading)
+    private func moveAddressButton(contract: Contract) -> some View {
+        let contractsThatSupportsMoving = store.state.activeContracts.filter({ $0.supportsAddressChange })
+        if contract.supportsAddressChange && Dependencies.featureFlags().isMovingFlowEnabled
+            && contractsThatSupportsMoving.count < 2
+        {
+            hSection {
+                hButton.LargeButton(type: .secondary) {
+                    contractsNavigationVm.isChangeAddressPresented = true
+                } content: {
+                    hText(L10n.InsuranceDetails.moveButton, style: .body1)
                 }
             }
+            .sectionContainerStyle(.transparent)
         }
     }
 }
@@ -353,7 +326,6 @@ struct ContractInformationView: View {
 @MainActor
 private class ContractsInformationViewModel: ObservableObject {
     var cancellable: AnyCancellable?
-    @Published var cancelInsuranceState: ProcessingState = .success
     func getListToDisplay(contract: Contract) -> [CoInsuredListType] {
         return contract.coInsured
             .map {


### PR DESCRIPTION
## [GEN-3289]

- Updated buttons for moving and cancellation in insurance details. Switched places.
- [Figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/Retention-UX-Improvements-App?node-id=5-12340&t=iDNAaZcU3PVEKdCR-0)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
