### PR TITLE
Added small delay when adding addon since BE can take some async time

### DIFF
--- a/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
+++ b/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
@@ -48,10 +48,13 @@ public class ChangeAddonViewModel: ObservableObject {
                 quoteId: selectedQuote?.quoteId ?? "",
                 addonId: selectedQuote?.addonId ?? ""
             )
-            NotificationCenter.default.post(
-                name: .addonAdded,
-                object: nil
-            )
+            Task {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                NotificationCenter.default.post(
+                    name: .addonAdded,
+                    object: nil
+                )
+            }
             withAnimation {
                 self.submittingAddonsViewState = .success
             }

--- a/Projects/Contracts/Sources/View/ContractTable.swift
+++ b/Projects/Contracts/Sources/View/ContractTable.swift
@@ -215,6 +215,10 @@ public class ContractTableViewModel: ObservableObject {
             Task {
                 await self?.getAddonBanner()
             }
+            Task {
+                let store: ContractStore = await globalPresentableStoreContainer.get()
+                store.send(.fetchContracts)
+            }
         }
     }
 


### PR DESCRIPTION
## [APP-XXX]

BE should immediately give us a new contract info when adding addon, but it happens that it take some time sometimes so adding delay to refresh after 1s. Also we have success screen anyway so it will not create any confusion for the member 

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
