### PR TITLE
Remove “success” pop-up after adding/removing co-insured

### DIFF
--- a/Projects/EditCoInsured/Sources/Navigation/EditCoInsuredNavigation.swift
+++ b/Projects/EditCoInsured/Sources/Navigation/EditCoInsuredNavigation.swift
@@ -201,18 +201,6 @@ public struct EditCoInsuredNavigation: View {
         .environmentObject(editCoInsuredViewModel)
     }
 
-    func openSuccessScreen(title: String) -> some View {
-        hForm {
-            SuccessScreen(title: title)
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        editCoInsuredNavigationVm.coInsuredInputModel = nil
-                    }
-                }
-        }
-        .hFormContentPosition(.compact)
-    }
-
     func openRemoveCoInsuredScreen() -> some View {
         return RemoveCoInsuredScreen(
             vm: editCoInsuredNavigationVm.coInsuredViewModel
@@ -224,19 +212,6 @@ public struct EditCoInsuredNavigation: View {
         openCoInsuredInput(
             coInsuredModelEdit: coInsuredInputModel
         )
-        .routerDestination(for: CoInsuredAction.self, options: .hidesBackButton) { actionType in
-            var title: String {
-                switch actionType {
-                case .add:
-                    return L10n.contractCoinsuredAdded
-                case .delete:
-                    return L10n.contractCoinsuredRemoved
-                default:
-                    return ""
-                }
-            }
-            openSuccessScreen(title: title)
-        }
     }
 }
 

--- a/Projects/EditCoInsured/Sources/View/CoInusuredInput.swift
+++ b/Projects/EditCoInsured/Sources/View/CoInusuredInput.swift
@@ -137,6 +137,7 @@ struct CoInusuredInputScreen: View {
                                             )
                                         }
                                     }
+                                    editCoInsuredNavigation.coInsuredInputModel = nil
                                 }
                             } content: {
                                 hText(L10n.removeConfirmationButton)
@@ -177,6 +178,7 @@ struct CoInusuredInputScreen: View {
                                                     origin: .coinsuredInput,
                                                     coInsured: insuredPeopleVm.completeList()
                                                 )
+                                                editCoInsuredNavigation.coInsuredInputModel = nil
                                             } else {
                                                 let coInsuredToAdd: CoInsuredModel = {
                                                     if vm.noSSN {
@@ -208,6 +210,7 @@ struct CoInusuredInputScreen: View {
                                                 {
                                                     insuredPeopleVm.addCoInsured(coInsuredToAdd)
                                                 }
+                                                editCoInsuredNavigation.coInsuredInputModel = nil
                                             }
 
                                             if !intentViewModel.showErrorViewForCoInsuredInput {

--- a/Projects/EditCoInsured/Sources/View/NewCoInsured/InsuredPeopleNewScreen.swift
+++ b/Projects/EditCoInsured/Sources/View/NewCoInsured/InsuredPeopleNewScreen.swift
@@ -26,8 +26,6 @@ struct InsuredPeopleNewScreen: View {
                         .verticalPadding(0)
                         .padding(.top, .padding16)
                     }
-                    //                    .hWithoutHorizontalPadding([.row])
-                    //                    .sectionContainerStyle(.transparent)
 
                     hSection {
                         ForEach(Array(listToDisplay.enumerated()), id: \.0) {


### PR DESCRIPTION
## [APP-XXX]

- [Slack thread](https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1743000721483029)
- [Figma](https://www.figma.com/design/WlwFCAWywXNcXVgPfYVmWu/Final-Design?node-id=14559-27305&t=z9szKmT9erXzUTIu-0)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
