### PR TITLE
Fixed perils spacing for insurance details

### DIFF
--- a/Projects/Contracts/Sources/View/ContractCoverage.swift
+++ b/Projects/Contracts/Sources/View/ContractCoverage.swift
@@ -23,7 +23,6 @@ struct ContractCoverageView: View {
                     },
                     perils: contract.allPerils
                 )
-                .hWithoutHorizontalPadding([.row, .divider])
             }
         }
     }

--- a/Projects/hCoreUI/Sources/Views/CoverageView.swift
+++ b/Projects/hCoreUI/Sources/Views/CoverageView.swift
@@ -23,6 +23,7 @@ public struct CoverageView: View {
             ) { limit in
                 didTapInsurableLimit(limit)
             }
+            .hWithoutHorizontalPadding([.row, .divider])
             VStack(spacing: .padding32) {
                 ForEach(perils, id: \.title) { perils in
                     VStack(spacing: .padding8) {
@@ -43,6 +44,7 @@ public struct CoverageView: View {
                     }
                 }
             }
+            .hWithoutHorizontalPadding([.section, .divider])
         }
     }
 }


### PR DESCRIPTION
Spacing for perils in insurance details increased and needs to be reduced. Moving hWithoutHorizontalPadding to CoverageView fixes it

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
