### PR TITLE
Added error screen if we end up on screen without any contracts

### DIFF
--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -288,10 +288,19 @@ public struct ChangeTierNavigation: View {
     private var wrapperHost: some View {
         Group {
             if let changeTierContracts = changeTierNavigationVm.changeTierContractsInput {
-                SelectInsuranceScreen(changeTierContractsInput: changeTierContracts)
-                    .routerDestination(for: ChangeTierContract.self) { changeTierContract in
-                        getScreen
-                    }
+                if changeTierContracts.contracts.isEmpty {
+                    GenericErrorView(
+                        title: L10n.somethingWentWrong,
+                        description: L10n.General.defaultError,
+                        formPosition: .center
+                    )
+                    .withDismissButton()
+                } else {
+                    SelectInsuranceScreen(changeTierContractsInput: changeTierContracts)
+                        .routerDestination(for: ChangeTierContract.self) { changeTierContract in
+                            getScreen
+                        }
+                }
             } else {
                 getScreen
             }


### PR DESCRIPTION
## [APP-XXX]

- It happens that we are missing contracts when opening change tier

This happens if we open deeplink https://hedvig.page.link/change-tier and we don't have any contracts
This is a quick fix, have a nice bottom sheet instead 

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
