### PR TITLE
Added activity wrapper since it is necessary for iPad

### DIFF
--- a/Projects/Forever/Sources/DiscountCodeSection.swift
+++ b/Projects/Forever/Sources/DiscountCodeSection.swift
@@ -28,7 +28,9 @@ struct DiscountCodeSectionView: View {
             if let code = foreverNavigationVm.foreverData?.discountCode {
                 ActionButtons(
                     code: code,
-                    onShare: { foreverNavigationVm.shareCode(code: code) },
+                    onShare: { vm in
+                        foreverNavigationVm.shareCode(code: code, modalPresentationWrapperVM: vm)
+                    },
                     onChange: { foreverNavigationVm.isChangeCodePresented = true }
                 )
             }
@@ -58,15 +60,23 @@ private struct DiscountCodeField: View {
 
 private struct ActionButtons: View {
     let code: String
-    let onShare: () -> Void
+    let onShare: (_ vm: ModalPresentationSourceWrapperViewModel) -> Void
     let onChange: () -> Void
-
+    @State var modalPresentationSourceWrapperViewModel = ModalPresentationSourceWrapperViewModel()
     var body: some View {
         hSection {
             VStack(spacing: .padding8) {
-                hButton.LargeButton(type: .primary, action: onShare) {
-                    hText(L10n.ReferralsEmpty.shareCodeButton)
-                }
+                ModalPresentationSourceWrapper(
+                    content: {
+                        hButton.LargeButton(type: .primary) {
+                            onShare(modalPresentationSourceWrapperViewModel)
+                        } content: {
+                            hText(L10n.ReferralsEmpty.shareCodeButton)
+                        }
+                    },
+                    vm: modalPresentationSourceWrapperViewModel
+                )
+
                 hButton.LargeButton(type: .ghost, action: onChange) {
                     hText(L10n.ReferralsChange.changeCode)
                 }

--- a/Projects/Forever/Sources/Navigation/ForeverNavigation.swift
+++ b/Projects/Forever/Sources/Navigation/ForeverNavigation.swift
@@ -28,9 +28,8 @@ public class ForeverNavigationViewModel: ObservableObject {
             }
         }
     }
-    var modalPresentationSourceWrapperViewModel = ModalPresentationSourceWrapperViewModel()
 
-    func shareCode(code: String) {
+    func shareCode(code: String, modalPresentationWrapperVM: ModalPresentationSourceWrapperViewModel) {
         let discount = foreverData?.monthlyDiscountPerReferral.formattedAmount
         let url =
             "\(hGraphQL.Environment.current.webBaseURL)/\(hCore.Localization.Locale.currentLocale.value.webPath)/forever/\(code)"
@@ -40,7 +39,7 @@ public class ForeverNavigationViewModel: ObservableObject {
             activityItems: [message as Any],
             applicationActivities: nil
         )
-        modalPresentationSourceWrapperViewModel.present(activity: activityVC)
+        modalPresentationWrapperVM.present(activity: activityVC)
     }
 }
 


### PR DESCRIPTION
## [APP-XXX]

- For iPad it is necessary to set source view and rect when presenting `UIActivityViewController`
![simulator_screenshot_46AF6C3D-DEE5-49FE-8E5E-40C72E106420](https://github.com/user-attachments/assets/6b72d9e1-1e38-4876-b74b-4ec097bd149e)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
