### PR TITLE
GEN-3608: Fix for radio button when not selected and disabled

### DIFF
--- a/Projects/hCoreUI/Sources/hForm/RadioFields/hRadioOptionField.swift
+++ b/Projects/hCoreUI/Sources/hForm/RadioFields/hRadioOptionField.swift
@@ -79,7 +79,11 @@ public struct hRadioOptionSelectedView<T>: View where T: Equatable {
     @hColorBuilder
     static func getFillColor(isSelected: Bool, enabled: Bool) -> some hColor {
         if !enabled {
-            hFillColor.Translucent.disabled
+            if isSelected {
+                hFillColor.Translucent.disabled
+            } else {
+                hSurfaceColor.Opaque.primary
+            }
         } else if isSelected {
             hSignalColor.Green.element
         } else {


### PR DESCRIPTION
## [GEN-3608]

- Bug fix when radio button is disabled and not selected. Looked like all options were selected before.
- [Slack thread](https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1744814689560039)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
