### PR TITLE
GEN-3477: Add claim outcome unresponsive

### DIFF
--- a/Projects/Claims/Sources/Models/ClaimModel.swift
+++ b/Projects/Claims/Sources/Models/ClaimModel.swift
@@ -70,6 +70,8 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
                 return L10n.ClaimStatus.Closed.supportText
             case .missingReceipt:
                 return L10n.ClaimStatus.MissingReceipt.supportText
+            case .unresponsive:
+                return L10n.claimOutcomeUnresponsiveSupportText
             case .none:
                 return ""
             }
@@ -122,6 +124,7 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
         case none
         case closed
         case missingReceipt
+        case unresponsive
 
         public init?(
             rawValue: RawValue
@@ -132,6 +135,7 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
             case "NOT_COVERED": self = .notCovered
             case "CLOSED": self = .closed
             case "MISSING_RECIEPT": self = .missingReceipt
+            case "UNRESPONSIVE": self = .unresponsive
             default: self = .none
             }
         }
@@ -150,6 +154,8 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
                 return L10n.ClaimStatusDetail.closed
             case .missingReceipt:
                 return L10n.ClaimStatusDetail.missingReceipt
+            case .unresponsive:
+                return L10n.Claim.Decision.unresponsive
             }
         }
     }

--- a/Projects/Claims/Sources/Views/ClaimStatus.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatus.swift
@@ -93,7 +93,7 @@ struct ClaimPills: View {
 extension ClaimModel.ClaimOutcome {
     var color: PillColor {
         switch self {
-        case .none, .notCompensated, .notCovered, .paid, .closed:
+        case .none, .notCompensated, .notCovered, .paid, .closed, .unresponsive:
             .grey
         case .missingReceipt:
             .amber
@@ -102,7 +102,7 @@ extension ClaimModel.ClaimOutcome {
 
     var colorLevel: PillColor.PillColorLevel {
         switch self {
-        case .none, .notCompensated, .notCovered:
+        case .none, .notCompensated, .notCovered, .unresponsive:
             .two
         case .paid, .closed, .missingReceipt:
             .three


### PR DESCRIPTION
## [APP-XXX]

- Add handling of claim outcome UNRESPONSIVE

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
