### PR TITLE
Logout from the app only when error is caused by non network issues

### DIFF
--- a/Projects/Authentication/Sources/Service/OctopusImplementation/AuthenticationClientAuthLib.swift
+++ b/Projects/Authentication/Sources/Service/OctopusImplementation/AuthenticationClientAuthLib.swift
@@ -280,8 +280,12 @@ final public class AuthenticationClientAuthLib: AuthenticationClient {
             ApolloClient.handleAuthTokenSuccessResult(result: accessTokenDto)
         case .error(let error):
             log.error("Refreshing failed \(error.errorMessage), forcing logout")
-            forceLogoutHook()
-            throw AuthError.refreshFailed
+            switch onEnum(of: error) {
+            case .iOError:
+                throw AuthError.networkIssue
+            case .backendErrorResponse, .unknownError:
+                throw AuthError.refreshFailed
+            }
         }
     }
 }

--- a/Projects/hGraphQL/Sources/Apollo Extensions/ApolloClient+Fetch.swift
+++ b/Projects/hGraphQL/Sources/Apollo Extensions/ApolloClient+Fetch.swift
@@ -92,6 +92,15 @@ extension ApolloClient {
                 break
             case .refreshFailed:
                 log.error("graphQL error \(operation)", error: error, attributes: [:])
+            case .networkIssue:
+                log.info("graphQL error \(operation)", error: error, attributes: [:])
+            }
+        } else if let error = error as? URLSessionClient.URLSessionClientError {
+            switch error {
+            case .networkError:
+                log.info("graphQL error \(operation)", error: error, attributes: [:])
+            default:
+                log.error("graphQL error \(operation)", error: error, attributes: [:])
             }
         } else {
             log.error("graphQL error \(operation)", error: error, attributes: [:])

--- a/Projects/hGraphQL/Sources/HeadersInterceptor.swift
+++ b/Projects/hGraphQL/Sources/HeadersInterceptor.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum AuthError: Error {
     case refreshTokenExpired
     case refreshFailed
+    case networkIssue
 }
 
 class HeadersInterceptor: @preconcurrency ApolloInterceptor {


### PR DESCRIPTION
## [APP-XXX]

When member has:
- bad internet connection which causes different network related errors
- app is sent to the background and refreshing of the token is not performed

we get IOError from the authLib. This error shouldn't logout member, just show errors in the app.

[datadog](https://app.datadoghq.eu/logs?query=service%3Aios%20%22IO%20Error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1739797756318&to_ts=1740402556318&live=true)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
