### PR TITLE
Fixed discounts with the same code

### DIFF
--- a/Projects/Payment/Sources/Models/PaymentData.swift
+++ b/Projects/Payment/Sources/Models/PaymentData.swift
@@ -93,13 +93,14 @@ public struct PaymentData: Codable, Equatable, Hashable, Sendable {
 }
 
 public struct Discount: Codable, Equatable, Identifiable, Hashable, Sendable {
-    public let id: String
+    public let id = UUID().uuidString
     let code: String
     let amount: MonetaryAmount?
     let title: String?
     let listOfAffectedInsurances: [AffectedInsurance]
     let validUntil: ServerBasedDate?
     let canBeDeleted: Bool
+    let discountId: String
 
     @MainActor
     var isValid: Bool {

--- a/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsDiscount.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsDiscount.swift
@@ -123,7 +123,6 @@ struct PaymentDetailsDiscount_Previews: PreviewProvider {
     static var previews: some View {
         Dependencies.shared.add(module: Module { () -> hCampaignClient in hCampaignClientDemo() })
         let discount: Discount = .init(
-            id: "1",
             code: "231223",
             amount: .sek(100),
             title: "23",
@@ -132,7 +131,8 @@ struct PaymentDetailsDiscount_Previews: PreviewProvider {
                 .init(id: "id 12", displayName: "DISPLAY NAME 2"),
             ],
             validUntil: "2023-12-06",
-            canBeDeleted: false
+            canBeDeleted: false,
+            discountId: "1"
         )
         return PaymentDetailsDiscountView(vm: .init(options: [.showExpire, .forPayment], discount: discount))
     }

--- a/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsView.swift
@@ -281,7 +281,6 @@ struct PaymentDetails_Previews: PreviewProvider {
             ],
             discounts: [
                 .init(
-                    id: "CODE",
                     code: "CODE",
                     amount: .sek(100),
                     title: "Title",
@@ -289,10 +288,10 @@ struct PaymentDetails_Previews: PreviewProvider {
                         .init(id: "1", displayName: "Car 15%")
                     ],
                     validUntil: "2023-11-20",
-                    canBeDeleted: false
+                    canBeDeleted: false,
+                    discountId: "CODE"
                 ),
                 .init(
-                    id: "CODE2",
                     code: "CODE2",
                     amount: .sek(99),
                     title: "Title1",
@@ -300,17 +299,17 @@ struct PaymentDetails_Previews: PreviewProvider {
                         .init(id: "2", displayName: "House 15%")
                     ],
                     validUntil: "2023-11-22",
-                    canBeDeleted: false
+                    canBeDeleted: false,
+                    discountId: "CODE2"
                 ),
                 .init(
-                    id: "FRIENDS",
                     code: "MY CODE",
                     amount: .sek(30),
                     title: "3 friends invited",
                     listOfAffectedInsurances: [],
                     validUntil: nil,
-                    canBeDeleted: false
-
+                    canBeDeleted: false,
+                    discountId: "FRIENDS"
                 ),
             ],
             paymentDetails: nil,

--- a/Projects/Payment/Sources/Screens/PaymentDiscounts/DeleteCampaignView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDiscounts/DeleteCampaignView.swift
@@ -102,7 +102,7 @@ class DeleteCampaignViewModel: ObservableObject {
 
         do {
             error = nil
-            try await campaignService.remove(codeId: discount.id)
+            try await campaignService.remove(codeId: discount.discountId)
             store.send(.load)
             store.send(.fetchDiscountsData)
             withAnimation {
@@ -133,13 +133,13 @@ struct DeleteCampaignView_Previews: PreviewProvider {
         DeleteCampaignView(
             vm: .init(
                 discount: .init(
-                    id: "id",
                     code: "CODE",
                     amount: nil,
                     title: "Title",
                     listOfAffectedInsurances: [],
                     validUntil: nil,
-                    canBeDeleted: false
+                    canBeDeleted: false,
+                    discountId: "id"
                 )
             )
         )

--- a/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
@@ -131,7 +131,6 @@ struct PaymentsDiscountView_Previews: PreviewProvider {
             data: .init(
                 discounts: [
                     .init(
-                        id: "id",
                         code: "code",
                         amount: .sek(100),
                         title: "title",
@@ -139,10 +138,10 @@ struct PaymentsDiscountView_Previews: PreviewProvider {
                             .init(id: "id1", displayName: "name")
                         ],
                         validUntil: "2023-11-10",
-                        canBeDeleted: true
+                        canBeDeleted: true,
+                        discountId: "id"
                     ),
                     .init(
-                        id: "id2",
                         code: "code 2",
                         amount: .sek(100),
                         title: "title 2",
@@ -150,7 +149,8 @@ struct PaymentsDiscountView_Previews: PreviewProvider {
                             .init(id: "id21", displayName: "name 2")
                         ],
                         validUntil: "2023-11-03",
-                        canBeDeleted: false
+                        canBeDeleted: false,
+                        discountId: "id2"
                     ),
                 ],
                 referralsData: .init(

--- a/Projects/Payment/Sources/Service/PaymentService/DemoImplementation/PaymentClientDemo.swift
+++ b/Projects/Payment/Sources/Service/PaymentService/DemoImplementation/PaymentClientDemo.swift
@@ -52,13 +52,13 @@ public class hPaymentClientDemo: hPaymentClient {
                 ],
                 discounts: [
                     .init(
-                        id: "CODE 2",
                         code: "CODE 2",
                         amount: .sek(30),
                         title: "15% off for 1 year",
                         listOfAffectedInsurances: [.init(id: "1", displayName: "Bastugatan 25 ∙ Bara du")],
                         validUntil: "2025-12-31",
-                        canBeDeleted: false
+                        canBeDeleted: false,
+                        discountId: "CODE 2"
                     )
                 ],
                 paymentDetails: .init(paymentMethod: "Autogiro", account: "****124124", bank: "Handelsbanken"),
@@ -111,13 +111,13 @@ public class hPaymentClientDemo: hPaymentClient {
                     ],
                     discounts: [
                         .init(
-                            id: "CODE 2",
                             code: "CODE 2",
                             amount: .sek(30),
                             title: "15% off for 1 year",
                             listOfAffectedInsurances: [.init(id: "1", displayName: "Bastugatan 25 ∙ Bara du")],
                             validUntil: "2025-12-31",
-                            canBeDeleted: false
+                            canBeDeleted: false,
+                            discountId: "CODE 2"
                         )
                     ],
                     paymentDetails: nil,
@@ -141,22 +141,22 @@ public class hPaymentClientDemo: hPaymentClient {
         return .init(
             discounts: [
                 .init(
-                    id: "CODE",
                     code: "CODE",
                     amount: .sek(30),
                     title: "15% off for 1 year",
                     listOfAffectedInsurances: [.init(id: "1", displayName: "Car Insurance * ABH 234")],
                     validUntil: "2023-12-10",
-                    canBeDeleted: true
+                    canBeDeleted: true,
+                    discountId: "CODE"
                 ),
                 .init(
-                    id: "CODE 2",
                     code: "CODE 2",
                     amount: .sek(30),
                     title: "15% off for 1 year",
                     listOfAffectedInsurances: [.init(id: "1", displayName: "Home insurace &*")],
                     validUntil: "2023-11-03",
-                    canBeDeleted: false
+                    canBeDeleted: false,
+                    discountId: "CODE 2"
                 ),
             ],
             referralsData: .init(

--- a/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentData+octopus.swift
+++ b/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentData+octopus.swift
@@ -161,7 +161,6 @@ extension Discount {
         with data: OctopusGraphQL.MemberChargeFragment.DiscountBreakdown,
         discount: OctopusGraphQL.PaymentDataQuery.Data.CurrentMember.RedeemedCampaign?
     ) {
-        id = UUID().uuidString
         code = data.code ?? discount?.code ?? ""
         amount = .init(fragment: data.discount.fragments.moneyFragment)
         title = discount?.description
@@ -170,19 +169,20 @@ extension Discount {
             ?? []
         validUntil = nil
         canBeDeleted = false
+        discountId = UUID().uuidString
     }
 
     init(
         with data: OctopusGraphQL.MemberChargeFragment.DiscountBreakdown,
         discountDto discount: ReedeemedCampaingDTO?
     ) {
-        id = UUID().uuidString
         code = data.code ?? discount?.code ?? ""
         amount = .init(fragment: data.discount.fragments.moneyFragment)
         title = discount?.description ?? ""
         listOfAffectedInsurances = []
         validUntil = nil
         canBeDeleted = false
+        discountId = UUID().uuidString
     }
 
 }

--- a/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentDiscountData+octopus.swift
+++ b/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentDiscountData+octopus.swift
@@ -19,7 +19,7 @@ extension Discount {
         self.amount = amountFromPaymentData
         self.canBeDeleted = true
         self.code = data.code
-        self.id = data.id
+        self.discountId = data.id
         self.listOfAffectedInsurances =
             data.onlyApplicableToContracts?.compactMap({ .init(id: $0.id, displayName: $0.exposureDisplayName) }) ?? []
         self.title = data.description

--- a/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentHistoryData+octopus.swift
+++ b/Projects/Payment/Sources/Service/PaymentService/OctopusImplementation/PaymentHistoryData+octopus.swift
@@ -85,13 +85,13 @@ extension Discount {
         with data: OctopusGraphQL.MemberChargeFragment.DiscountBreakdown,
         discount: OctopusGraphQL.ReedemCampaignsFragment.RedeemedCampaign?
     ) {
-        id = UUID().uuidString
         code = data.code ?? discount?.code ?? ""
         amount = .init(fragment: data.discount.fragments.moneyFragment)
         title = discount?.description ?? ""
         listOfAffectedInsurances = []
         validUntil = nil
         canBeDeleted = false
+        discountId = UUID().uuidString
     }
 
 }


### PR DESCRIPTION
- It can happen that we get 2 discounts with the same id
Make a id that is always unique and don't depend on the id of the discount ( which is odd to have same for 2 records )

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
