### PR TITLE
Rename hWithoutHorizontalPadding to hRowWithoutHorizontalPadding

### DIFF
--- a/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
@@ -91,7 +91,7 @@ public struct ChangeTierLandingScreen: View {
                 }
                 .hFieldSize(.small)
                 .hBackgroundOption(option: (colorScheme == .light) ? [.negative] : [.secondary])
-                .hWithoutHorizontalPadding
+                .hRowWithoutHorizontalPadding
 
                 hRow {
                     PriceField(

--- a/Projects/ChangeTier/Sources/Views/CompareTierScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/CompareTierScreen.swift
@@ -48,7 +48,7 @@ struct CompareTierScreen: View {
         .sectionContainerStyle(.transparent)
         .padding(.bottom, .padding24)
         .hWithoutDividerPadding
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .accessibilityHint(L10n.tierFlowCoverageLabel + tierName)
     }
 

--- a/Projects/Contracts/Sources/View/ContractCoverage.swift
+++ b/Projects/Contracts/Sources/View/ContractCoverage.swift
@@ -24,7 +24,7 @@ struct ContractCoverageView: View {
                     },
                     perils: contract.allPerils
                 )
-                .hWithoutHorizontalPadding
+                .hRowWithoutHorizontalPadding
             }
         }
     }

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -86,7 +86,7 @@ struct ContractInformationView: View {
                             .padding(.bottom, .padding16)
                         }
                     }
-                    .hWithoutHorizontalPadding
+                    .hRowWithoutHorizontalPadding
                 }
             }
         }

--- a/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
+++ b/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
@@ -58,7 +58,7 @@ struct UpcomingChangesScreen: View {
             }
             .padding(.top, .padding16)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .hWithoutDividerPadding
     }
 }

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
@@ -94,7 +94,7 @@ struct QuestionsItems: View {
                         log.info("question clicked", error: nil, attributes: ["helpCenter": attributes])
                         router.push(item)
                     }
-                    .hWithoutHorizontalPadding
+                    .hRowWithoutHorizontalPadding
                     .hWithoutDividerPadding
                 }
                 .hSectionWithoutHorizontalPadding

--- a/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsDiscount.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsDiscount.swift
@@ -71,7 +71,7 @@ struct PaymentDetailsDiscountView: View {
             }
             .foregroundColor(hTextColor.Opaque.secondary)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .dividerInsets(.all, 0)
     }
 

--- a/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsView.swift
@@ -94,7 +94,7 @@ struct PaymentDetailsView: View {
                     InfoCard(text: L10n.paymentsCarriedAdjustmentInfo, type: .info)
                 }
             }
-            .hWithoutHorizontalPadding
+            .hRowWithoutHorizontalPadding
         }
     }
 
@@ -111,7 +111,7 @@ struct PaymentDetailsView: View {
                     InfoCard(text: L10n.paymentsSettlementAdjustmentInfo, type: .info)
                 }
             }
-            .hWithoutHorizontalPadding
+            .hRowWithoutHorizontalPadding
         }
     }
 
@@ -137,7 +137,7 @@ struct PaymentDetailsView: View {
                 hText(" ")
             }
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .accessibilityElement(children: .combine)
     }
 
@@ -162,7 +162,7 @@ struct PaymentDetailsView: View {
                 }
             }
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .accessibilityElement(children: .combine)
     }
 
@@ -191,7 +191,7 @@ struct PaymentDetailsView: View {
                         .foregroundColor(hTextColor.Opaque.secondary)
                 }
             }
-            .hWithoutHorizontalPadding
+            .hRowWithoutHorizontalPadding
             .dividerInsets(.all, 0)
 
             list.append((item.key, AnyView(view)))
@@ -211,7 +211,7 @@ struct PaymentDetailsView: View {
                 .foregroundColor(hTextColor.Opaque.secondary)
             }
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
     }
 }
 

--- a/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDiscounts/PaymentsDiscountsView.swift
@@ -119,7 +119,7 @@ struct PaymentsDiscountsView: View {
         hRow {
             ReferralView(referral: referral)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .dividerInsets(.all, 0)
     }
 }

