### PR TITLE
Add cross sell screen for other flows

### DIFF
--- a/Projects/Addons/Sources/Views/AddonProcessingScreen.swift
+++ b/Projects/Addons/Sources/Views/AddonProcessingScreen.swift
@@ -19,6 +19,16 @@ struct AddonProcessingScreen: View {
             state: $vm.submittingAddonsViewState
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak vm] in
+            if vm?.submittingAddonsViewState == .success {
+                Task {
+                    NotificationCenter.default.post(
+                        name: .addonAdded,
+                        object: nil
+                    )
+                }
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
+++ b/Projects/Addons/Sources/Views/ChangeAddonViewModel.swift
@@ -50,13 +50,6 @@ public class ChangeAddonViewModel: ObservableObject {
                 addonId: selectedQuote?.addonId ?? ""
             )
             logAddonEvent()
-            Task {
-                try await Task.sleep(nanoseconds: 1_000_000_000)
-                NotificationCenter.default.post(
-                    name: .addonAdded,
-                    object: nil
-                )
-            }
             withAnimation {
                 self.submittingAddonsViewState = .success
             }

--- a/Projects/ChangeTier/Sources/Views/ChangeTierProcessingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierProcessingScreen.swift
@@ -1,3 +1,4 @@
+import CrossSell
 import SwiftUI
 import hCore
 import hCoreUI
@@ -20,6 +21,11 @@ struct ChangeTierProcessingView: View {
             state: $vm.viewState
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak vm] in
+            if vm?.viewState == .success {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .changeTier))
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellInfo.swift
@@ -1,0 +1,59 @@
+import Foundation
+import hCore
+import hGraphQL
+
+public struct CrossSellInfo: Identifiable, Equatable, Sendable {
+    public static func == (lhs: CrossSellInfo, rhs: CrossSellInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public let id: String = UUID().uuidString
+    public let type: CrossSellInfoType
+    let additionalInfo: (any Encodable & Sendable)?
+
+    public init<T>(type: CrossSellInfoType, additionalInfo: T) where T: Encodable & Codable & Sendable {
+        self.type = type
+        self.additionalInfo = additionalInfo
+    }
+
+    public init(type: CrossSellInfoType) {
+        self.type = type
+        self.additionalInfo = nil
+    }
+
+    public enum CrossSellInfoType: String, Codable, Equatable, Sendable {
+        case home
+        case claim
+        case changeTier
+        case addon
+        case coInsured
+        case moveFlow
+
+        public var delayInNanoSeconds: UInt64 {
+            switch self {
+            case .home, .claim:
+                return 0
+            case .changeTier, .addon, .coInsured, .moveFlow:
+                return 1_200_000_000
+            }
+        }
+    }
+
+    fileprivate func asLogData() -> [AttributeKey: AttributeValue] {
+        var data = [AttributeKey: AttributeValue]()
+        data["source"] = type.rawValue
+        data["info"] = additionalInfo
+        return data
+    }
+
+    @MainActor
+    func logCrossSellEvent() {
+        log.addUserAction(
+            type: .custom,
+            name: "crossSell",
+            error: nil,
+            attributes: self.asLogData()
+        )
+    }
+
+}

--- a/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingScreen.swift
@@ -15,7 +15,10 @@ public struct CrossSellingScreen: View {
         info: CrossSellInfo
     ) {
         self.addonCardOnClick = addonCardOnClick
-        logCrossSellEvent(info: info)
+        Task {
+            try await Task.sleep(nanoseconds: 200_000_000)
+            info.logCrossSellEvent()
+        }
     }
 
     public var body: some View {
@@ -64,50 +67,6 @@ public struct CrossSellingScreen: View {
                 .sectionContainerStyle(.transparent)
             }
         }
-    }
-
-    private func logCrossSellEvent(info: CrossSellInfo) {
-        log.addUserAction(
-            type: .custom,
-            name: "crossSell",
-            error: nil,
-            attributes: info.asLogData()
-        )
-    }
-}
-
-public struct CrossSellInfo: Identifiable, Equatable {
-    public static func == (lhs: CrossSellInfo, rhs: CrossSellInfo) -> Bool {
-        lhs.id == rhs.id
-    }
-
-    public let id: String = UUID().uuidString
-    public let type: CrossSellInfoType
-    let additionalInfo: (any Encodable)?
-
-    public init<T>(type: CrossSellInfoType, additionalInfo: T) where T: Encodable & Equatable {
-        self.type = type
-        self.additionalInfo = additionalInfo
-    }
-
-    public init(type: CrossSellInfoType) {
-        self.type = type
-        self.additionalInfo = nil
-    }
-
-    public enum CrossSellInfoType: String, Codable, Equatable {
-        case home
-        case claim
-        case changeTier
-        case addon
-        case coInsured
-    }
-
-    fileprivate func asLogData() -> [AttributeKey: AttributeValue] {
-        var data = [AttributeKey: AttributeValue]()
-        data["source"] = type.rawValue
-        data["info"] = additionalInfo
-        return data
     }
 }
 

