### PR TITLE
Remove animation on text when contract is expanded

### DIFF
--- a/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsContractDetails.swift
+++ b/Projects/Payment/Sources/Screens/PaymentDetails/PaymentDetailsContractDetails.swift
@@ -57,6 +57,8 @@ struct ContractDetails: View {
                         .foregroundColor(hTextColor.Translucent.secondary)
                 }
             }
+            .lineLimit(expandedContracts.contains(contract.id) ? nil : 1)
+
         }
         .withEmptyAccessory
         .onTap {
@@ -145,7 +147,7 @@ struct ContractDetails: View {
             contract: .init(
                 id: "id1",
                 title: "title long title thatgoes 2 lines",
-                subtitle: "subtitle",
+                subtitle: "subtitle which is long so it takes 2 so we can see how it looks",
                 netAmount: .sek(250),
                 grossAmount: .sek(200),
                 discounts: [


### PR DESCRIPTION
## [APP-XXX]

- [Notion](https://www.notion.so/hedviginsurance/Weird-transition-on-the-text-just-make-it-instant-with-no-animation-on-text-1f3c3f71cb0a80afb02cc20c1d80f280)
- Change 2

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
