### PR TITLE
Feature/cross sell/tooltip timming update

### DIFF
--- a/Projects/App/Sources/Navigation/MainNavigation.swift
+++ b/Projects/App/Sources/Navigation/MainNavigation.swift
@@ -150,6 +150,10 @@ class MainNavigationViewModel: ObservableObject {
             }
         }
         configureAppBadgeTracking()
+
+        //we want to show it initially when app launches if there is any
+        ToolbarOptionType.newOfferNotification.resetTooltipDisplayState()
+        ToolbarOptionType.chatNotification.resetTooltipDisplayState()
     }
 
     private func checkForFeatureFlags() async {

--- a/Projects/hCoreUI/Sources/ToolbarButtonView/TooltipType.swift
+++ b/Projects/hCoreUI/Sources/ToolbarButtonView/TooltipType.swift
@@ -104,7 +104,7 @@ public enum ToolbarOptionType: Int, Hashable, Codable, Equatable, Sendable {
         case .travelCertificate, .insuranceEvidence:
             return 60
         case .newOfferNotification:
-            return 60
+            return 60 * 10  // 10 minutes
         default:
             return nil
         }
@@ -239,6 +239,10 @@ public enum ToolbarOptionType: Int, Hashable, Codable, Equatable, Sendable {
 
     var userDefaultsKey: String {
         "tooltip_\(tooltipId)_past_date"
+    }
+
+    public func resetTooltipDisplayState() {
+        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
     }
 
 }


### PR DESCRIPTION
If we have new offer:
- show new offer tooltip max once per 10 minutes
- show new offer tooltip when app starts

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
