### PR TITLE
GEN-3530: Add cross sell screen for other flows

### DIFF
--- a/Projects/Addons/Sources/Views/AddonProcessingScreen.swift
+++ b/Projects/Addons/Sources/Views/AddonProcessingScreen.swift
@@ -19,6 +19,16 @@ struct AddonProcessingScreen: View {
             state: $vm.submittingAddonsViewState
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak vm] in
+            if vm?.submittingAddonsViewState == .success {
+                Task {
+                    NotificationCenter.default.post(
+                        name: .addonAdded,
+                        object: nil
+                    )
+                }
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
+++ b/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
@@ -50,13 +50,6 @@ public class ChangeAddonViewModel: ObservableObject {
                 addonId: selectedQuote?.addonId ?? ""
             )
             logAddonEvent()
-            Task {
-                try await Task.sleep(nanoseconds: 1_000_000_000)
-                NotificationCenter.default.post(
-                    name: .addonAdded,
-                    object: nil
-                )
-            }
             withAnimation {
                 self.submittingAddonsViewState = .success
             }

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -443,7 +443,8 @@ struct HomeTab: View {
         }
         .detent(
             item: $homeNavigationVm.navBarItems.isNewOfferPresented,
-            style: [.height]
+            style: [.height],
+            options: .constant(.alwaysOpenOnTop)
         ) { claimInfo in
             CrossSellingScreen(
                 addonCardOnClick: { contractIds in
@@ -617,17 +618,18 @@ class LoggedInNavigationViewModel: ObservableObject {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(fetchAddons),
+            selector: #selector(addonAdded),
             name: .addonAdded,
             object: nil
         )
     }
 
-    @objc func fetchAddons(notification: Notification) {
+    @objc func addonAdded(notification: Notification) {
         Task {
             let store: CrossSellStore = globalPresentableStoreContainer.get()
             await store.sendAsync(.fetchAddonBanner)
         }
+        NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .moveFlow))
     }
 
     @objc func openDeepLinkNotification(notification: Notification) {

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -498,7 +498,7 @@ struct HomeTab: View {
                     let claimsStore: ClaimsStore = globalPresentableStoreContainer.get()
                     if claim?.showClaimClosedFlow ?? false {
                         if let claim = claim {
-                            homeNavigationVm.navBarItems.isNewOfferPresented = claim.asCrossSellInfo
+                            NotificationCenter.default.post(name: .openCrossSell, object: claim.asCrossSellInfo)
                             let service: hFetchClaimDetailsClient = Dependencies.shared.resolve()
                             try await service.acknowledgeClosedStatus(claimId: claim.id)
                             claimsStore.send(.fetchClaims)

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -629,7 +629,7 @@ class LoggedInNavigationViewModel: ObservableObject {
             let store: CrossSellStore = globalPresentableStoreContainer.get()
             await store.sendAsync(.fetchAddonBanner)
         }
-        NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .moveFlow))
+        NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .addon))
     }
 
     @objc func openDeepLinkNotification(notification: Notification) {

--- a/Projects/ChangeTier/Sources/Views/ChangeTierProcessingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierProcessingScreen.swift
@@ -1,3 +1,4 @@
+import CrossSell
 import SwiftUI
 import hCore
 import hCoreUI
@@ -20,6 +21,11 @@ struct ChangeTierProcessingView: View {
             state: $vm.viewState
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak vm] in
+            if vm?.viewState == .success {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .changeTier))
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
@@ -1,0 +1,49 @@
+import Foundation
+import hCore
+import hGraphQL
+
+public struct CrossSellInfo: Identifiable, Equatable, Sendable {
+    public static func == (lhs: CrossSellInfo, rhs: CrossSellInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public let id: String = UUID().uuidString
+    public let type: CrossSellInfoType
+    let additionalInfo: (any Encodable & Sendable)?
+
+    public init<T>(type: CrossSellInfoType, additionalInfo: T) where T: Encodable & Codable & Sendable {
+        self.type = type
+        self.additionalInfo = additionalInfo
+    }
+
+    public init(type: CrossSellInfoType) {
+        self.type = type
+        self.additionalInfo = nil
+    }
+
+    public enum CrossSellInfoType: String, Codable, Equatable, Sendable {
+        case home
+        case claim
+        case changeTier
+        case addon
+        case coInsured
+        case moveFlow
+    }
+
+    fileprivate func asLogData() -> [AttributeKey: AttributeValue] {
+        var data = [AttributeKey: AttributeValue]()
+        data["source"] = type.rawValue
+        data["info"] = additionalInfo
+        return data
+    }
+
+    @MainActor
+    func logCrossSellEvent() {
+        log.addUserAction(
+            type: .custom,
+            name: "crossSell",
+            error: nil,
+            attributes: self.asLogData()
+        )
+    }
+}

--- a/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
@@ -28,6 +28,15 @@ public struct CrossSellInfo: Identifiable, Equatable, Sendable {
         case addon
         case coInsured
         case moveFlow
+
+        public var delayInNanoSeconds: UInt64 {
+            switch self {
+            case .home, .claim:
+                return 0
+            case .changeTier, .addon, .coInsured, .moveFlow:
+                return 1_200_000_000
+            }
+        }
     }
 
     fileprivate func asLogData() -> [AttributeKey: AttributeValue] {
@@ -46,4 +55,5 @@ public struct CrossSellInfo: Identifiable, Equatable, Sendable {
             attributes: self.asLogData()
         )
     }
+
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
@@ -15,7 +15,7 @@ public struct CrossSellingScreen: View {
         info: CrossSellInfo
     ) {
         self.addonCardOnClick = addonCardOnClick
-        logCrossSellEvent(info: info)
+        info.logCrossSellEvent()
     }
 
     public var body: some View {
@@ -64,50 +64,6 @@ public struct CrossSellingScreen: View {
                 .sectionContainerStyle(.transparent)
             }
         }
-    }
-
-    private func logCrossSellEvent(info: CrossSellInfo) {
-        log.addUserAction(
-            type: .custom,
-            name: "crossSell",
-            error: nil,
-            attributes: info.asLogData()
-        )
-    }
-}
-
-public struct CrossSellInfo: Identifiable, Equatable {
-    public static func == (lhs: CrossSellInfo, rhs: CrossSellInfo) -> Bool {
-        lhs.id == rhs.id
-    }
-
-    public let id: String = UUID().uuidString
-    public let type: CrossSellInfoType
-    let additionalInfo: (any Encodable)?
-
-    public init<T>(type: CrossSellInfoType, additionalInfo: T) where T: Encodable & Equatable {
-        self.type = type
-        self.additionalInfo = additionalInfo
-    }
-
-    public init(type: CrossSellInfoType) {
-        self.type = type
-        self.additionalInfo = nil
-    }
-
-    public enum CrossSellInfoType: String, Codable, Equatable {
-        case home
-        case claim
-        case changeTier
-        case addon
-        case coInsured
-    }
-
-    fileprivate func asLogData() -> [AttributeKey: AttributeValue] {
-        var data = [AttributeKey: AttributeValue]()
-        data["source"] = type.rawValue
-        data["info"] = additionalInfo
-        return data
     }
 }
 

