### PR TITLE
GEN-3291: New design for suggestion cards in termination survey

### DIFF
--- a/Projects/TerminateContracts/GraphQL/Octopus/TerminationStartFlow.graphql
+++ b/Projects/TerminateContracts/GraphQL/Octopus/TerminationStartFlow.graphql
@@ -75,16 +75,20 @@ fragment FlowTerminationSurveyStepOptionFragment on FlowTerminationSurveyOption 
 
 fragment FlowTerminationSurveyOptionSuggestionFragment on FlowTerminationSurveyOptionSuggestion {
          id
+         infoType
          ... on FlowTerminationSurveyOptionSuggestionAction {
-           action
-           buttonTitle
-           description
+            action
+            buttonTitle
+            description
          }
          ... on FlowTerminationSurveyOptionSuggestionRedirect {
-           url
-           description
-           buttonTitle
+            url
+            description
+            buttonTitle
          }
+        ... on FlowTerminationSurveyOptionSuggestionInfo {
+            description
+        }
 }
 
 fragment FlowTerminationSurveyOptionFeedbackFragment on FlowTerminationSurveyOptionFeedback {

--- a/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
+++ b/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
@@ -18,7 +18,7 @@ public struct TerminationFlowSurveyStepModelOption: FlowStepModel, Identifiable 
 enum TerminationFlowSurveyStepSuggestion: FlowStepModel {
     case action(action: TerminationFlowSurveyStepSuggestionAction)
     case redirect(redirect: TerminationFlowSurveyStepSuggestionRedirection)
-    case suggestInfo(info: TerminationFlowSurveyStepSuggestionInfo)
+    case suggestionInfo(info: TerminationFlowSurveyStepSuggestionInfo)
 }
 
 public struct TerminationFlowSurveyStepSuggestionAction: FlowStepModel {

--- a/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
+++ b/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
@@ -18,6 +18,7 @@ public struct TerminationFlowSurveyStepModelOption: FlowStepModel, Identifiable 
 enum TerminationFlowSurveyStepSuggestion: FlowStepModel {
     case action(action: TerminationFlowSurveyStepSuggestionAction)
     case redirect(redirect: TerminationFlowSurveyStepSuggestionRedirection)
+    case suggestInfo(info: TerminationFlowSurveyStepSuggestionInfo)
 }
 
 public struct TerminationFlowSurveyStepSuggestionAction: FlowStepModel {
@@ -25,6 +26,7 @@ public struct TerminationFlowSurveyStepSuggestionAction: FlowStepModel {
     public let action: FlowTerminationSurveyRedirectAction
     let description: String
     let buttonTitle: String
+    let type: SurveySuggestionInfoType
 }
 
 public enum FlowTerminationSurveyRedirectAction: FlowStepModel {
@@ -38,11 +40,23 @@ struct TerminationFlowSurveyStepSuggestionRedirection: FlowStepModel {
     let url: String
     let description: String
     let buttonTitle: String
+    let type: SurveySuggestionInfoType
+}
+
+struct TerminationFlowSurveyStepSuggestionInfo: FlowStepModel {
+    let id: String
+    let description: String
+    let type: SurveySuggestionInfoType
 }
 
 struct TerminationFlowSurveyStepFeedback: FlowStepModel {
     let id: String
     let isRequired: Bool
+}
+
+enum SurveySuggestionInfoType: Codable {
+    case info
+    case offer
 }
 
 public enum SurveyScreenSubtitleType: Codable, Sendable {

--- a/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
+++ b/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import hCore
+import hCoreUI
 
 public struct TerminationFlowSurveyStepModel: FlowStepModel {
     let id: String
@@ -57,6 +58,15 @@ struct TerminationFlowSurveyStepFeedback: FlowStepModel {
 enum SurveySuggestionInfoType: Codable {
     case info
     case offer
+
+    var notificationType: NotificationType {
+        switch self {
+        case .info:
+            return .info
+        case .offer:
+            return .campaign
+        }
+    }
 }
 
 public enum SurveyScreenSubtitleType: Codable, Sendable {

--- a/Projects/TerminateContracts/Sources/Service/OctopusImplementation/TerminateContractsClientOctopus.swift
+++ b/Projects/TerminateContracts/Sources/Service/OctopusImplementation/TerminateContractsClientOctopus.swift
@@ -239,7 +239,8 @@ extension OctopusGraphQL.FlowTerminationSurveyOptionSuggestionFragment {
                     id: optionActionSuggestion.id,
                     action: action,
                     description: description,
-                    buttonTitle: buttonTitle
+                    buttonTitle: buttonTitle,
+                    type: .offer
                 )
             )
         } else if let optionRedirectSuggestion = self.asFlowTerminationSurveyOptionSuggestionRedirect {
@@ -248,7 +249,8 @@ extension OctopusGraphQL.FlowTerminationSurveyOptionSuggestionFragment {
                     id: optionRedirectSuggestion.id,
                     url: optionRedirectSuggestion.url,
                     description: optionRedirectSuggestion.description,
-                    buttonTitle: optionRedirectSuggestion.buttonTitle
+                    buttonTitle: optionRedirectSuggestion.buttonTitle,
+                    type: .offer
                 )
             )
         }

--- a/Projects/TerminateContracts/Sources/Service/OctopusImplementation/TerminateContractsClientOctopus.swift
+++ b/Projects/TerminateContracts/Sources/Service/OctopusImplementation/TerminateContractsClientOctopus.swift
@@ -240,7 +240,7 @@ extension OctopusGraphQL.FlowTerminationSurveyOptionSuggestionFragment {
                     action: action,
                     description: description,
                     buttonTitle: buttonTitle,
-                    type: .offer
+                    type: optionActionSuggestion.infoType.value?.asInfoType ?? .offer
                 )
             )
         } else if let optionRedirectSuggestion = self.asFlowTerminationSurveyOptionSuggestionRedirect {
@@ -250,7 +250,15 @@ extension OctopusGraphQL.FlowTerminationSurveyOptionSuggestionFragment {
                     url: optionRedirectSuggestion.url,
                     description: optionRedirectSuggestion.description,
                     buttonTitle: optionRedirectSuggestion.buttonTitle,
-                    type: .offer
+                    type: optionRedirectSuggestion.infoType.value?.asInfoType ?? .offer
+                )
+            )
+        } else if let optionSuggestionInfo = self.asFlowTerminationSurveyOptionSuggestionInfo {
+            return .suggestionInfo(
+                info: .init(
+                    id: optionSuggestionInfo.id,
+                    description: optionSuggestionInfo.description,
+                    type: optionSuggestionInfo.infoType.value?.asInfoType ?? .offer
                 )
             )
         }
@@ -279,6 +287,15 @@ extension GraphQLEnum<OctopusGraphQL.FlowTerminationSurveyRedirectAction> {
 extension OctopusGraphQL.FlowTerminationSurveyOptionFeedbackFragment {
     var asFeedback: TerminationFlowSurveyStepFeedback? {
         .init(id: self.id, isRequired: self.isRequired)
+    }
+}
+
+extension OctopusGraphQL.FlowTerminationSurveyOptionSuggestionInfoType {
+    var asInfoType: SurveySuggestionInfoType {
+        switch self {
+        case .info: return .info
+        case .offer: return .offer
+        }
     }
 }
 

--- a/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
+++ b/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
@@ -64,7 +64,7 @@ struct TerminationSurveyScreen: View {
                                 .zIndex(1)
                                 Group {
                                     if let suggestion = option.suggestion, option.id == vm.selectedOption?.id {
-                                        buildInfo(for: suggestion)
+                                        suggestionView(for: suggestion)
                                             .matchedGeometryEffect(id: "buildInfo", in: animationNamespace)
                                     }
 
@@ -88,10 +88,10 @@ struct TerminationSurveyScreen: View {
     }
 
     @ViewBuilder
-    func buildInfo(for suggestion: TerminationFlowSurveyStepSuggestion) -> some View {
+    func suggestionView(for suggestion: TerminationFlowSurveyStepSuggestion) -> some View {
         switch suggestion {
         case .action(let action):
-            InfoCard(text: action.description, type: .campaign)
+            InfoCard(text: action.description, type: action.type == .offer ? .campaign : .info)
                 .buttons([
                     .init(
                         buttonTitle: action.buttonTitle,
@@ -102,7 +102,7 @@ struct TerminationSurveyScreen: View {
                 ])
                 .hButtonIsLoading(terminationFlowNavigationViewModel.redirectActionLoadingState == .loading)
         case .redirect(let redirect):
-            InfoCard(text: redirect.description, type: .campaign)
+            InfoCard(text: redirect.description, type: redirect.type == .offer ? .campaign : .info)
                 .buttons([
                     .init(
                         buttonTitle: redirect.buttonTitle,
@@ -114,6 +114,8 @@ struct TerminationSurveyScreen: View {
                     )
                 ])
                 .hButtonIsLoading(false)
+        case .suggestInfo(let info):
+            InfoCard(text: info.description, type: info.type == .offer ? .campaign : .info)
         }
     }
 
@@ -254,7 +256,8 @@ class SurveyScreenViewModel: ObservableObject {
                     id: "actionId",
                     action: .updateAddress,
                     description: "description",
-                    buttonTitle: "button title"
+                    buttonTitle: "button title",
+                    type: .offer
                 )
             ),
             feedBack: nil,
@@ -273,11 +276,14 @@ class SurveyScreenViewModel: ObservableObject {
         .init(
             id: "optionId3",
             title: "Option title 3",
-            suggestion: nil,
-            feedBack: .init(
-                id: "feedbackId",
-                isRequired: true
+            suggestion: .suggestInfo(
+                info: .init(
+                    id: "id",
+                    description: "description",
+                    type: .info
+                )
             ),
+            feedBack: nil,
             subOptions: nil
         ),
         .init(
@@ -295,6 +301,7 @@ class SurveyScreenViewModel: ObservableObject {
     return NavigationView {
         TerminationSurveyScreen(vm: .init(options: options, subtitleType: .default))
             .navigationBarTitleDisplayMode(.inline)
+            .environmentObject(TerminationFlowNavigationViewModel(configs: [], terminateInsuranceViewModel: .init()))
     }
 }
 

--- a/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
+++ b/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
@@ -68,7 +68,6 @@ struct TerminationSurveyScreen: View {
                     }
                     if let suggestion = vm.selectedOption?.suggestion {
                         suggestionView(for: suggestion)
-                            .matchedGeometryEffect(id: "buildInfo", in: animationNamespace)
                     }
 
                     if let optionId = vm.selectedOption?.id, let feedBack = vm.allFeedBackViewModels[optionId],
@@ -88,7 +87,7 @@ struct TerminationSurveyScreen: View {
     func suggestionView(for suggestion: TerminationFlowSurveyStepSuggestion) -> some View {
         switch suggestion {
         case .action(let action):
-            InfoCard(text: action.description, type: action.type == .offer ? .campaign : .info)
+            InfoCard(text: action.description, type: action.type.notificationType)
                 .buttons([
                     .init(
                         buttonTitle: action.buttonTitle,
@@ -99,7 +98,7 @@ struct TerminationSurveyScreen: View {
                 ])
                 .hButtonIsLoading(terminationFlowNavigationViewModel.redirectActionLoadingState == .loading)
         case .redirect(let redirect):
-            InfoCard(text: redirect.description, type: redirect.type == .offer ? .campaign : .info)
+            InfoCard(text: redirect.description, type: redirect.type.notificationType)
                 .buttons([
                     .init(
                         buttonTitle: redirect.buttonTitle,
@@ -112,7 +111,7 @@ struct TerminationSurveyScreen: View {
                 ])
                 .hButtonIsLoading(false)
         case .suggestionInfo(let info):
-            InfoCard(text: info.description, type: info.type == .offer ? .campaign : .info)
+            InfoCard(text: info.description, type: info.type.notificationType)
         }
     }
 

--- a/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
+++ b/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
@@ -62,24 +62,21 @@ struct TerminationSurveyScreen: View {
                                 )
                                 .hFieldSize(.medium)
                                 .zIndex(1)
-                                Group {
-                                    if let suggestion = option.suggestion, option.id == vm.selectedOption?.id {
-                                        suggestionView(for: suggestion)
-                                            .matchedGeometryEffect(id: "buildInfo", in: animationNamespace)
-                                    }
-
-                                    if let feedBack = vm.allFeedBackViewModels[option.id],
-                                        option.id == vm.selectedOption?.id
-                                    {
-                                        TerminationFlowSurveyStepFeedBackView(
-                                            vm: feedBack
-                                        )
-                                    }
-                                }
-                                .frame(minHeight: 120)
                             }
                         }
 
+                    }
+                    if let suggestion = vm.selectedOption?.suggestion {
+                        suggestionView(for: suggestion)
+                            .matchedGeometryEffect(id: "buildInfo", in: animationNamespace)
+                    }
+
+                    if let optionId = vm.selectedOption?.id, let feedBack = vm.allFeedBackViewModels[optionId],
+                        optionId == vm.selectedOption?.id
+                    {
+                        TerminationFlowSurveyStepFeedBackView(
+                            vm: feedBack
+                        )
                     }
                 }
             }
@@ -236,8 +233,16 @@ class SurveyScreenViewModel: ObservableObject {
             return true
         }()
 
-        if selectedOption?.suggestion != nil {
-            continueEnabled = false
+        if let suggestion = selectedOption?.suggestion {
+            switch suggestion {
+            case let .action(action):
+                if action.action == .updateAddress {
+                    continueEnabled = false
+                }
+                continueEnabled = true
+            default:
+                continueEnabled = true
+            }
         } else {
             continueEnabled = status
         }

--- a/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
+++ b/Projects/TerminateContracts/Sources/Views/TerminationSurveyScreen.swift
@@ -111,7 +111,7 @@ struct TerminationSurveyScreen: View {
                     )
                 ])
                 .hButtonIsLoading(false)
-        case .suggestInfo(let info):
+        case .suggestionInfo(let info):
             InfoCard(text: info.description, type: info.type == .offer ? .campaign : .info)
         }
     }
@@ -281,7 +281,7 @@ class SurveyScreenViewModel: ObservableObject {
         .init(
             id: "optionId3",
             title: "Option title 3",
-            suggestion: .suggestInfo(
+            suggestion: .suggestionInfo(
                 info: .init(
                     id: "id",
                     description: "description",

--- a/Projects/hCore/Sources/DeepLink.swift
+++ b/Projects/hCore/Sources/DeepLink.swift
@@ -78,12 +78,7 @@ public enum DeepLink: String, Codable, CaseIterable {
     @MainActor
     public static func getType(from url: URL) -> DeepLink? {
         guard Environment.staging.isDeeplink(url) || Environment.production.isDeeplink(url) else { return nil }
-
-        let components = url.pathComponents
-            .filter {
-                $0 != "/" && $0 != "deeplink"
-            }
-            .joined(separator: "/")
+        let components = url.pathComponents.filter { $0 != "/" }.filter({ $0 != "deeplink" }).joined(separator: "/")
 
         guard let type = DeepLink(rawValue: components) else {
             return nil

--- a/Projects/hCore/Sources/DeepLink.swift
+++ b/Projects/hCore/Sources/DeepLink.swift
@@ -78,7 +78,13 @@ public enum DeepLink: String, Codable, CaseIterable {
     @MainActor
     public static func getType(from url: URL) -> DeepLink? {
         guard Environment.staging.isDeeplink(url) || Environment.production.isDeeplink(url) else { return nil }
-        let components = url.pathComponents.filter { $0 != "/" }.joined(separator: "/")
+
+        let components = url.pathComponents
+            .filter {
+                $0 != "/" && $0 != "deeplink"
+            }
+            .joined(separator: "/")
+
         guard let type = DeepLink(rawValue: components) else {
             return nil
         }


### PR DESCRIPTION
## [GEN-3291]

- Updated design in termination survey flow for suggestions (info cards)
- We want to use both campaign (green) and info cards (blue) and have with and without buttons
- [Figma](https://www.figma.com/design/zItETkT4mu5ANVDYED5gEm/Retention-UX-Improvements-App?node-id=27-4697&t=iDNAaZcU3PVEKdCR-0)

##Blockers
- Waiting for graphQL implementation on backend

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
