### PR TITLE
Fixed width of processing screen + showAsList date picker fix

### DIFF
--- a/Projects/Claims/Sources/Views/ClaimFilesView.swift
+++ b/Projects/Claims/Sources/Views/ClaimFilesView.swift
@@ -137,17 +137,19 @@ public struct ClaimFilesView: View {
     }
 
     private var loadingView: some View {
-        hSection {
-            VStack(spacing: 20) {
-                Spacer()
-                hText(L10n.fileUploadIsUploading)
-                ProgressView(value: vm.progress)
-                    .frame(width: UIScreen.main.bounds.width * 0.53)
-                    .progressViewStyle(hProgressViewStyle())
-                Spacer()
+        GeometryReader { proxy in
+            hSection {
+                VStack(spacing: 20) {
+                    Spacer()
+                    hText(L10n.fileUploadIsUploading)
+                    ProgressView(value: vm.progress)
+                        .frame(width: proxy.size.width * 0.53)
+                        .progressViewStyle(hProgressViewStyle())
+                    Spacer()
+                }
             }
+            .sectionContainerStyle(.transparent)
         }
-        .sectionContainerStyle(.transparent)
     }
 
     private var successView: some View {

--- a/Projects/hCoreUI/Sources/Views/GeneralDatePicker.swift
+++ b/Projects/hCoreUI/Sources/Views/GeneralDatePicker.swift
@@ -17,9 +17,9 @@ public struct DatePickerView: View {
                 HStack {
                     if vm.config.showAsList ?? false {
                         datePicker
-                            .datePickerStyle(.wheel)
-                            .padding(.trailing, 23)
                             .padding(.bottom, .padding16)
+                            .labelsHidden()
+                            .datePickerStyle(.wheel)
                     } else {
                         datePicker
                             .tint(hSignalColor.Green.element)
@@ -112,6 +112,7 @@ public struct DatePickerView: View {
 struct DatePickerView_Previews: PreviewProvider {
     @State static var date = Date()
     static var previews: some View {
+        Dependencies.shared.add(module: Module { () -> DateService in DateService() })
         return VStack {
             DatePickerView(
                 vm:
@@ -121,7 +122,8 @@ struct DatePickerView_Previews: PreviewProvider {
                         date: $date,
                         config: .init(
                             placeholder: "PLACEHOLDER",
-                            title: "TITLE"
+                            title: "TITLE",
+                            showAsList: true
                         )
                     )
             )
@@ -301,10 +303,14 @@ struct hDatePickerField_Previews: PreviewProvider {
         hDatePickerField
         .HDatePickerFieldConfig(
             placeholder: "Placeholder",
-            title: "Departure date"
+            title: "Departure date",
+            showAsList: true
         )
     static var previews: some View {
-        VStack {
+
+        Dependencies.shared.add(module: Module { () -> DateService in DateService() })
+
+        return VStack {
             hDatePickerField(config: config, selectedDate: dateForSmall)
                 .hFieldSize(.small)
             hDatePickerField(config: config, selectedDate: dateForSmallWithRealDate)

--- a/Projects/hCoreUI/Sources/Views/ProcessingStateView.swift
+++ b/Projects/hCoreUI/Sources/Views/ProcessingStateView.swift
@@ -117,30 +117,33 @@ public struct ProcessingStateView: View {
 
     @ViewBuilder
     private var loadingView: some View {
-        ZStack(alignment: .bottom) {
-            BackgroundView().ignoresSafeArea()
-            VStack {
-                Spacer()
-                hText(loadingViewText)
-                ProgressView(value: vm.progress)
-                    .frame(width: UIScreen.main.bounds.width * 0.53)
-                    .accessibilityHidden(true)
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            animationTimings.forEach { item in
-                                withAnimation(
-                                    .easeInOut(duration: TimeInterval(item.duration)).delay(TimeInterval(item.delay))
-                                ) {
-                                    vm.progress = item.progress
+        GeometryReader { proxy in
+            ZStack(alignment: .bottom) {
+                BackgroundView().ignoresSafeArea()
+                VStack {
+                    Spacer()
+                    hText(loadingViewText)
+                    ProgressView(value: vm.progress)
+                        .frame(width: proxy.size.width * 0.53)
+                        .accessibilityHidden(true)
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                animationTimings.forEach { item in
+                                    withAnimation(
+                                        .easeInOut(duration: TimeInterval(item.duration))
+                                            .delay(TimeInterval(item.delay))
+                                    ) {
+                                        vm.progress = item.progress
+                                    }
                                 }
                             }
                         }
-                    }
-                    .progressViewStyle(hProgressViewStyle())
-                Spacer()
+                        .progressViewStyle(hProgressViewStyle())
+                    Spacer()
+                }
             }
+            .accessibilityElement(children: .combine)
         }
-        .accessibilityElement(children: .combine)
     }
 }
 


### PR DESCRIPTION
## [APP-XXX]

- Updated processing screen progress bar width
![Simulator Screenshot - iPad mini (A17 Pro) - 2025-03-27 at 15 38 45](https://github.com/user-attachments/assets/5e8ddde8-a23b-43c0-8964-aa406992358b)

- Updated date picker when having showAsList set to true
![simulator_screenshot_AFADFF66-7374-4CF3-9D3B-6A761BE8E936](https://github.com/user-attachments/assets/bcf55801-3439-44b5-ae95-bd79b954a241)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