--- a/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
+++ b/Projects/EditCoInsuredShared/Sources/Models/EditCoInsuredViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import CrossSell
 import Foundation
 import hCore
 
@@ -86,16 +87,18 @@ public class EditCoInsuredViewModel: ObservableObject {
                 }
             }
 
-            try await Task.sleep(nanoseconds: 400_000_000)
-
             if let missingContract {
+                try await Task.sleep(nanoseconds: 400_000_000)
                 let missingContractConfig = InsuredPeopleConfig(
                     contract: missingContract,
                     preSelectedCoInsuredList: existingCoInsured.get(contractId: missingContract.id),
                     fromInfoCard: false
                 )
                 editCoInsuredModelMissingAlert = missingContractConfig
+            } else {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .coInsured))
             }
+
         }
     }
 }

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -3,6 +3,7 @@ import Chat
 import Claims
 import Combine
 import Contracts
+import CrossSell
 import Foundation
 import Payment
 import PresentableStore
@@ -31,7 +32,7 @@ extension HomeScreen {
             action: { type in
                 switch type {
                 case .newOffer:
-                    navigationVm.navBarItems.isNewOfferPresented = .init(type: .home)
+                    NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .home))
                 case .firstVet:
                     navigationVm.navBarItems.isFirstVetPresented = true
                 case .chat, .chatNotification:

--- a/Projects/MoveFlow/Sources/View/MovingFlowProcessingScreen.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowProcessingScreen.swift
@@ -1,3 +1,4 @@
+import CrossSell
 import PresentableStore
 import SwiftUI
 import hCore
@@ -25,6 +26,11 @@ struct MovingFlowProcessingScreen: View {
             duration: 6
         )
         .hStateViewButtonConfig(errorButtons)
+        .onDeinit { [weak movingFlowConfirmVm] in
+            if movingFlowConfirmVm?.viewState == .success {
+                NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .moveFlow))
+            }
+        }
     }
 
     private var errorButtons: StateViewButtonConfig {

--- a/Projects/hCore/Sources/NotificationCenter+NotificationName.swift
+++ b/Projects/hCore/Sources/NotificationCenter+NotificationName.swift
@@ -8,4 +8,6 @@ extension Notification.Name {
     public static let openDeepLink = Notification.Name("openDeepLink")
     public static let registerForPushNotifications = Notification.Name("registerForPushNotifications")
     public static let addonAdded = Notification.Name("addonAdded")
+    public static let openCrossSell = Notification.Name("openCrossSell")
+
 }


### PR DESCRIPTION
Added cross sells after:
- moving flow
- edit co insured
- add-on flow (either add or upgrade)
- change tier flow

Show cross sale only once after success flow

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
