### PR TITLE
GEN-3389: Handle cross sell after dismissing claim details

### DIFF
--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -341,14 +341,7 @@ struct HomeTab: View {
         return RouterHost(router: homeNavigationVm.router, tracking: self) {
             HomeScreen()
                 .routerDestination(for: ClaimModel.self, options: [.hidesBottomBarWhenPushed]) { claim in
-                    ClaimDetailView(claim: claim, type: .claim(id: claim.id))
-                        .environmentObject(homeNavigationVm)
-                        .configureTitle(L10n.claimsYourClaim)
-                        .onDisappear {
-                            if claim.showClaimClosedFlow {
-                                homeNavigationVm.navBarItems.isNewOfferPresented = true
-                            }
-                        }
+                    openClaimDetails(claim: claim, type: .claim(id: claim.id))
                 }
                 .routerDestination(for: String.self) { conversation in
                     InboxView()
@@ -477,18 +470,24 @@ struct HomeTab: View {
                         case let .claimDetailForConversationId(id):
                             let claimStore: ClaimsStore = globalPresentableStoreContainer.get()
                             let claim = claimStore.state.claimFromConversation(for: id)
-                            ClaimDetailView(claim: claim, type: .conversation(id: id))
-                                .configureTitle(L10n.claimsYourClaim)
-                                .onDisappear {
-                                    if let claim, claim.showClaimClosedFlow {
-                                        homeNavigationVm.navBarItems.isNewOfferPresented = true
-                                    }
-                                }
+                            openClaimDetails(claim: claim, type: .conversation(id: id))
                         }
                     }
                 )
             }
         )
