### PR TITLE
GEN-3411: Added preselected contract id for contract step in ClaimFlow + refactor ItemPickerScreen

### DIFF
--- a/Projects/Addons/Sources/Navigation/ChangeAddonNavigation.swift
+++ b/Projects/Addons/Sources/Navigation/ChangeAddonNavigation.swift
@@ -165,7 +165,7 @@ public struct ChangeAddonNavigation: View {
     }
 
     private var selectInsuranceScreen: some View {
-        AddonSelectInsuranceScreen()
+        AddonSelectInsuranceScreen(changeAddonNavigationVm: changeAddonNavigationVm)
             .withDismissButton()
     }
 }

--- a/Projects/Addons/Sources/Views/AddonSelectInsuranceScreen.swift
+++ b/Projects/Addons/Sources/Views/AddonSelectInsuranceScreen.swift
@@ -4,12 +4,61 @@ import hCore
 import hCoreUI
 
 public struct AddonSelectInsuranceScreen: View {
-    @EnvironmentObject var changeAddonNavigationVm: ChangeAddonNavigationViewModel
-    @StateObject var vm = AddonSelectInsuranceScreenViewModel()
+    @ObservedObject var changeAddonNavigationVm: ChangeAddonNavigationViewModel
+    @ObservedObject var vm: AddonSelectInsuranceScreenViewModel
+    let itemConfig: ItemConfig<AddonConfig>
 
+    init(
+        changeAddonNavigationVm: ChangeAddonNavigationViewModel,
+        vm: AddonSelectInsuranceScreenViewModel = AddonSelectInsuranceScreenViewModel()
+    ) {
+        self.changeAddonNavigationVm = changeAddonNavigationVm
+        self.vm = vm
+        self.itemConfig = .init(
+            items: {
+                let addonContractConfigs: [AddonConfig] = changeAddonNavigationVm.input.contractConfigs ?? []
+                let items = addonContractConfigs.map({
+                    (
+                        object: $0,
+                        displayName: ItemModel(
+                            title: $0.displayName,
+                            subTitle: $0.exposureName
+                        )
+                    )
+                })
+
+                return items
+            }(),
+            preSelectedItems: { vm.selectedItems },
+            onSelected: { selected in
+                if let selectedContract = selected.first?.0 {
+                    vm.selectedItems = selected.compactMap({ $0.0 })
+                    changeAddonNavigationVm.changeAddonVm = .init(
+                        contractId: selectedContract.contractId,
+                        addonSource: changeAddonNavigationVm.input.addonSource
+                    )
+                    vm.observer = changeAddonNavigationVm.changeAddonVm!.$fetchAddonsViewState
+                        .sink { [weak vm] value in
+                            withAnimation {
+                                vm?.processingState = value
+                            }
+                            if value == .success {
+                                changeAddonNavigationVm.router.push(ChangeAddonRouterActions.addonLandingScreen)
+                                vm?.observer = nil
+                            }
+                        }
+                }
+            },
+            singleSelect: true,
+            attachToBottom: true,
+            disableIfNoneSelected: true,
+            hButtonText: L10n.generalContinueButton,
+            fieldSize: .small
+        )
+    }
     public var body: some View {
         successView
-            .loading($vm.processingState)
+            .loadingWithButtonLoading($vm.processingState)
             .hStateViewButtonConfig(
                 .init(
                     actionButton: .init(
@@ -26,47 +75,7 @@ public struct AddonSelectInsuranceScreen: View {
 
     private var successView: some View {
         ItemPickerScreen<AddonConfig>(
-            config: .init(
-                items: {
-                    let addonContractConfigs: [AddonConfig] = changeAddonNavigationVm.input.contractConfigs ?? []
-                    let items = addonContractConfigs.map({
-                        (
-                            object: $0,
-                            displayName: ItemModel(
-                                title: $0.displayName,
-                                subTitle: $0.exposureName
-                            )
-                        )
-                    })
-
-                    return items
-                }(),
-                preSelectedItems: { vm.selectedItems },
-                onSelected: { selected in
-                    if let selectedContract = selected.first?.0 {
-                        vm.selectedItems = selected.compactMap({ $0.0 })
-                        changeAddonNavigationVm.changeAddonVm = .init(
-                            contractId: selectedContract.contractId,
-                            addonSource: changeAddonNavigationVm.input.addonSource
-                        )
-                        vm.observer = changeAddonNavigationVm.changeAddonVm!.$fetchAddonsViewState
-                            .sink { [weak vm] value in
-                                withAnimation {
-                                    vm?.processingState = value
-                                }
-                                if value == .success {
-                                    changeAddonNavigationVm.router.push(ChangeAddonRouterActions.addonLandingScreen)
-                                    vm?.observer = nil
-                                }
-                            }
-                    }
-                },
-                singleSelect: true,
-                attachToBottom: true,
-                disableIfNoneSelected: true,
-                hButtonText: L10n.generalContinueButton,
-                fieldSize: .small
-            )
+            config: itemConfig
         )
         .hFormTitle(
             title: .init(.small, .heading2, L10n.addonFlowSelectInsuranceTitle, alignment: .leading),
@@ -85,17 +94,16 @@ class AddonSelectInsuranceScreenViewModel: ObservableObject {
 #Preview {
     Dependencies.shared.add(module: Module { () -> AddonsClient in AddonsClientDemo() })
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
-    return AddonSelectInsuranceScreen()
-        .environmentObject(
-            ChangeAddonNavigationViewModel(
-                input: .init(
-                    addonSource: .insurances,
-                    contractConfigs: [
-                        .init(contractId: "1", exposureName: "1", displayName: "1"),
-                        .init(contractId: "2", exposureName: "2", displayName: "2"),
+    return AddonSelectInsuranceScreen(
+        changeAddonNavigationVm: ChangeAddonNavigationViewModel(
+            input: .init(
+                addonSource: .insurances,
+                contractConfigs: [
+                    .init(contractId: "1", exposureName: "1", displayName: "1"),
+                    .init(contractId: "2", exposureName: "2", displayName: "2"),
 
-                    ]
-                )
+                ]
             )
         )
+    )
 }

--- a/Projects/Addons/Sources/Views/AddonSelectInsuranceScreen.swift
+++ b/Projects/Addons/Sources/Views/AddonSelectInsuranceScreen.swift
@@ -6,7 +6,7 @@ import hCoreUI
 public struct AddonSelectInsuranceScreen: View {
     @ObservedObject var changeAddonNavigationVm: ChangeAddonNavigationViewModel
     @ObservedObject var vm: AddonSelectInsuranceScreenViewModel
-    let itemConfig: ItemConfig<AddonConfig>
+    let itemPickerConfig: ItemConfig<AddonConfig>
 
     init(
         changeAddonNavigationVm: ChangeAddonNavigationViewModel,
@@ -14,7 +14,7 @@ public struct AddonSelectInsuranceScreen: View {
     ) {
         self.changeAddonNavigationVm = changeAddonNavigationVm
         self.vm = vm
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 let addonContractConfigs: [AddonConfig] = changeAddonNavigationVm.input.contractConfigs ?? []
                 let items = addonContractConfigs.map({
@@ -75,7 +75,7 @@ public struct AddonSelectInsuranceScreen: View {
 
     private var successView: some View {
         ItemPickerScreen<AddonConfig>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .hFormTitle(
             title: .init(.small, .heading2, L10n.addonFlowSelectInsuranceTitle, alignment: .leading),

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -291,10 +291,13 @@ public struct ChangeTierNavigation: View {
                     )
                     .withDismissButton()
                 } else {
-                    SelectInsuranceScreen(changeTierContractsInput: changeTierContracts)
-                        .routerDestination(for: ChangeTierContract.self) { changeTierContract in
-                            getScreen
-                        }
+                    SelectInsuranceScreen(
+                        changeTierContractsInput: changeTierContracts,
+                        changeTierNavigationVm: changeTierNavigationVm
+                    )
+                    .routerDestination(for: ChangeTierContract.self) { changeTierContract in
+                        getScreen
+                    }
                 }
             } else {
                 getScreen

--- a/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
@@ -4,47 +4,52 @@ import hCoreUI
 
 struct SelectInsuranceScreen: View {
     let changeTierContractsInput: ChangeTierContractsInput
-    @EnvironmentObject var changeTierNavigationVm: ChangeTierNavigationViewModel
-
-    init(changeTierContractsInput: ChangeTierContractsInput) {
+    @ObservedObject var changeTierNavigationVm: ChangeTierNavigationViewModel
+    let itemConfig: ItemConfig<ChangeTierContract>
+    init(
+        changeTierContractsInput: ChangeTierContractsInput,
+        changeTierNavigationVm: ChangeTierNavigationViewModel
+    ) {
         self.changeTierContractsInput = changeTierContractsInput
+        self.changeTierNavigationVm = changeTierNavigationVm
+        self.itemConfig = .init(
+            items: {
+                let items = changeTierContractsInput.contracts.map({
+                    (
+                        object: $0,
+                        displayName: ItemModel(
+                            title: $0.contractDisplayName,
+                            subTitle: $0.contractExposureName
+                        )
+                    )
+                })
+                return items
+            }(),
+            preSelectedItems: { [] },
+            onSelected: { selected in
+                if let selectedContract = selected.first?.0 {
+                    changeTierNavigationVm.vm = .init(
+                        changeTierInput: .contractWithSource(
+                            data: .init(
+                                source: changeTierContractsInput.source,
+                                contractId: selectedContract.contractId
+                            )
+                        )
+                    )
+                    changeTierNavigationVm.router.push(selectedContract)
+                }
+            },
+            singleSelect: true,
+            attachToBottom: true,
+            disableIfNoneSelected: true,
+            hButtonText: L10n.generalContinueButton,
+            fieldSize: .small
+        )
     }
 
     var body: some View {
         ItemPickerScreen<ChangeTierContract>(
-            config: .init(
-                items: {
-                    let items = changeTierContractsInput.contracts.map({
-                        (
-                            object: $0,
-                            displayName: ItemModel(
-                                title: $0.contractDisplayName,
-                                subTitle: $0.contractExposureName
-                            )
-                        )
-                    })
-                    return items
-                }(),
-                preSelectedItems: { [] },
-                onSelected: { selected in
-                    if let selectedContract = selected.first?.0 {
-                        changeTierNavigationVm.vm = .init(
-                            changeTierInput: .contractWithSource(
-                                data: .init(
-                                    source: changeTierContractsInput.source,
-                                    contractId: selectedContract.contractId
-                                )
-                            )
-                        )
-                        changeTierNavigationVm.router.push(selectedContract)
-                    }
-                },
-                singleSelect: true,
-                attachToBottom: true,
-                disableIfNoneSelected: true,
-                hButtonText: L10n.generalContinueButton,
-                fieldSize: .small
-            )
+            config: itemConfig
         )
         .hFormTitle(
             title: .init(.small, .body2, L10n.tierFlowTitle, alignment: .leading),
@@ -67,6 +72,22 @@ struct SelectInsuranceScreen: View {
                 )
 
             ]
+        ),
+        changeTierNavigationVm: .init(
+            changeTierContractsInput: .init(
+                source: .betterCoverage,
+                contracts: [
+                    .init(
+                        contractId: "contractId",
+                        contractDisplayName: "displayName",
+                        contractExposureName: "exposureName"
+                    )
+
+                ]
+            ),
+            onChangedTier: {
+
+            }
         )
     )
 }

--- a/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
@@ -5,14 +5,14 @@ import hCoreUI
 struct SelectInsuranceScreen: View {
     let changeTierContractsInput: ChangeTierContractsInput
     @ObservedObject var changeTierNavigationVm: ChangeTierNavigationViewModel
-    let itemConfig: ItemConfig<ChangeTierContract>
+    let itemPickerConfig: ItemConfig<ChangeTierContract>
     init(
         changeTierContractsInput: ChangeTierContractsInput,
         changeTierNavigationVm: ChangeTierNavigationViewModel
     ) {
         self.changeTierContractsInput = changeTierContractsInput
         self.changeTierNavigationVm = changeTierNavigationVm
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 let items = changeTierContractsInput.contracts.map({
                     (
@@ -49,7 +49,7 @@ struct SelectInsuranceScreen: View {
 
     var body: some View {
         ItemPickerScreen<ChangeTierContract>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .hFormTitle(
             title: .init(.small, .body2, L10n.tierFlowTitle, alignment: .leading),

--- a/Projects/Claims/GraphQL/Octopus/StartClaimsFlow.graphql
+++ b/Projects/Claims/GraphQL/Octopus/StartClaimsFlow.graphql
@@ -67,6 +67,7 @@ fragment FlowClaimFailedStepFragment on FlowClaimFailedStep {
 
 fragment FlowClaimContractSelectStepFragment on FlowClaimContractSelectStep {
     id
+    selectedOptionId
     options {
         ...FlowClaimContractOptionFragment
     }

--- a/Projects/Claims/Sources/Navigation/ClaimsNavigation.swift
+++ b/Projects/Claims/Sources/Navigation/ClaimsNavigation.swift
@@ -279,7 +279,7 @@ public struct ClaimsNavigation: View {
                         case .dateOfOccurrancePlusLocation:
                             SubmitClaimOccurrencePlusLocationScreen(claimsNavigationVm: claimsNavigationVm)
                         case .selectContract:
-                            SelectContractView()
+                            SelectContractView(claimsNavigationVm: claimsNavigationVm)
                         case let .phoneNumber(model):
                             SubmitClaimContactScreen(model: model)
                         case .audioRecording:
@@ -332,7 +332,7 @@ public struct ClaimsNavigation: View {
             presented: $claimsNavigationVm.isLocationPickerPresented,
             style: [.height]
         ) {
-            LocationView()
+            LocationView(claimsNavigationVm: claimsNavigationVm, router: claimsNavigationVm.router)
                 .environmentObject(claimsNavigationVm)
                 .navigationTitle(L10n.Claims.Incident.Screen.location)
                 .embededInNavigation(options: .navigationType(type: .large), tracking: ClaimsDetentType.locationPicker)
@@ -347,9 +347,12 @@ public struct ClaimsNavigation: View {
                 .routerDestination(
                     for: ClaimFlowItemBrandOptionModel.self
                 ) { brandModel in
-                    ModelPickerView(brand: brandModel)
-                        .environmentObject(claimsNavigationVm)
-                        .navigationTitle(L10n.claimsChooseModelTitle)
+                    ModelPickerView(
+                        router: claimsNavigationVm.router,
+                        claimsNavigationVm: claimsNavigationVm,
+                        brand: brandModel
+                    )
+                    .navigationTitle(L10n.claimsChooseModelTitle)
                 }
                 .embededInNavigation(options: .navigationType(type: .large), tracking: ClaimsDetentType.brandPicker)
         }

--- a/Projects/Claims/Sources/Service/OctopusImplementation/SubmitClaimClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/SubmitClaimClientOctopus.swift
@@ -703,7 +703,7 @@ extension FlowClaimContractSelectStepModel {
     init(
         with data: OctopusGraphQL.FlowClaimContractSelectStepFragment
     ) {
-        self.selectedContractId = data.options.first?.id
+        self.selectedContractId = data.selectedOptionId ?? data.options.first?.id
         self.availableContractOptions = data.options.map({ .init(with: $0) })
     }
 }

--- a/Projects/Claims/Sources/Views/ModelPickerView.swift
+++ b/Projects/Claims/Sources/Views/ModelPickerView.swift
@@ -3,54 +3,67 @@ import hCore
 import hCoreUI
 
 struct ModelPickerView: View {
-    @EnvironmentObject var router: Router
-    @EnvironmentObject var claimsNavigationVm: ClaimsNavigationViewModel
+    @ObservedObject var router: Router
+    @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
     let brand: ClaimFlowItemBrandOptionModel
+    var itemConfig: ItemConfig<ClaimFlowItemModelOptionModel>
 
-    var body: some View {
+    init(router: Router, claimsNavigationVm: ClaimsNavigationViewModel, brand: ClaimFlowItemBrandOptionModel) {
+        self.router = router
+        self.claimsNavigationVm = claimsNavigationVm
+        self.brand = brand
         let step = claimsNavigationVm.singleItemModel
         let customName = step?.selectedItemBrand == brand.itemBrandId ? step?.customName : nil
-        return ItemPickerScreen<ClaimFlowItemModelOptionModel>(
-            config: .init(
-                items: {
-                    return step?.getListOfModels(for: brand.itemBrandId)?
-                        .compactMap({ ($0, .init(title: $0.displayName)) }) ?? []
+        self.itemConfig = .init(
+            items: {
+                return step?.getListOfModels(for: brand.itemBrandId)?
+                    .compactMap({ ($0, .init(title: $0.displayName)) }) ?? []
 
-                }(),
-                preSelectedItems: {
-                    if let item = step?.getListOfModels()?.first(where: { $0.itemModelId == step?.selectedItemModel }) {
-                        return [item]
-                    }
-                    return []
-                },
-                onSelected: { [weak router] item in
-                    if item.first?.0 == nil {
+            }(),
+            preSelectedItems: {
+                if let item = step?.getListOfModels()?.first(where: { $0.itemModelId == step?.selectedItemModel }) {
+                    return [item]
+                }
+                return []
+            },
+            onSelected: { [weak router] item in
+                if item.first?.0 == nil {
+                    claimsNavigationVm.singleItemModel?.selectedItemBrand = brand.itemBrandId
+                    let customName = item.first?.1 ?? ""
+                    claimsNavigationVm.singleItemModel?.customName = customName
+                    claimsNavigationVm.singleItemModel?.selectedItemModel = nil
+                } else {
+                    if let object = item.first?.0 {
                         claimsNavigationVm.singleItemModel?.selectedItemBrand = brand.itemBrandId
-                        let customName = item.first?.1 ?? ""
-                        claimsNavigationVm.singleItemModel?.customName = customName
-                        claimsNavigationVm.singleItemModel?.selectedItemModel = nil
-                    } else {
-                        if let object = item.first?.0 {
-                            claimsNavigationVm.singleItemModel?.customName = nil
-                            claimsNavigationVm.singleItemModel?.selectedItemModel = object.itemModelId
-                        }
+                        claimsNavigationVm.singleItemModel?.customName = nil
+                        claimsNavigationVm.singleItemModel?.selectedItemModel = object.itemModelId
                     }
-                    router?.dismiss()
-                },
-                onCancel: { [weak router] in
-                    router?.dismiss()
-                },
-                singleSelect: true,
-                manualInputPlaceholder: L10n.Claims.Item.Enter.Model.name,
-                manualBrandName: customName,
-                contentPosition: .top,
-                useAlwaysAttachedToBottom: true
-            )
+                }
+                router?.dismiss()
+            },
+            onCancel: { [weak router] in
+                router?.dismiss()
+            },
+            singleSelect: true,
+            manualInputPlaceholder: L10n.Claims.Item.Enter.Model.name,
+            manualBrandName: customName,
+            contentPosition: .top,
+            useAlwaysAttachedToBottom: true
+        )
+    }
+
+    var body: some View {
+        return ItemPickerScreen<ClaimFlowItemModelOptionModel>(
+            config: itemConfig
         )
         .hIncludeManualInput
     }
 }
 
 #Preview {
-    ModelPickerView(brand: .init(displayName: "displayName", itemBrandId: "brandId", itemTypeId: "type"))
+    ModelPickerView(
+        router: Router(),
+        claimsNavigationVm: .init(),
+        brand: .init(displayName: "displayName", itemBrandId: "brandId", itemTypeId: "type")
+    )
 }

--- a/Projects/Claims/Sources/Views/ModelPickerView.swift
+++ b/Projects/Claims/Sources/Views/ModelPickerView.swift
@@ -6,7 +6,7 @@ struct ModelPickerView: View {
     @ObservedObject var router: Router
     @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
     let brand: ClaimFlowItemBrandOptionModel
-    var itemConfig: ItemConfig<ClaimFlowItemModelOptionModel>
+    var itemPickerConfig: ItemConfig<ClaimFlowItemModelOptionModel>
 
     init(router: Router, claimsNavigationVm: ClaimsNavigationViewModel, brand: ClaimFlowItemBrandOptionModel) {
         self.router = router
@@ -14,7 +14,7 @@ struct ModelPickerView: View {
         self.brand = brand
         let step = claimsNavigationVm.singleItemModel
         let customName = step?.selectedItemBrand == brand.itemBrandId ? step?.customName : nil
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 return step?.getListOfModels(for: brand.itemBrandId)?
                     .compactMap({ ($0, .init(title: $0.displayName)) }) ?? []
@@ -54,7 +54,7 @@ struct ModelPickerView: View {
 
     var body: some View {
         return ItemPickerScreen<ClaimFlowItemModelOptionModel>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .hIncludeManualInput
     }

--- a/Projects/Claims/Sources/Views/SubmitClaim/Contracts/SelectContractView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Contracts/SelectContractView.swift
@@ -5,7 +5,7 @@ import hCoreUI
 struct SelectContractView: View {
     @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
     @ObservedObject var vm = SelectContractViewModel()
-    let itemConfig: ItemConfig<FlowClaimContractSelectOptionModel>
+    let itemPickerConfig: ItemConfig<FlowClaimContractSelectOptionModel>
 
     init(
         claimsNavigationVm: ClaimsNavigationViewModel,
@@ -13,7 +13,7 @@ struct SelectContractView: View {
     ) {
         self.claimsNavigationVm = claimsNavigationVm
         self.vm = vm
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 return claimsNavigationVm.contractSelectModel?.availableContractOptions
                     .compactMap({
@@ -54,7 +54,7 @@ struct SelectContractView: View {
     }
     var body: some View {
         ItemPickerScreen<FlowClaimContractSelectOptionModel>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .padding(.bottom, .padding16)
         .hFormTitle(

--- a/Projects/Claims/Sources/Views/SubmitClaim/Contracts/SelectContractView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/Contracts/SelectContractView.swift
@@ -3,48 +3,58 @@ import hCore
 import hCoreUI
 
 struct SelectContractView: View {
-    @EnvironmentObject var claimsNavigationVm: ClaimsNavigationViewModel
-    @StateObject var vm = SelectContractViewModel()
+    @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
+    @ObservedObject var vm = SelectContractViewModel()
+    let itemConfig: ItemConfig<FlowClaimContractSelectOptionModel>
 
-    var body: some View {
-        let contractStep = claimsNavigationVm.contractSelectModel
-        ItemPickerScreen<FlowClaimContractSelectOptionModel>(
-            config: .init(
-                items: {
-                    return contractStep?.availableContractOptions
-                        .compactMap({
-                            (object: $0, displayName: .init(title: $0.displayTitle, subTitle: $0.displaySubTitle))
-                        })
-                        ?? []
-                }(),
-                preSelectedItems: {
-                    if let preselected = contractStep?.availableContractOptions
-                        .first(where: { $0.id == contractStep?.selectedContractId })
-                    {
-                        return [preselected]
-                    }
-                    return []
-                },
-                onSelected: { selectedContract in
-                    if let object = selectedContract.first?.0 {
-                        if let model = claimsNavigationVm.contractSelectModel {
-                            Task {
-                                let step = await vm.contractSelectRequest(
-                                    contractId: object.id,
-                                    context: claimsNavigationVm.currentClaimContext ?? "",
-                                    model: model
-                                )
-                                if let step {
-                                    claimsNavigationVm.navigate(data: step)
-                                }
+    init(
+        claimsNavigationVm: ClaimsNavigationViewModel,
+        vm: SelectContractViewModel = SelectContractViewModel()
+    ) {
+        self.claimsNavigationVm = claimsNavigationVm
+        self.vm = vm
+        self.itemConfig = .init(
+            items: {
+                return claimsNavigationVm.contractSelectModel?.availableContractOptions
+                    .compactMap({
+                        (object: $0, displayName: .init(title: $0.displayTitle, subTitle: $0.displaySubTitle))
+                    })
+                    ?? []
+            }(),
+            preSelectedItems: {
+                if let preselected = claimsNavigationVm.contractSelectModel?.availableContractOptions
+                    .first(where: { $0.id == claimsNavigationVm.contractSelectModel?.selectedContractId })
+                {
+                    return [preselected]
+                }
+                return []
+            },
+            onSelected: { selectedContract in
+                if let object = selectedContract.first?.0 {
+                    claimsNavigationVm.contractSelectModel?.selectedContractId = object.id
+                    if let model = claimsNavigationVm.contractSelectModel {
+                        Task {
+                            let step = await vm.contractSelectRequest(
+                                contractId: object.id,
+                                context: claimsNavigationVm.currentClaimContext ?? "",
+                                model: model
+                            )
+                            if let step {
+                                claimsNavigationVm.navigate(data: step)
                             }
                         }
                     }
-                },
-                singleSelect: true,
-                attachToBottom: true,
-                fieldSize: .medium
-            )
+                }
+            },
+            singleSelect: true,
+            attachToBottom: true,
+            hButtonText: L10n.generalContinueButton,
+            fieldSize: .medium
+        )
+    }
+    var body: some View {
+        ItemPickerScreen<FlowClaimContractSelectOptionModel>(
+            config: itemConfig
         )
         .padding(.bottom, .padding16)
         .hFormTitle(
@@ -93,7 +103,6 @@ public class SelectContractViewModel: ObservableObject {
 struct SelectContractScreen_Previews: PreviewProvider {
     static var previews: some View {
         Dependencies.shared.add(module: Module { () -> hFetchEntrypointsClient in FetchEntrypointsClientDemo() })
-        return SelectContractView()
-            .environmentObject(ClaimsNavigationViewModel())
+        return SelectContractView(claimsNavigationVm: .init())
     }
 }

--- a/Projects/Claims/Sources/Views/SubmitClaim/LocationView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/LocationView.swift
@@ -5,12 +5,12 @@ import hCoreUI
 struct LocationView: View {
     @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
     @ObservedObject var router: Router
-    let itemConfig: ItemConfig<ClaimFlowLocationOptionModel>
+    let itemPickerConfig: ItemConfig<ClaimFlowLocationOptionModel>
 
     init(claimsNavigationVm: ClaimsNavigationViewModel, router: Router) {
         self.claimsNavigationVm = claimsNavigationVm
         self.router = router
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 return claimsNavigationVm.occurrencePlusLocationModel?.locationModel?.options
                     .compactMap({ (object: $0, displayName: .init(title: $0.displayName)) }) ?? []
@@ -38,7 +38,7 @@ struct LocationView: View {
     }
     var body: some View {
         ItemPickerScreen<ClaimFlowLocationOptionModel>(
-            config: itemConfig
+            config: itemPickerConfig
         )
     }
 }

--- a/Projects/Claims/Sources/Views/SubmitClaim/LocationView.swift
+++ b/Projects/Claims/Sources/Views/SubmitClaim/LocationView.swift
@@ -3,40 +3,46 @@ import hCore
 import hCoreUI
 
 struct LocationView: View {
-    @EnvironmentObject var claimsNavigationVm: ClaimsNavigationViewModel
-    @EnvironmentObject var router: Router
+    @ObservedObject var claimsNavigationVm: ClaimsNavigationViewModel
+    @ObservedObject var router: Router
+    let itemConfig: ItemConfig<ClaimFlowLocationOptionModel>
 
+    init(claimsNavigationVm: ClaimsNavigationViewModel, router: Router) {
+        self.claimsNavigationVm = claimsNavigationVm
+        self.router = router
+        self.itemConfig = .init(
+            items: {
+                return claimsNavigationVm.occurrencePlusLocationModel?.locationModel?.options
+                    .compactMap({ (object: $0, displayName: .init(title: $0.displayName)) }) ?? []
+            }(),
+            preSelectedItems: {
+                if let value = claimsNavigationVm.occurrencePlusLocationModel?.locationModel?
+                    .getSelectedOption()
+                {
+                    return [value]
+                }
+                return []
+            },
+            onSelected: { [weak claimsNavigationVm] selectedLocation in
+                if let object = selectedLocation.first?.0 {
+                    claimsNavigationVm?.isLocationPickerPresented = false
+                    claimsNavigationVm?.occurrencePlusLocationModel?.locationModel?.location =
+                        object.value
+                }
+            },
+            onCancel: { [weak router] in
+                router?.dismiss()
+            },
+            singleSelect: true
+        )
+    }
     var body: some View {
         ItemPickerScreen<ClaimFlowLocationOptionModel>(
-            config: .init(
-                items: {
-                    return claimsNavigationVm.occurrencePlusLocationModel?.locationModel?.options
-                        .compactMap({ (object: $0, displayName: .init(title: $0.displayName)) }) ?? []
-                }(),
-                preSelectedItems: {
-                    if let value = claimsNavigationVm.occurrencePlusLocationModel?.locationModel?
-                        .getSelectedOption()
-                    {
-                        return [value]
-                    }
-                    return []
-                },
-                onSelected: { [weak claimsNavigationVm] selectedLocation in
-                    if let object = selectedLocation.first?.0 {
-                        claimsNavigationVm?.isLocationPickerPresented = false
-                        claimsNavigationVm?.occurrencePlusLocationModel?.locationModel?.location =
-                            object.value
-                    }
-                },
-                onCancel: { [weak router] in
-                    router?.dismiss()
-                },
-                singleSelect: true
-            )
+            config: itemConfig
         )
     }
 }
 
 #Preview {
-    LocationView()
+    LocationView(claimsNavigationVm: .init(), router: .init())
 }

--- a/Projects/EditCoInsured/Sources/Navigation/EditCoInsuredNavigation.swift
+++ b/Projects/EditCoInsured/Sources/Navigation/EditCoInsuredNavigation.swift
@@ -136,6 +136,7 @@ public struct EditCoInsuredNavigation: View {
         ) { selectCoInsured in
             openCoInsuredSelectScreen(contractId: selectCoInsured.id)
                 .environmentObject(editCoInsuredNavigationVm)
+                .embededInNavigation(tracking: EditCoInsuredDetentType.selectCoInsured)
         }
         .modally(presented: $editCoInsuredNavigationVm.showProgressScreenWithSuccess) {
             openProgress(showSuccess: true)

--- a/Projects/EditCoInsured/Sources/View/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/AlreadyExistingCoInsured/InsuredPeopleScreen.swift
@@ -224,6 +224,7 @@ class InsuredPeopleNewScreenModel: ObservableObject {
     @Published var coInsuredDeleted: [CoInsuredModel] = []
     @Published var noSSN = false
     var config: InsuredPeopleConfig = InsuredPeopleConfig()
+    @Published var isLoading = false
 
     func completeList(
         coInsuredAdded: [CoInsuredModel]? = nil,

--- a/Projects/EditCoInsured/Sources/View/CoInsuredSelectScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/CoInsuredSelectScreen.swift
@@ -8,7 +8,7 @@ struct CoInsuredSelectScreen: View {
     @ObservedObject var vm: InsuredPeopleNewScreenModel
     @ObservedObject private var editCoInsuredNavigation: EditCoInsuredNavigationViewModel
     @ObservedObject private var intentViewModel: IntentViewModel
-    let itemConfig: ItemConfig<CoInsuredModel>
+    let itemPickerConfig: ItemConfig<CoInsuredModel>
     public init(
         contractId: String,
         editCoInsuredNavigation: EditCoInsuredNavigationViewModel
@@ -22,7 +22,7 @@ struct CoInsuredSelectScreen: View {
             })
         let intentViewModel = editCoInsuredNavigation.intentViewModel
 
-        itemConfig = .init(
+        itemPickerConfig = .init(
             items: {
                 return
                     alreadyAddedCoinsuredMembers
@@ -105,7 +105,7 @@ struct CoInsuredSelectScreen: View {
 
     var picker: some View {
         ItemPickerScreen<CoInsuredModel>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .hItemPickerBottomAttachedView {
             hButton.LargeButton(type: .ghost) {

--- a/Projects/EditCoInsured/Sources/View/CoInsuredSelectScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/CoInsuredSelectScreen.swift
@@ -5,23 +5,85 @@ import hCoreUI
 
 struct CoInsuredSelectScreen: View {
     let contractId: String
-    @State var isLoading = false
     @ObservedObject var vm: InsuredPeopleNewScreenModel
-    let alreadyAddedCoinsuredMembers: [CoInsuredModel]
     @ObservedObject private var editCoInsuredNavigation: EditCoInsuredNavigationViewModel
     @ObservedObject private var intentViewModel: IntentViewModel
+    let itemConfig: ItemConfig<CoInsuredModel>
     public init(
         contractId: String,
         editCoInsuredNavigation: EditCoInsuredNavigationViewModel
     ) {
         self.contractId = contractId
         self.editCoInsuredNavigation = editCoInsuredNavigation
-        vm = editCoInsuredNavigation.coInsuredViewModel
-        alreadyAddedCoinsuredMembers = editCoInsuredNavigation.coInsuredViewModel.config.preSelectedCoInsuredList
+        let vm = editCoInsuredNavigation.coInsuredViewModel
+        let alreadyAddedCoinsuredMembers = editCoInsuredNavigation.coInsuredViewModel.config.preSelectedCoInsuredList
             .filter({
                 !editCoInsuredNavigation.coInsuredViewModel.coInsuredAdded.contains($0)
             })
-        intentViewModel = editCoInsuredNavigation.intentViewModel
+        let intentViewModel = editCoInsuredNavigation.intentViewModel
+
+        itemConfig = .init(
+            items: {
+                return
+                    alreadyAddedCoinsuredMembers
+                    .compactMap {
+                        ((object: $0, displayName: .init(title: $0.fullName ?? "")))
+                    }
+            }(),
+            preSelectedItems: { [] },
+            onSelected: { selectedCoinsured in
+                if let selectedCoinsured = selectedCoinsured.first {
+                    if let object = selectedCoinsured.0 {
+
+                        vm.addCoInsured(
+                            .init(
+                                firstName: object.firstName,
+                                lastName: object.lastName,
+                                SSN: object.SSN,
+                                birthDate: object.birthDate,
+                                needsMissingInfo: false
+                            )
+                        )
+                    }
+                    Task {
+                        withAnimation {
+                            vm.isLoading = true
+                        }
+                        await intentViewModel.getIntent(
+                            contractId: contractId,
+                            origin: .coinsuredSelectList,
+                            coInsured: vm.completeList()
+                        )
+                        withAnimation {
+                            vm.isLoading = false
+                        }
+                        if !intentViewModel.showErrorViewForCoInsuredList {
+                            editCoInsuredNavigation.selectCoInsured = nil
+                        } else {
+                            if let object = selectedCoinsured.0 {
+                                vm.removeCoInsured(
+                                    .init(
+                                        firstName: object.firstName,
+                                        lastName: object.lastName,
+                                        SSN: object.SSN,
+                                        birthDate: object.birthDate,
+                                        needsMissingInfo: false
+                                    )
+                                )
+                            }
+                        }
+                        editCoInsuredNavigation.selectCoInsured = nil
+                    }
+                }
+            },
+            onCancel: {
+                editCoInsuredNavigation.selectCoInsured = nil
+            },
+            singleSelect: true,
+            attachToBottom: true
+        )
+        self.intentViewModel = intentViewModel
+        self.vm = vm
         intentViewModel.errorMessageForCoinsuredList = nil
         intentViewModel.errorMessageForInput = nil
     }
@@ -43,66 +105,7 @@ struct CoInsuredSelectScreen: View {
 
     var picker: some View {
         ItemPickerScreen<CoInsuredModel>(
-            config: .init(
-                items: {
-                    return
-                        alreadyAddedCoinsuredMembers
-                        .compactMap {
-                            ((object: $0, displayName: .init(title: $0.fullName ?? "")))
-                        }
-                }(),
-                preSelectedItems: { [] },
-                onSelected: { selectedCoinsured in
-                    if let selectedCoinsured = selectedCoinsured.first {
-                        if let object = selectedCoinsured.0 {
-
-                            vm.addCoInsured(
-                                .init(
-                                    firstName: object.firstName,
-                                    lastName: object.lastName,
-                                    SSN: object.SSN,
-                                    birthDate: object.birthDate,
-                                    needsMissingInfo: false
-                                )
-                            )
-                        }
-                        Task {
-                            withAnimation {
-                                isLoading = true
-                            }
-                            await intentViewModel.getIntent(
-                                contractId: contractId,
-                                origin: .coinsuredSelectList,
-                                coInsured: vm.completeList()
-                            )
-                            withAnimation {
-                                isLoading = false
-                            }
-                            if !intentViewModel.showErrorViewForCoInsuredList {
-                                editCoInsuredNavigation.selectCoInsured = nil
-                            } else {
-                                if let object = selectedCoinsured.0 {
-                                    vm.removeCoInsured(
-                                        .init(
-                                            firstName: object.firstName,
-                                            lastName: object.lastName,
-                                            SSN: object.SSN,
-                                            birthDate: object.birthDate,
-                                            needsMissingInfo: false
-                                        )
-                                    )
-                                }
-                            }
-                            editCoInsuredNavigation.selectCoInsured = nil
-                        }
-                    }
-                },
-                onCancel: {
-                    editCoInsuredNavigation.selectCoInsured = nil
-                },
-                singleSelect: true,
-                attachToBottom: true
-            )
+            config: itemConfig
         )
         .hItemPickerBottomAttachedView {
             hButton.LargeButton(type: .ghost) {
@@ -118,12 +121,12 @@ struct CoInsuredSelectScreen: View {
                     hText(L10n.generalAddNew)
                 }
             }
-            .disabled(isLoading)
+            .disabled(vm.isLoading)
             .hButtonDontShowLoadingWhenDisabled(true)
             .padding(.top, -12)
             .padding(.bottom, -4)
         }
-        .hButtonIsLoading(isLoading)
+        .hButtonIsLoading(vm.isLoading)
     }
 }
 

--- a/Projects/MoveFlow/Sources/Service/Navigation/MovingFlowNavigation.swift
+++ b/Projects/MoveFlow/Sources/Service/Navigation/MovingFlowNavigation.swift
@@ -14,6 +14,7 @@ public class MovingFlowNavigationViewModel: ObservableObject {
     @Published public var addressInputModel = AddressInputModel()
     @Published public var movingFlowVm: MovingFlowModel?
     @Published public var houseInformationInputvm = HouseInformationInputModel()
+    @Published var isBuildingTypePickerPresented: ExtraBuildingTypeNavigationModel?
     var movingFlowConfirmViewModel: MovingFlowConfirmViewModel?
     var quoteSummaryViewModel: QuoteSummaryViewModel?
 
@@ -118,10 +119,10 @@ extension MovingFlowRouterActions: TrackingViewNameProtocol {
 
 struct ExtraBuildingTypeNavigationModel: Identifiable, Equatable {
     static func == (lhs: ExtraBuildingTypeNavigationModel, rhs: ExtraBuildingTypeNavigationModel) -> Bool {
-        return true
+        return lhs.id == rhs.id
     }
 
-    public var id: String?
+    public var id = UUID().uuidString
     var extraBuildingType: ExtraBuildingType?
 
     var addExtraBuildingVm: MovingFlowAddExtraBuildingViewModel
@@ -132,7 +133,6 @@ public struct MovingFlowNavigation: View {
     @StateObject var router = Router()
     private let onMoved: () -> Void
     @State var cancellable: AnyCancellable?
-    @State var isBuildingTypePickerPresented: ExtraBuildingTypeNavigationModel?
 
     public init(
         onMoved: @escaping () -> Void
@@ -170,15 +170,8 @@ public struct MovingFlowNavigation: View {
             style: [.height]
         ) { houseInformationInputModel in
             MovingFlowAddExtraBuildingScreen(
-                isBuildingTypePickerPresented: $isBuildingTypePickerPresented,
                 houseInformationInputVm: houseInformationInputModel
             )
-            .detent(item: $isBuildingTypePickerPresented, style: [.height]) { model in
-                openTypeOfBuildingPicker(
-                    for: model.extraBuildingType,
-                    addExtraBuilingViewModel: model.addExtraBuildingVm
-                )
-            }
             .environmentObject(movingFlowNavigationVm)
             .navigationTitle(L10n.changeAddressAddBuilding)
             .embededInNavigation(
@@ -191,6 +184,16 @@ public struct MovingFlowNavigation: View {
             style: [.large]
         ) { document in
             PDFPreview(document: document)
+        }
+        .detent(
+            item: $movingFlowNavigationVm.isBuildingTypePickerPresented,
+            style: [.height],
+            options: .constant([.alwaysOpenOnTop])
+        ) { model in
+            openTypeOfBuildingPicker(
+                for: model.extraBuildingType,
+                addExtraBuilingViewModel: model.addExtraBuildingVm
+            )
         }
         .onDisappear {
             onMoved()
@@ -257,7 +260,7 @@ public struct MovingFlowNavigation: View {
     ) -> some View {
         TypeOfBuildingPickerScreen(
             currentlySelected: currentlySelected,
-            isBuildingTypePickerPresented: $isBuildingTypePickerPresented,
+            movingFlowNavigationVm: movingFlowNavigationVm,
             addExtraBuidlingViewModel: addExtraBuilingViewModel
         )
         .navigationTitle(L10n.changeAddressExtraBuildingContainerTitle)
@@ -265,7 +268,6 @@ public struct MovingFlowNavigation: View {
             options: [.navigationType(type: .large)],
             tracking: MovingFlowDetentType.typeOfBuildingPicker
         )
-        .environmentObject(movingFlowNavigationVm)
     }
 }
 

--- a/Projects/MoveFlow/Sources/View/MovingFlowAddExtraBuildingScreen.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowAddExtraBuildingScreen.swift
@@ -10,13 +10,10 @@ struct MovingFlowAddExtraBuildingScreen: View {
     @ObservedObject var houseInformationInputVm: HouseInformationInputModel
 
     @EnvironmentObject var movingFlowNavigationVm: MovingFlowNavigationViewModel
-    @Binding var isBuildingTypePickerPresented: ExtraBuildingTypeNavigationModel?
 
     init(
-        isBuildingTypePickerPresented: Binding<ExtraBuildingTypeNavigationModel?>,
         houseInformationInputVm: HouseInformationInputModel
     ) {
-        self._isBuildingTypePickerPresented = isBuildingTypePickerPresented
         self.houseInformationInputVm = houseInformationInputVm
     }
 
@@ -62,7 +59,7 @@ struct MovingFlowAddExtraBuildingScreen: View {
             placeholder: L10n.changeAddressExtraBuildingContainerTitle,
             error: $vm.buildingTypeError
         ) {
-            isBuildingTypePickerPresented = ExtraBuildingTypeNavigationModel(
+            movingFlowNavigationVm.isBuildingTypePickerPresented = ExtraBuildingTypeNavigationModel(
                 extraBuildingType: vm.buildingType,
                 addExtraBuildingVm: vm
             )
@@ -140,11 +137,8 @@ public class MovingFlowAddExtraBuildingViewModel: ObservableObject {
 }
 
 struct MovingFlowAddExtraBuildingView_Previews: PreviewProvider {
-    @State static var isOn: ExtraBuildingTypeNavigationModel? = .init(addExtraBuildingVm: .init())
-
     static var previews: some View {
         MovingFlowAddExtraBuildingScreen(
-            isBuildingTypePickerPresented: $isOn,
             houseInformationInputVm: .init()
         )
     }

--- a/Projects/MoveFlow/Sources/View/TypeOfBuildingPickerScreen.swift
+++ b/Projects/MoveFlow/Sources/View/TypeOfBuildingPickerScreen.swift
@@ -6,7 +6,7 @@ struct TypeOfBuildingPickerScreen: View {
     var currentlySelected: ExtraBuildingType?
     @ObservedObject var movingFlowNavigationVm: MovingFlowNavigationViewModel
     @ObservedObject var addExtraBuidlingViewModel: MovingFlowAddExtraBuildingViewModel
-    let itemConfig: ItemConfig<ExtraBuildingType>
+    let itemPickerConfig: ItemConfig<ExtraBuildingType>
     public init(
         currentlySelected: ExtraBuildingType?,
         movingFlowNavigationVm: MovingFlowNavigationViewModel,
@@ -15,7 +15,7 @@ struct TypeOfBuildingPickerScreen: View {
         self.movingFlowNavigationVm = movingFlowNavigationVm
         self.currentlySelected = currentlySelected
         self.addExtraBuidlingViewModel = addExtraBuidlingViewModel
-        self.itemConfig = .init(
+        self.itemPickerConfig = .init(
             items: {
                 return movingFlowNavigationVm.movingFlowVm?.extraBuildingTypes
                     .compactMap({ (object: $0, displayName: .init(title: $0.translatedValue)) }) ?? []
@@ -44,7 +44,7 @@ struct TypeOfBuildingPickerScreen: View {
 
     var body: some View {
         ItemPickerScreen<ExtraBuildingType>(
-            config: itemConfig
+            config: itemPickerConfig
         )
     }
 }

--- a/Projects/MoveFlow/Sources/View/TypeOfBuildingPickerScreen.swift
+++ b/Projects/MoveFlow/Sources/View/TypeOfBuildingPickerScreen.swift
@@ -4,47 +4,47 @@ import hCoreUI
 
 struct TypeOfBuildingPickerScreen: View {
     var currentlySelected: ExtraBuildingType?
-    @Binding var isBuildingTypePickerPresented: ExtraBuildingTypeNavigationModel?
-    @EnvironmentObject var movingFlowNavigationVm: MovingFlowNavigationViewModel
+    @ObservedObject var movingFlowNavigationVm: MovingFlowNavigationViewModel
     @ObservedObject var addExtraBuidlingViewModel: MovingFlowAddExtraBuildingViewModel
-
+    let itemConfig: ItemConfig<ExtraBuildingType>
     public init(
         currentlySelected: ExtraBuildingType?,
-        isBuildingTypePickerPresented: Binding<ExtraBuildingTypeNavigationModel?>,
+        movingFlowNavigationVm: MovingFlowNavigationViewModel,
         addExtraBuidlingViewModel: MovingFlowAddExtraBuildingViewModel
     ) {
+        self.movingFlowNavigationVm = movingFlowNavigationVm
         self.currentlySelected = currentlySelected
-        self._isBuildingTypePickerPresented = isBuildingTypePickerPresented
         self.addExtraBuidlingViewModel = addExtraBuidlingViewModel
+        self.itemConfig = .init(
+            items: {
+                return movingFlowNavigationVm.movingFlowVm?.extraBuildingTypes
+                    .compactMap({ (object: $0, displayName: .init(title: $0.translatedValue)) }) ?? []
+            }(),
+            preSelectedItems: {
+                if let currentlySelected {
+                    return [currentlySelected]
+                }
+                return []
+            },
+            onSelected: { selected in
+                if let selected = selected.first {
+                    movingFlowNavigationVm.isBuildingTypePickerPresented = nil
+                    if let object = selected.0 {
+                        addExtraBuidlingViewModel.buildingType = object
+                    }
+                }
+            },
+            onCancel: {
+                movingFlowNavigationVm.isBuildingTypePickerPresented = nil
+            },
+            singleSelect: true,
+            useAlwaysAttachedToBottom: true
+        )
     }
 
     var body: some View {
         ItemPickerScreen<ExtraBuildingType>(
-            config: .init(
-                items: {
-                    return movingFlowNavigationVm.movingFlowVm?.extraBuildingTypes
-                        .compactMap({ (object: $0, displayName: .init(title: $0.translatedValue)) }) ?? []
-                }(),
-                preSelectedItems: {
-                    if let currentlySelected {
-                        return [currentlySelected]
-                    }
-                    return []
-                },
-                onSelected: { selected in
-                    if let selected = selected.first {
-                        isBuildingTypePickerPresented = nil
-                        if let object = selected.0 {
-                            addExtraBuidlingViewModel.buildingType = object
-                        }
-                    }
-                },
-                onCancel: {
-                    isBuildingTypePickerPresented = nil
-                },
-                singleSelect: true,
-                useAlwaysAttachedToBottom: true
-            )
+            config: itemConfig
         )
     }
 }
@@ -52,7 +52,7 @@ struct TypeOfBuildingPickerScreen: View {
 #Preview {
     TypeOfBuildingPickerScreen(
         currentlySelected: nil,
-        isBuildingTypePickerPresented: .constant(nil),
+        movingFlowNavigationVm: .init(),
         addExtraBuidlingViewModel: .init()
     )
 }

--- a/Projects/TravelCertificate/Sources/TravelCertificateNavigation.swift
+++ b/Projects/TravelCertificate/Sources/TravelCertificateNavigation.swift
@@ -72,6 +72,8 @@ public enum ListToolBarPlacement {
 public struct TravelCertificateNavigation: View {
     @ObservedObject var vm: TravelCertificateNavigationViewModel
     @StateObject var router = Router()
+    @StateObject var createNewRouter = Router()
+
     private var infoButtonPlacement: ListToolBarPlacement
     private let useOwnNavigation: Bool
 
@@ -152,6 +154,7 @@ public struct TravelCertificateNavigation: View {
                     }
                 }
                 .embededInNavigation(
+                    router: createNewRouter,
                     tracking: specificationModel.specification.count > 1
                         ? TravelCertificateRouterActions.list(specifications: specificationModel.specification)
                         : TravelCertificateRouterActions.startDate(
@@ -182,8 +185,11 @@ public struct TravelCertificateNavigation: View {
     private func showContractsList(
         for specifications: [TravelInsuranceContractSpecification]
     ) -> some View {
-        ContractsScreen(specifications: specifications)
-            .addDismissFlow()
+        ContractsScreen(
+            router: createNewRouter,
+            specifications: specifications
+        )
+        .addDismissFlow()
     }
 
     private func showStartDateScreen(
@@ -197,9 +203,10 @@ public struct TravelCertificateNavigation: View {
     private func showWhoIsTravelingScreen(
         specification: TravelInsuranceContractSpecification
     ) -> some View {
-        vm.whoIsTravelingViewModel = WhoIsTravelingViewModel(specification: specification)
+        vm.whoIsTravelingViewModel = WhoIsTravelingViewModel(specification: specification, router: createNewRouter)
         return WhoIsTravelingScreen(
-            vm: vm.whoIsTravelingViewModel!
+            vm: vm.whoIsTravelingViewModel!,
+            travelCertificateNavigationVm: vm
         )
         .environmentObject(vm)
         .addDismissFlow()

--- a/Projects/TravelCertificate/Sources/Views/ContractsScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/ContractsScreen.swift
@@ -5,44 +5,50 @@ import hCoreUI
 struct ContractsScreen: View {
     @State var isLoading: Bool = false
     let specifications: [TravelInsuranceContractSpecification]
-    @EnvironmentObject var router: Router
+    let router: Router
+    let itemConfig: ItemConfig<TravelInsuranceContractSpecification>
 
-    init(specifications: [TravelInsuranceContractSpecification]) {
+    init(
+        router: Router,
+        specifications: [TravelInsuranceContractSpecification]
+    ) {
         self.specifications = specifications
+        self.router = router
+        itemConfig = .init(
+            items: {
+                return specifications.map {
+                    (object: $0, displayName: .init(title: $0.street))
+                }
+            }(),
+            preSelectedItems: {
+                guard let preSelected = specifications.first else {
+                    return []
+                }
+                return [preSelected]
+            },
+            onSelected: { selected in
+                if let selected = selected.first?.0 {
+                    router.push(TravelCertificateRouterActions.startDate(specification: selected))
+                }
+            },
+            singleSelect: true,
+            attachToBottom: true,
+            hButtonText: L10n.generalContinueButton
+        )
     }
 
     public var body: some View {
         ItemPickerScreen<TravelInsuranceContractSpecification>(
-            config: .init(
-                items: {
-                    return specifications.map {
-                        (object: $0, displayName: .init(title: $0.street))
-                    }
-                }(),
-                preSelectedItems: {
-                    guard let preSelected = specifications.first else {
-                        return []
-                    }
-                    return [preSelected]
-                },
-                onSelected: { selected in
-                    if let selected = selected.first?.0 {
-                        router.push(TravelCertificateRouterActions.startDate(specification: selected))
-                    }
-                },
-                singleSelect: true,
-                attachToBottom: true,
-                hButtonText: L10n.generalContinueButton
-            )
+            config: itemConfig
         )
         .padding(.bottom, .padding16)
-        .hFormTitle(title: .init(.standard, .displayXSLong, L10n.TravelCertificate.selectContractTitle))
+        .hFormTitle(title: .init(.small, .heading2, L10n.TravelCertificate.selectContractTitle, alignment: .leading))
         .hButtonIsLoading(isLoading)
     }
 }
 
 struct TravelInsuranceContractsScreen_Previews: PreviewProvider {
     static var previews: some View {
-        ContractsScreen(specifications: [])
+        ContractsScreen(router: .init(), specifications: [])
     }
 }

--- a/Projects/TravelCertificate/Sources/Views/ContractsScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/ContractsScreen.swift
@@ -6,7 +6,7 @@ struct ContractsScreen: View {
     @State var isLoading: Bool = false
     let specifications: [TravelInsuranceContractSpecification]
     let router: Router
-    let itemConfig: ItemConfig<TravelInsuranceContractSpecification>
+    let itemPickerConfig: ItemConfig<TravelInsuranceContractSpecification>
 
     init(
         router: Router,
@@ -14,7 +14,7 @@ struct ContractsScreen: View {
     ) {
         self.specifications = specifications
         self.router = router
-        itemConfig = .init(
+        itemPickerConfig = .init(
             items: {
                 return specifications.map {
                     (object: $0, displayName: .init(title: $0.street))
@@ -39,7 +39,7 @@ struct ContractsScreen: View {
 
     public var body: some View {
         ItemPickerScreen<TravelInsuranceContractSpecification>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .padding(.bottom, .padding16)
         .hFormTitle(title: .init(.small, .heading2, L10n.TravelCertificate.selectContractTitle, alignment: .leading))

--- a/Projects/TravelCertificate/Sources/Views/TravelCertificateProcessingScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/TravelCertificateProcessingScreen.swift
@@ -166,7 +166,8 @@ struct SuccessScreen_Previews: PreviewProvider {
                         street: "",
                         email: "",
                         fullName: ""
-                    )
+                    ),
+                    router: .init()
                 )
             )
     }

--- a/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
@@ -9,11 +9,11 @@ import hCoreUI
 struct WhoIsTravelingScreen: View {
     @ObservedObject var vm: WhoIsTravelingViewModel
     @ObservedObject var travelCertificateNavigationVm: TravelCertificateNavigationViewModel
-    let itemConfig: ItemConfig<CoInsuredModel>
+    let itemPickerConfig: ItemConfig<CoInsuredModel>
     init(vm: WhoIsTravelingViewModel, travelCertificateNavigationVm: TravelCertificateNavigationViewModel) {
         self.vm = vm
         self.travelCertificateNavigationVm = travelCertificateNavigationVm
-        itemConfig = .init(
+        itemPickerConfig = .init(
             items: {
                 return vm.coInsuredModelData.compactMap({
                     (object: $0, displayName: ItemModel(title: $0.fullName ?? ""))
@@ -59,7 +59,7 @@ struct WhoIsTravelingScreen: View {
 
     var body: some View {
         ItemPickerScreen<CoInsuredModel>(
-            config: itemConfig
+            config: itemPickerConfig
         )
         .hFormTitle(title: .init(.small, .heading2, L10n.TravelCertificate.whoIsTraveling, alignment: .leading))
         .disabled(vm.isLoading)

--- a/Projects/hCoreUI/Sources/ItemPickerScreen.swift
+++ b/Projects/hCoreUI/Sources/ItemPickerScreen.swift
@@ -71,6 +71,7 @@ public class ItemConfig<T>: ObservableObject where T: Equatable & Hashable {
         self.infoCard = infoCard
         self.contentPosition = contentPosition
         self.useAlwaysAttachedToBottom = useAlwaysAttachedToBottom
+        self.selectedItems = preSelectedItems()
     }
 
     public struct ItemPickerInfoCard {
@@ -173,10 +174,6 @@ public struct ItemPickerScreen<T>: View where T: Equatable & Hashable {
     }
 
     private func onAppear(with proxy: ScrollViewProxy) {
-        config.selectedItems = config.items.filter({ config.preSelectedItems.contains($0.object) })
-            .map({
-                $0.object
-            })
         if let selectedItem = config.selectedItems.first, config.selectedItems.count == 1 {
             proxy.scrollTo(selectedItem, anchor: .center)
         }


### PR DESCRIPTION
## [APP-XXX]

- Added preselected contract id
- Refactored ItemPickerScreen since it didn't save data when view dissapear
- Changed it everywhere where is needed + checked all places where its updated 🥳 

Issue was related to that every time ItemPickerScreen is rendered, new ItemConfig is created. 
Having it as a property on the view is solution where it is generated once

Its a lot

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
