### PR TITLE
GEN-3768: Fix accessibility voice over issue

### DIFF
--- a/Projects/SubmitClaim/Sources/Views/AudioRecording/AudioRecorder.swift
+++ b/Projects/SubmitClaim/Sources/Views/AudioRecording/AudioRecorder.swift
@@ -3,7 +3,8 @@ import Combine
 import SwiftUI
 import hCoreUI
 
-public class AudioRecorder: ObservableObject {
+@MainActor
+public class AudioRecorder: @preconcurrency ObservableObject {
     public static let audioFileExtension = "m4a"
     private let filePath: URL
 
@@ -84,6 +85,14 @@ public class AudioRecorder: ObservableObject {
     private func stopRecording() {
         recorder?.stop()
         isRecording = false
+
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default, options: [])
+            try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("Failed to reset AVAudioSession: \(error)")
+        }
+
         if FileManager.default.fileExists(atPath: filePath.relativePath) {
             self.recording = Recording(url: filePath, created: Date(), sample: decibelScale)
         }


### PR DESCRIPTION
## [GEN-3768]

- Fixed issue with voicover being mute after stopping recording.
- https://reports.useit.se/hedvig-iosapp-may2025/problems/recording-a-clip-highjacks-the-audio-of-voiceover/ 

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