+    }
+
+    private func openClaimDetails(claim: ClaimModel?, type: FetchClaimDetailsType) -> some View {
+        ClaimDetailView(claim: claim, type: type)
+            .configureTitle(L10n.claimsYourClaim)
+            .onDisappear {
+                let claimsStore: ClaimsStore = globalPresentableStoreContainer.get()
+                if claim?.showClaimClosedFlow ?? false {
+                    homeNavigationVm.navBarItems.isNewOfferPresented = true
+                    claimsStore.send(.fetchClaims)
+                }
+            }
     }
 }
 

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -481,11 +481,17 @@ struct HomeTab: View {
     private func openClaimDetails(claim: ClaimModel?, type: FetchClaimDetailsType) -> some View {
         ClaimDetailView(claim: claim, type: type)
             .configureTitle(L10n.claimsYourClaim)
-            .onDisappear {
-                let claimsStore: ClaimsStore = globalPresentableStoreContainer.get()
-                if claim?.showClaimClosedFlow ?? false {
-                    homeNavigationVm.navBarItems.isNewOfferPresented = true
-                    claimsStore.send(.fetchClaims)
+            .onDeinit {
+                Task {
+                    let claimsStore: ClaimsStore = globalPresentableStoreContainer.get()
+                    if claim?.showClaimClosedFlow ?? false {
+                        homeNavigationVm.navBarItems.isNewOfferPresented = true
+                        let service: hFetchClaimDetailsClient = Dependencies.shared.resolve()
+                        if let claimId = claim?.id {
+                            try await service.acknowledgeClosedStatus(claimId: claimId)
+                        }
+                        claimsStore.send(.fetchClaims)
+                    }
                 }
             }
     }

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -344,6 +344,11 @@ struct HomeTab: View {
                     ClaimDetailView(claim: claim, type: .claim(id: claim.id))
                         .environmentObject(homeNavigationVm)
                         .configureTitle(L10n.claimsYourClaim)
+                        .onDisappear {
+                            if claim.showClaimClosedFlow {
+                                homeNavigationVm.navBarItems.isNewOfferPresented = true
+                            }
+                        }
                 }
                 .routerDestination(for: String.self) { conversation in
                     InboxView()
@@ -474,6 +479,11 @@ struct HomeTab: View {
                             let claim = claimStore.state.claimFromConversation(for: id)
                             ClaimDetailView(claim: claim, type: .conversation(id: id))
                                 .configureTitle(L10n.claimsYourClaim)
+                                .onDisappear {
+                                    if let claim, claim.showClaimClosedFlow {
+                                        homeNavigationVm.navBarItems.isNewOfferPresented = true
+                                    }
+                                }
                         }
                     }
                 )

--- a/Projects/Claims/GraphQL/Octopus/ClaimAcknowledgeClosedStatus.graphql
+++ b/Projects/Claims/GraphQL/Octopus/ClaimAcknowledgeClosedStatus.graphql
@@ -1,8 +1,5 @@
 mutation ClaimAcknowledgeClosedStatus($claimAcknowledgeClosedStatusId: ID!) {
   claimAcknowledgeClosedStatus(id: $claimAcknowledgeClosedStatusId) {
-    claim {
-        ...ClaimFragment
-    }
     userError {
       message
     }

--- a/Projects/Claims/GraphQL/Octopus/ClaimAcknowledgeClosedStatus.graphql
+++ b/Projects/Claims/GraphQL/Octopus/ClaimAcknowledgeClosedStatus.graphql
@@ -1,0 +1,10 @@
+mutation ClaimAcknowledgeClosedStatus($claimAcknowledgeClosedStatusId: ID!) {
+  claimAcknowledgeClosedStatus(id: $claimAcknowledgeClosedStatusId) {
+    claim {
+        ...ClaimFragment
+    }
+    userError {
+      message
+    }
+  }
+}

--- a/Projects/Claims/GraphQL/Octopus/Claims.graphql
+++ b/Projects/Claims/GraphQL/Octopus/Claims.graphql
@@ -25,4 +25,5 @@ fragment ClaimFragment on Claim {
     conversation {
         ...ConversationFragment
     }
+    showClaimClosedFlow
 }

--- a/Projects/Claims/Sources/Models/ClaimModel.swift
+++ b/Projects/Claims/Sources/Models/ClaimModel.swift
@@ -18,8 +18,8 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
         claimType: String,
         incidentDate: String?,
         productVariant: ProductVariant?,
-        conversation: Conversation?
-
+        conversation: Conversation?,
+        showClaimClosedFlow: Bool
     ) {
         self.id = id
         self.status = status
@@ -33,6 +33,7 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
         self.incidentDate = incidentDate
         self.productVariant = productVariant
         self.conversation = conversation
+        self.showClaimClosedFlow = showClaimClosedFlow
     }
 
     public let claimType: String
@@ -47,6 +48,7 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public let payoutAmount: MonetaryAmount?
     public let targetFileUploadUri: String
     public let conversation: Conversation?
+    public let showClaimClosedFlow: Bool
     public var statusParagraph: String {
         switch self.status {
         case .submitted:

--- a/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
+++ b/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
@@ -24,5 +24,5 @@ public class FetchClaimDetailsClientDemo: hFetchClaimDetailsClient {
         return (claimId: "1", files: [])
     }
 
-    public func acknowledgeClosedStatus(statusId: String) async throws {}
+    public func acknowledgeClosedStatus(claimId: String) async throws {}
 }

--- a/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
+++ b/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
@@ -24,7 +24,5 @@ public class FetchClaimDetailsClientDemo: hFetchClaimDetailsClient {
         return (claimId: "1", files: [])
     }
 
-    public func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel? {
-        return nil
-    }
+    public func acknowledgeClosedStatus(statusId: String) async throws {}
 }

--- a/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
+++ b/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
@@ -15,11 +15,16 @@ public class FetchClaimDetailsClientDemo: hFetchClaimDetailsClient {
             claimType: "",
             incidentDate: nil,
             productVariant: nil,
-            conversation: nil
+            conversation: nil,
+            showClaimClosedFlow: true
         )
     }
 
     public func getFiles(for type: FetchClaimDetailsType) async throws -> (claimId: String, files: [hCore.File]) {
         return (claimId: "1", files: [])
+    }
+
+    public func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel? {
+        return nil
     }
 }

--- a/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimClientOctopus.swift
@@ -33,6 +33,7 @@ extension ClaimModel {
         self.productVariant = .init(data: claim.productVariant?.fragments.productVariantFragment)
         self.claimType = claim.claimType ?? ""
         self.conversation = .init(fragment: claim.conversation.fragments.conversationFragment, type: .claim)
+        self.showClaimClosedFlow = claim.showClaimClosedFlow
     }
 }
 

