### PR TITLE
GEN-3769: Fix for claims flow triaging voiceover when error message is displayed

### DIFF
--- a/Projects/SubmitClaim/Sources/Views/Entrypoints/SelectClaimEntrypoint.swift
+++ b/Projects/SubmitClaim/Sources/Views/Entrypoints/SelectClaimEntrypoint.swift
@@ -325,6 +325,9 @@ struct ShowTagList: View {
                     } else {
                         withAnimation {
                             notValid = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                UIAccessibility.post(notification: .announcement, argument: L10n.claimsSelectCategory)
+                            }
                         }
                         selection = ""
                     }


### PR DESCRIPTION
## [GEN-3769]

- Display error when visible 
- [Change 2](https://reports.useit.se/hedvig-iosapp-may2025/problems/error-messages-not-read-with-voiceover/)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
