### PR TITLE
remove number if perilCover is only one

### DIFF
--- a/Projects/hCoreUI/Sources/Peril/Accordion.swift
+++ b/Projects/hCoreUI/Sources/Peril/Accordion.swift
@@ -109,8 +109,10 @@ struct AccordionButtonStyle: SwiftUI.ButtonStyle {
                     if let perilCover = peril?.covered {
                         ForEach(Array(perilCover.enumerated()), id: \.offset) { index, item in
                             HStack(alignment: .top, spacing: 8) {
-                                hText(String(format: "%02d", index + 1), style: .label)
-                                    .foregroundColor(hTextColor.Opaque.tertiary)
+                                if perilCover.count > 1 {
+                                    hText(String(format: "%02d", index + 1), style: .label)
+                                        .foregroundColor(hTextColor.Opaque.tertiary)
+                                }
                                 hText(item, style: .label)
                             }
                         }

--- a/Projects/hCoreUI/Sources/Peril/PerilCollection.swift
+++ b/Projects/hCoreUI/Sources/Peril/PerilCollection.swift
@@ -29,7 +29,9 @@ struct PerilCollection_Previews: PreviewProvider {
                     title: "title",
                     description: "lkflihf uhreuidhf iwureahriur ekfshiuf erhfw iueherfuihgfeuihfgrui fruhfiuehf",
                     color: "#C45F4F",
-                    covered: []
+                    covered: [
+                        "covered 1"
+                    ]
                 ),
                 .init(
                     id: "2",


### PR DESCRIPTION
## [APP-XXX]

- Remove number if we only have one cover item

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