--- a/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimDetailsClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimDetailsClientOctopus.swift
@@ -50,8 +50,8 @@ public class FetchClaimDetailsClientOctopus: hFetchClaimDetailsClient {
         }
     }
 
-    public func acknowledgeClosedStatus(statusId: String) async throws {
-        let mutation = OctopusGraphQL.ClaimAcknowledgeClosedStatusMutation(claimAcknowledgeClosedStatusId: statusId)
+    public func acknowledgeClosedStatus(claimId: String) async throws {
+        let mutation = OctopusGraphQL.ClaimAcknowledgeClosedStatusMutation(claimAcknowledgeClosedStatusId: claimId)
         let data = try await octopus.client.perform(mutation: mutation)
         if let userError = data.claimAcknowledgeClosedStatus?.userError {
             throw FetchClaimDetailsError.serviceError(message: userError.message ?? L10n.General.errorBody)

--- a/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimDetailsClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/FetchClaimDetailsClientOctopus.swift
@@ -50,14 +50,11 @@ public class FetchClaimDetailsClientOctopus: hFetchClaimDetailsClient {
         }
     }
 
-    public func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel? {
+    public func acknowledgeClosedStatus(statusId: String) async throws {
         let mutation = OctopusGraphQL.ClaimAcknowledgeClosedStatusMutation(claimAcknowledgeClosedStatusId: statusId)
         let data = try await octopus.client.perform(mutation: mutation)
-        if let claimFragment = data.claimAcknowledgeClosedStatus?.claim?.fragments.claimFragment {
-            return ClaimModel(claim: claimFragment)
-        } else if let userError = data.claimAcknowledgeClosedStatus?.userError {
+        if let userError = data.claimAcknowledgeClosedStatus?.userError {
             throw FetchClaimDetailsError.serviceError(message: userError.message ?? L10n.General.errorBody)
         }
-        return nil
     }
 }

--- a/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
+++ b/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
@@ -22,7 +22,7 @@ class FetchClaimDetailsService {
         return try await client.getFiles(for: type)
     }
 
-    func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel? {
+    func acknowledgeClosedStatus(statusId: String) async throws {
         log.info("\(FetchClaimDetailsService.self): acknowledgeClosedStatus for \(type)", error: nil, attributes: nil)
         return try await client.acknowledgeClosedStatus(statusId: statusId)
     }
@@ -32,7 +32,7 @@ class FetchClaimDetailsService {
 public protocol hFetchClaimDetailsClient {
     func get(for type: FetchClaimDetailsType) async throws -> ClaimModel
     func getFiles(for type: FetchClaimDetailsType) async throws -> (claimId: String, files: [File])
-    func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel?
+    func acknowledgeClosedStatus(statusId: String) async throws
 }
 
 public enum FetchClaimDetailsType {

--- a/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
+++ b/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
@@ -24,7 +24,7 @@ class FetchClaimDetailsService {
 
     func acknowledgeClosedStatus(statusId: String) async throws {
         log.info("\(FetchClaimDetailsService.self): acknowledgeClosedStatus for \(type)", error: nil, attributes: nil)
-        return try await client.acknowledgeClosedStatus(statusId: statusId)
+        return try await client.acknowledgeClosedStatus(claimId: statusId)
     }
 }
 
@@ -32,7 +32,7 @@ class FetchClaimDetailsService {
 public protocol hFetchClaimDetailsClient {
     func get(for type: FetchClaimDetailsType) async throws -> ClaimModel
     func getFiles(for type: FetchClaimDetailsType) async throws -> (claimId: String, files: [File])
-    func acknowledgeClosedStatus(statusId: String) async throws
+    func acknowledgeClosedStatus(claimId: String) async throws
 }
 
 public enum FetchClaimDetailsType {

--- a/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
+++ b/Projects/Claims/Sources/Service/Protocols/FetchClaimDetailsClient.swift
@@ -21,12 +21,18 @@ class FetchClaimDetailsService {
         log.info("\(FetchClaimDetailsService.self): getFiles for \(type)", error: nil, attributes: nil)
         return try await client.getFiles(for: type)
     }
+
+    func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel? {
+        log.info("\(FetchClaimDetailsService.self): acknowledgeClosedStatus for \(type)", error: nil, attributes: nil)
+        return try await client.acknowledgeClosedStatus(statusId: statusId)
+    }
 }
 
 @MainActor
 public protocol hFetchClaimDetailsClient {
     func get(for type: FetchClaimDetailsType) async throws -> ClaimModel
     func getFiles(for type: FetchClaimDetailsType) async throws -> (claimId: String, files: [File])
+    func acknowledgeClosedStatus(statusId: String) async throws -> ClaimModel?
 }
 
 public enum FetchClaimDetailsType {
@@ -36,6 +42,7 @@ public enum FetchClaimDetailsType {
 
 enum FetchClaimDetailsError: Error {
     case noClaimFound
+    case serviceError(message: String)
 }
 
 extension FetchClaimDetailsError: LocalizedError {

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -395,7 +395,8 @@ struct ClaimDetailView_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return ClaimDetailView(
             claim: claim,

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -136,11 +136,6 @@ public struct ClaimDetailView: View {
                 })
             )
         )
-        .onDisappear {
-            Task {
-                await vm.acknowledgeClosedStatus()
-            }
-        }
     }
 
     @ViewBuilder
@@ -558,13 +553,6 @@ public class ClaimDetailViewModel: ObservableObject {
 
     var canAddFiles: Bool {
         return self.claim?.status != .closed && fetchFilesError == nil
-    }
-
-    @MainActor
-    func acknowledgeClosedStatus() async {
-        do {
-            try await claimDetailsService.acknowledgeClosedStatus(statusId: self.claim?.id ?? "")
-        } catch {}
     }
 }
 

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -136,6 +136,11 @@ public struct ClaimDetailView: View {
                 })
             )
         )
+        .onDisappear {
+            Task {
+                await vm.acknowledgeClosedStatus()
+            }
+        }
     }
 
     @ViewBuilder
@@ -553,6 +558,13 @@ public class ClaimDetailViewModel: ObservableObject {
 
     var canAddFiles: Bool {
         return self.claim?.status != .closed && fetchFilesError == nil
+    }
+
+    @MainActor
+    func acknowledgeClosedStatus() async {
+        do {
+            try await claimDetailsService.acknowledgeClosedStatus(statusId: self.claim?.id ?? "")
+        } catch {}
     }
 }
 

--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -139,7 +139,8 @@ struct ClaimBeingHandled_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)
@@ -173,7 +174,8 @@ struct ClaimReopened_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)
@@ -207,7 +209,8 @@ struct ClaimPaid_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)
@@ -240,7 +243,8 @@ struct ClaimNotCompensated_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)
@@ -274,7 +278,8 @@ struct ClaimNotCovered_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)
@@ -308,7 +313,8 @@ struct ClaimClosed_Previews: PreviewProvider {
                 hasClaim: true,
                 claimType: "claim type",
                 unreadMessageCount: 0
-            )
+            ),
+            showClaimClosedFlow: true
         )
         return VStack(spacing: 20) {
             ClaimStatus(claim: data, enableTap: true)


### PR DESCRIPTION
## [GEN-3389]

- Added `showClaimClosedFlow` and `claimAcknowledgeClosedStatus` mutation from schema
- After dismissing claim details screen, show cross sell if `showClaimClosedFlow` is true, then call `claimAcknowledgeClosedStatus`

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
