### PR TITLE
Fixed not working select insurances screen for addons

### DIFF
--- a/Projects/Addons/Sources/Navigation/ChangeAddonNavigation.swift
+++ b/Projects/Addons/Sources/Navigation/ChangeAddonNavigation.swift
@@ -162,13 +162,8 @@ public struct ChangeAddonNavigation: View {
     }
 
     private var selectInsuranceScreen: some View {
-        AddonSelectInsuranceScreen(
-            changeAddonVm: changeAddonNavigationVm.changeAddonVm
-                ?? .init(
-                    contractId: changeAddonNavigationVm.input.contractConfigs?.first?.contractId ?? ""
-                )
-        )
-        .withDismissButton()
+        AddonSelectInsuranceScreen()
+            .withDismissButton()
     }
 }
 


### PR DESCRIPTION
## [APP-XXX]

- Select insurance for addons didn't work, fixed in this PR

how to test: replace following code inside `ChangeAddonNavigation` when starting any addon flow
```
    public init(
        input: ChangeAddonInput
    ) {
        self.changeAddonNavigationVm = .init(input: input)
    }
```

with
```
    public init(
        input: ChangeAddonInput
    ) {
        var testConfig = input.contractConfigs ?? []
        testConfig.append(.init(contractId: "test", exposureName: "exp", displayName: "dis"))
        self.changeAddonNavigationVm = .init(input: .init(contractConfigs: testConfig))
    }
```

and select first option and continue

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
