### PR TITLE
GEN-3770: Accessibility grouping of headers and text

### DIFF
--- a/Projects/Addons/Sources/Views/AddonLearnMoreView.swift
+++ b/Projects/Addons/Sources/Views/AddonLearnMoreView.swift
@@ -11,16 +11,17 @@ struct AddonLearnMoreView: View {
                 hSection {
                     VStack(alignment: .leading, spacing: .padding4) {
                         hText(model.title, style: .body2)
+                            .accessibilityAddTraits(.isHeader)
                         hText(model.description, style: .body1)
                             .foregroundColor(hTextColor.Opaque.secondary)
                     }
                     .fixedSize(horizontal: false, vertical: true)
-                    .accessibilityElement(children: .combine)
 
                     hPill(text: L10n.addonLearnMoreLabel, color: .blue)
                         .hFieldSize(.medium)
                         .padding(.top, .padding32)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityAddTraits(.isHeader)
                 }
                 .sectionContainerStyle(.transparent)
 

--- a/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
+++ b/Projects/App/Sources/Screens/ClaimsScreen/Screens/ClaimFlowAskForPushnotifications.swift
@@ -47,12 +47,12 @@ struct AskForPushNotifications: View {
                     .accessibilityHidden(true)
                 VStack(spacing: 0) {
                     hText(L10n.activateNotificationsTitle)
+                        .accessibilityAddTraits(.isHeader)
                     hText(text)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, .padding32)
                         .foregroundColor(hTextColor.Opaque.secondary)
                 }
-                .accessibilityElement(children: .combine)
                 hButton(
                     .medium,
                     .primary,

--- a/Projects/App/Sources/Screens/ClaimsScreen/Screens/HonestyPledge.swift
+++ b/Projects/App/Sources/Screens/ClaimsScreen/Screens/HonestyPledge.swift
@@ -164,7 +164,6 @@ struct HonestyPledge: View {
                     }
                     .padding(.bottom, .padding32)
                 }
-                .accessibilityElement(children: .combine)
 
                 SlideToConfirm(onConfirmAction: {
                     onConfirmAction?()

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents.swift
@@ -113,11 +113,11 @@ struct SupportView: View {
                 VStack(spacing: 0) {
                     hText(L10n.hcChatQuestion)
                         .foregroundColor(hTextColor.Translucent.primary)
+                        .accessibilityAddTraits(.isHeader)
                     hText(L10n.hcChatAnswer)
                         .foregroundColor(hTextColor.Translucent.secondary)
                         .multilineTextAlignment(.center)
                 }
-                .accessibilityElement(children: .combine)
                 PresentableStoreLens(HomeStore.self) { state in
                     state.hasSentOrRecievedAtLeastOneMessage
                 } _: { hasSentOrRecievedAtLeastOneMessage in

--- a/Projects/SubmitClaim/Sources/Views/SummaryInfo/SubmitClaimSummaryScreen.swift
+++ b/Projects/SubmitClaim/Sources/Views/SummaryInfo/SubmitClaimSummaryScreen.swift
@@ -38,7 +38,6 @@ public struct SubmitClaimSummaryScreen: View {
                 .withHeader(title: L10n.changeAddressDetails)
                 .padding(.top, .padding16)
                 .sectionContainerStyle(.transparent)
-                .accessibilityElement(children: .combine)
 
                 hSection {
                     hRowDivider()
@@ -177,6 +176,7 @@ public struct SubmitClaimSummaryScreen: View {
                 Spacer()
                 value.hText(.body1).foregroundColor(hTextColor.Opaque.secondary)
             }
+            .accessibilityElement(children: .combine)
         }
     }
 

--- a/Projects/hCoreUI/Sources/Peril/Accordion.swift
+++ b/Projects/hCoreUI/Sources/Peril/Accordion.swift
@@ -5,126 +5,136 @@ public struct AccordionView: View {
     let peril: Perils?
     let title: String
     let description: String
-    @State var extended = false
+    @State private var extended = false
 
-    public init(
-        peril: Perils
-    ) {
+    public init(peril: Perils) {
         self.peril = peril
         self.title = peril.title
         self.description = peril.description
     }
 
-    public init(
-        title: String,
-        description: String
-    ) {
+    public init(title: String, description: String) {
         self.title = title
         self.description = description
         self.peril = nil
     }
 
     public var body: some View {
-        SwiftUI.Button {
-            withAnimation {
-                extended.toggle()
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: {
+                withAnimation {
+                    extended.toggle()
+                    UIAccessibility.post(notification: .layoutChanged, argument: nil)
+                }
+            }) {
+                AccordionHeader(
+                    peril: peril,
+                    title: title,
+                    extended: extended
+                )
+                .padding(.horizontal, .padding16)
+                .padding(.vertical, 17)
             }
-        } label: {
-            EmptyView()
+            .accessibilityLabel("\(title)")
+            .accessibilityAddTraits(.isButton)
+            .modifier(
+                BackgorundColorAnimation(
+                    animationTrigger: $extended,
+                    color: hSurfaceColor.Opaque.primary,
+                    animationColor: hSurfaceColor.Opaque.secondary
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: .cornerRadiusL))
+
+            if extended {
+                AccordionBody(peril: peril, description: description)
+                    .padding(.bottom, .padding8)
+                    .accessibilityElement(children: .contain)
+            }
         }
-        .buttonStyle(
-            AccordionButtonStyle(
-                peril: peril,
-                title: title,
-                description: description,
-                extended: $extended
-            )
-        )
-        .modifier(
-            BackgorundColorAnimation(
-                animationTrigger: $extended,
-                color: hSurfaceColor.Opaque.primary,
-                animationColor: hSurfaceColor.Opaque.secondary
-            )
-        )
-        .clipShape(RoundedRectangle(cornerRadius: .cornerRadiusL))
     }
 }
 
-struct AccordionButtonStyle: SwiftUI.ButtonStyle {
-    var peril: Perils?
+struct AccordionHeader: View {
+    let peril: Perils?
     let title: String
-    let description: String
+    let extended: Bool
 
-    @Binding var extended: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        VStack(alignment: .center, spacing: 11) {
-            HStack(alignment: .top, spacing: .padding8) {
-                if let color = peril?.color {
-                    Group {
-                        if peril?.isDisabled ?? false {
-                            Circle()
-                                .fill(hFillColor.Opaque.disabled)
-                        } else {
-                            Circle()
-                                .fill(Color(hexString: color))
-                        }
+    var body: some View {
+        HStack(alignment: .top, spacing: .padding8) {
+            if let color = peril?.color {
+                Group {
+                    if peril?.isDisabled ?? false {
+                        Circle()
+                            .fill(hFillColor.Opaque.disabled)
+                    } else {
+                        Circle()
+                            .fill(Color(hexString: color))
                     }
-                    .frame(width: 16, height: 16)
-                    .padding([.horizontal, .vertical], .padding4)
                 }
-                hText(title, style: .body1)
-                    .lineLimit(extended ? nil : 1)
-                    .foregroundColor(getTextColor)
-                Spacer()
-                ZStack {
-                    Group {
-                        Image(
-                            uiImage: hCoreUIAssets.minus.image
-                        )
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .transition(.opacity.animation(.easeOut))
-                        .rotationEffect(extended ? Angle(degrees: 360) : Angle(degrees: 270))
-                        Image(
-                            uiImage: hCoreUIAssets.minus.image
-                        )
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .transition(.opacity.animation(.easeOut))
-                        .rotationEffect(extended ? Angle(degrees: 360) : Angle(degrees: 180))
-                    }
-                    .foregroundColor(getTextColor)
-                }
+                .frame(width: 16, height: 16)
+                .padding([.horizontal, .vertical], .padding4)
             }
-
-            if extended {
-                VStack(alignment: .leading, spacing: .padding12) {
-                    hText(description, style: peril != nil ? .label : .body1)
-                        .padding(.bottom, .padding12)
-                        .foregroundColor(getTextColor)
-                    if let perilCover = peril?.covered {
-                        ForEach(Array(perilCover.enumerated()), id: \.offset) { index, item in
-                            HStack(alignment: .top, spacing: 8) {
-                                if perilCover.count > 1 {
-                                    hText(String(format: "%02d", index + 1), style: .label)
-                                        .foregroundColor(hTextColor.Opaque.tertiary)
-                                }
-                                hText(item, style: .label)
-                            }
-                        }
-                    }
+            hText(title, style: .body1)
+                .lineLimit(extended ? nil : 1)
+                .foregroundColor(getTextColor)
+            Spacer()
+            ZStack {
+                Group {
+                    Image(
+                        uiImage: hCoreUIAssets.minus.image
+                    )
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .transition(.opacity.animation(.easeOut))
+                    .rotationEffect(extended ? Angle(degrees: 360) : Angle(degrees: 270))
+                    Image(
+                        uiImage: hCoreUIAssets.minus.image
+                    )
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .transition(.opacity.animation(.easeOut))
+                    .rotationEffect(extended ? Angle(degrees: 360) : Angle(degrees: 180))
                 }
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, .padding32)
+                .foregroundColor(getTextColor)
             }
         }
-        .padding(.horizontal, .padding16)
-        .padding(.top, 15)
-        .padding(.bottom, 17)
-        .contentShape(Rectangle())
+        .accessibilityAddTraits(extended ? .isHeader : [])
+    }
 
+    @hColorBuilder
+    var getTextColor: some hColor {
+        if peril?.isDisabled ?? false {
+            hTextColor.Opaque.disabled
+        } else {
+            hTextColor.Opaque.primary
+        }
+    }
+}
+
+struct AccordionBody: View {
+    let peril: Perils?
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: .padding12) {
+            hText(description, style: peril != nil ? .label : .body1)
+                .padding(.bottom, .padding12)
+                .foregroundColor(getTextColor)
+            if let perilCover = peril?.covered {
+                ForEach(Array(perilCover.enumerated()), id: \.offset) { index, item in
+                    HStack(alignment: .top, spacing: 8) {
+                        if perilCover.count > 1 {
+                            hText(String(format: "%02d", index + 1), style: .label)
+                                .foregroundColor(hTextColor.Opaque.tertiary)
+                        }
+                        hText(item, style: .label)
+                    }
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, .padding32)
     }
 
     @hColorBuilder

--- a/Projects/hCoreUI/Sources/Router/Router.swift
+++ b/Projects/hCoreUI/Sources/Router/Router.swift
@@ -356,6 +356,7 @@ extension View {
                 VStack(alignment: .leading, spacing: 0) {
                     hText(title, style: .heading1)
                         .foregroundColor(titleViewColor(titleColor))
+                        .accessibilityAddTraits(.isHeader)
                     hText(subTitle, style: .heading1)
                         .foregroundColor(hTextColor.Opaque.secondary)
                 }
@@ -367,7 +368,6 @@ extension View {
             }
         }
         .padding(.top, .padding8)
-        .accessibilityElement(children: .combine)
     }
 
     @hColorBuilder


### PR DESCRIPTION
## [GEN-3770]

- [Change 2](https://reports.useit.se/hedvig-iosapp-may2025/problems/unnecessary-grouping-of-objects/)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
