### PR TITLE
Set deductible percentage to nil if value is 0

### DIFF
--- a/Projects/ChangeTier/Sources/Service/OctopusImplementation/ChangeTierClientOctopus.swift
+++ b/Projects/ChangeTier/Sources/Service/OctopusImplementation/ChangeTierClientOctopus.swift
@@ -60,7 +60,8 @@ public class ChangeTierClientOctopus: ChangeTierClient {
                             quoteAmount: .init(
                                 optionalFragment: intent.agreementToChange.deductible?.amount.fragments.moneyFragment
                             ),
-                            quotePercentage: intent.agreementToChange.deductible?.percentage,
+                            quotePercentage: (intent.agreementToChange.deductible?.percentage == 0)
+                                ? nil : intent.agreementToChange.deductible?.percentage,
                             subTitle: nil,
                             basePremium: .init(fragment: intent.agreementToChange.basePremium.fragments.moneyFragment),
                             displayItems: [],


### PR DESCRIPTION
## [APP-XXX]

- Fix for this [issue](https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1740041137641069)
- Deductible percentage should be set to nil if value is 0
 
## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
