### PR TITLE
GEN-3786: Increase target area for chat and dismiss button

### DIFF
--- a/Projects/Chat/Sources/Views/ChatInputView.swift
+++ b/Projects/Chat/Sources/Views/ChatInputView.swift
@@ -67,6 +67,7 @@ struct ChatInputView: View {
                     .frame(width: 24, height: 24)
                     .padding(.padding8)
             }
+            .frame(width: 44, height: 44)
             .accessibilityValue(L10n.voiceoverChatSendMessageButton)
         }
         .padding(.leading, .padding4)

--- a/Projects/hCoreUI/Sources/View+dismissButton.swift
+++ b/Projects/hCoreUI/Sources/View+dismissButton.swift
@@ -90,6 +90,7 @@ private struct CloseButtonModifier: ViewModifier {
                     hCoreUIAssets.close.view
                         .offset(y: CGFloat(-reducedTopSpacing))
                 }
+                .frame(width: 44, height: 44)
                 .foregroundColor(hTextColor.Opaque.primary)
                 .accessibilityLabel(L10n.a11YBack)
             }


### PR DESCRIPTION
## [GEN-3786]

- Increase click target are to 44x44 which is minimum for accessibility
- Chat send button and dismiss buttom

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
