### PR TITLE
GEN-3619: Bugfix for showing coinsured info card incorrect in travel certificate

### DIFF
--- a/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
+++ b/Projects/TravelCertificate/Sources/Views/WhoIsTravelingScreen.swift
@@ -93,7 +93,7 @@ class WhoIsTravelingViewModel: ObservableObject {
         coInsured.append(insuranceHolder)
         coInsured.append(contentsOf: contract?.coInsured.filter({ !$0.hasMissingInfo }) ?? [])
         coInsuredModelData = coInsured
-        hasMissingCoInsuredData = contract?.coInsured.allSatisfy({ $0.hasMissingInfo }) ?? false
+        hasMissingCoInsuredData = contract?.coInsured.filter({ $0.hasMissingInfo }).count != 0
     }
 
     func setCoInsured(data: [PolicyCoinsuredPersonModel]) {


### PR DESCRIPTION
## [GEN-3619]

- Change 1
- Change 2

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
