### PR TITLE
GEN-3558: Upgrade datadog dependency version to 2.25

### DIFF
--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
@@ -16,7 +16,6 @@ struct HelpCenterPill: View {
         self.color = color
     }
 
-    @hColorBuilder
     var body: some View {
         hPill(text: title, color: color)
             .hFieldSize(.small)

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -56,7 +56,7 @@ public enum ExternalDependencies: CaseIterable {
             ]
         case .reveal: return []
         case .datadog:
-            return [.package(url: "https://github.com/DataDog/dd-sdk-ios.git", .exact("2.23.0"))]
+            return [.package(url: "https://github.com/DataDog/dd-sdk-ios.git", .exact("2.25.0"))]
         case .authlib:
             return [
                 .package(url: "https://github.com/HedvigInsurance/authlib.git", .exact("1.4.120241009085400"))


### PR DESCRIPTION
## [GEN-3558]

- Upgraded Datadog dependency to version 25.5 in order to be compatible with Xcode 16.3

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