--- a/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
@@ -15,7 +15,10 @@ public struct CrossSellingScreen: View {
         info: CrossSellInfo
     ) {
         self.addonCardOnClick = addonCardOnClick
-        info.logCrossSellEvent()
+        Task {
+            try await Task.sleep(nanoseconds: 200_000_000)
+            info.logCrossSellEvent()
+        }
     }
 
     public var body: some View {

--- a/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
+++ b/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import CrossSell
 import Foundation
 import hCore
 
@@ -86,16 +87,18 @@ public class EditCoInsuredViewModel: ObservableObject {
                 }
             }
 
-            try await Task.sleep(nanoseconds: 400_000_000)
-
             if let missingContract {
+                try await Task.sleep(nanoseconds: 400_000_000)
                 let missingContractConfig = InsuredPeopleConfig(
                     contract: missingContract,
                     preSelectedCoInsuredList: existingCoInsured.get(contractId: missingContract.id),
                     fromInfoCard: false
                 )
                 editCoInsuredModelMissingAlert = missingContractConfig
+            } else {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .coInsured))
             }
+
         }
     }
 }

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -58,6 +58,15 @@ public class HomeNavigationViewModel: ObservableObject {
             }
         }
 
+        NotificationCenter.default.addObserver(forName: .openCrossSell, object: nil, queue: nil) {
+            [weak self] notification in
+            if let crossSellInfo = notification.object as? CrossSellInfo {
+                Task { @MainActor in
+                    self?.navBarItems.isNewOfferPresented = crossSellInfo
+                }
+            }
+        }
+
     }
 
     public var router = Router()

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -25,6 +25,7 @@ public struct ChatConversation: Equatable, Identifiable, Sendable {
 @MainActor
 public class HomeNavigationViewModel: ObservableObject {
     public static var isChatPresented = false
+    private var didShowCrossSellAfterSuccessFlow = false
     private var cancellables = Set<AnyCancellable>()
     public init() {
 
@@ -62,8 +63,16 @@ public class HomeNavigationViewModel: ObservableObject {
             [weak self] notification in
             if let crossSellInfo = notification.object as? CrossSellInfo {
                 Task { @MainActor in
-                    try await Task.sleep(nanoseconds: 1_200_000_000)
-                    self?.navBarItems.isNewOfferPresented = crossSellInfo
+                    let typesForWhichWeShouldShowAlways = [
+                        CrossSellInfo.CrossSellInfoType.claim, CrossSellInfo.CrossSellInfoType.home,
+                    ]
+                    if self?.didShowCrossSellAfterSuccessFlow == false
+                        || typesForWhichWeShouldShowAlways.contains(crossSellInfo.type)
+                    {
+                        try await Task.sleep(nanoseconds: crossSellInfo.type.delayInNanoSeconds)
+                        self?.didShowCrossSellAfterSuccessFlow = true
+                        self?.navBarItems.isNewOfferPresented = crossSellInfo
+                    }
                 }
             }
         }

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -70,7 +70,9 @@ public class HomeNavigationViewModel: ObservableObject {
                         || typesForWhichWeShouldShowAlways.contains(crossSellInfo.type)
                     {
                         try await Task.sleep(nanoseconds: crossSellInfo.type.delayInNanoSeconds)
-                        self?.didShowCrossSellAfterSuccessFlow = true
+                        if crossSellInfo.type != CrossSellInfo.CrossSellInfoType.home {
+                            self?.didShowCrossSellAfterSuccessFlow = true
+                        }
                         self?.navBarItems.isNewOfferPresented = crossSellInfo
                     }
                 }

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -62,6 +62,7 @@ public class HomeNavigationViewModel: ObservableObject {
             [weak self] notification in
             if let crossSellInfo = notification.object as? CrossSellInfo {
                 Task { @MainActor in
+                    try await Task.sleep(nanoseconds: 1_200_000_000)
                     self?.navBarItems.isNewOfferPresented = crossSellInfo
                 }
             }

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -3,6 +3,7 @@ import Chat
 import Claims
 import Combine
 import Contracts
+import CrossSell
 import Foundation
 import Payment
 import PresentableStore
@@ -31,7 +32,7 @@ extension HomeScreen {
             action: { type in
                 switch type {
                 case .newOffer:
-                    navigationVm.navBarItems.isNewOfferPresented = .init(type: .home)
+                    NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .home))
                 case .firstVet:
                     navigationVm.navBarItems.isFirstVetPresented = true
                 case .chat, .chatNotification:

--- a/Projects/MoveFlow/Sources/View/MovingFlowProcessingScreen.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowProcessingScreen.swift
@@ -1,3 +1,4 @@
+import CrossSell
 import PresentableStore
 import SwiftUI
 import hCore
@@ -25,6 +26,11 @@ struct MovingFlowProcessingScreen: View {
             duration: 6
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak movingFlowConfirmVm] in
+            if movingFlowConfirmVm?.viewState == .success {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .moveFlow))
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/hCore/Sources/NotificationCenter+NotificationName.swift
+++ b/Projects/hCore/Sources/NotificationCenter+NotificationName.swift
@@ -8,4 +8,6 @@ extension Notification.Name {
     public static let openDeepLink = Notification.Name("openDeepLink")
     public static let registerForPushNotifications = Notification.Name("registerForPushNotifications")
     public static let addonAdded = Notification.Name("addonAdded")
+    public static let openCrossSell = Notification.Name("openCrossSell")
+
 }


### PR DESCRIPTION

Added cross sells after:
1. moving flow 
2. edit co insured
3. add-on flow (either add or upgrade)
4. change tier flow

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