--- a/Projects/Payment/Sources/Screens/PaymentsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsView.swift
@@ -145,7 +145,7 @@ public struct PaymentsView: View {
         .onTap {
             router.push(PaymentsRouterAction.discounts)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .dividerInsets(.all, 0)
 
     }
@@ -161,7 +161,7 @@ public struct PaymentsView: View {
         .onTap {
             router.push(PaymentsRouterAction.history)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .dividerInsets(.all, 0)
     }
 
@@ -179,7 +179,7 @@ public struct PaymentsView: View {
         .withCustomAccessory {
             hText(descriptor).foregroundColor(hTextColor.Opaque.secondary)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .dividerInsets(.all, 0)
     }
 

--- a/Projects/Profile/Sources/Views/Screens/AppInfo/AppInfoView.swift
+++ b/Projects/Profile/Sources/Views/Screens/AppInfo/AppInfoView.swift
@@ -20,7 +20,7 @@ public struct AppInfoView: View {
             }
             .padding(.top, .padding8)
         }
-        .hWithoutHorizontalPadding
+        .hRowWithoutHorizontalPadding
         .hWithoutDividerPadding
         .sectionContainerStyle(.transparent)
         .hFormAlwaysAttachToBottom {

--- a/Projects/Profile/Sources/Views/Screens/Profile/Profile.swift
+++ b/Projects/Profile/Sources/Views/Screens/Profile/Profile.swift
@@ -48,7 +48,7 @@ public struct ProfileView: View {
                 }
                 .sectionContainerStyle(.transparent)
                 .padding(.top, .padding16)
-                .hWithoutHorizontalPadding
+                .hRowWithoutHorizontalPadding
                 .hWithoutDividerPadding
             }
         }

--- a/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
+++ b/Projects/hCoreUI/Sources/ToggleStyles/CheckboxToggleStyle.swift
@@ -20,7 +20,7 @@ public struct CheckboxToggleStyle: ToggleStyle {
                 configuration.label
             }
             .verticalPadding(0)
-            .hWithoutHorizontalPadding
+            .hRowWithoutHorizontalPadding
             .padding(.top, getTopPadding)
             .padding(.bottom, getBottomPadding)
             .padding(.horizontal, getHorizontalPadding)

--- a/Projects/hCoreUI/Sources/hForm/hRow.swift
+++ b/Projects/hCoreUI/Sources/hForm/hRow.swift
@@ -39,7 +39,7 @@ struct RowButtonStyle: SwiftUI.ButtonStyle {
 public struct hRow<Content: View, Accessory: View>: View {
     @SwiftUI.Environment(\.hRowPosition) var position: hRowPosition
     @Environment(\.hWithoutDivider) var hWithoutDivider
-    @Environment(\.hWithoutHorizontalPadding) var withoutHorizontalPadding
+    @Environment(\.hRowWithoutHorizontalPadding) var hRowWithoutHorizontalPadding
 
     var content: Content
     var accessory: Accessory
@@ -91,7 +91,7 @@ public struct hRow<Content: View, Accessory: View>: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, withoutHorizontalPadding ? 0 : horizontalPadding)
+            .padding(.horizontal, hRowWithoutHorizontalPadding ? 0 : horizontalPadding)
             .padding(.vertical, verticalPadding)
             .padding(.top, topPadding)
             .padding(.bottom, bottomPadding)

--- a/Projects/hCoreUI/Sources/hForm/hSection.swift
+++ b/Projects/hCoreUI/Sources/hForm/hSection.swift
@@ -309,15 +309,15 @@ private struct EnvironmentHWithoutHorizontalPadding: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    public var hWithoutHorizontalPadding: Bool {
+    public var hRowWithoutHorizontalPadding: Bool {
         get { self[EnvironmentHWithoutHorizontalPadding.self] }
         set { self[EnvironmentHWithoutHorizontalPadding.self] = newValue }
     }
 }
 
 extension View {
-    public var hWithoutHorizontalPadding: some View {
-        self.environment(\.hWithoutHorizontalPadding, true)
+    public var hRowWithoutHorizontalPadding: some View {
+        self.environment(\.hRowWithoutHorizontalPadding, true)
     }
 }
 


### PR DESCRIPTION
## [APP-XXX]

- Renaming of hWithoutHorizontalPadding to hRowWithoutHorizontalPadding to make it more readable since we also have hSectionWithoutHorizontalPadding

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
