### PR TITLE
Fix for success screen to use hForm instead of view

### DIFF
--- a/Projects/Forever/Sources/Navigation/ForeverNavigation.swift
+++ b/Projects/Forever/Sources/Navigation/ForeverNavigation.swift
@@ -58,6 +58,7 @@ extension ForeverRouterActions: TrackingViewNameProtocol {
 
 public struct ForeverNavigation: View {
     @EnvironmentObject var router: Router
+    private var changeCodeRouter = Router()
     @StateObject var foreverNavigationVm = ForeverNavigationViewModel()
     let useOwnNavigation: Bool
 
@@ -85,16 +86,17 @@ public struct ForeverNavigation: View {
                 .routerDestination(for: ForeverRouterActions.self, options: .hidesBackButton) { routerAction in
                     switch routerAction {
                     case .success:
-                        SuccessScreen(title: L10n.ReferralsChange.codeChanged)
-                            .onAppear { [weak router] in
+                        SuccessScreen(title: L10n.ReferralsChange.codeChanged, formPosition: .compact)
+                            .onAppear { [weak changeCodeRouter] in
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                    router?.dismiss()
+                                    changeCodeRouter?.dismiss()
                                 }
                             }
                     }
                 }
                 .configureTitle(L10n.ReferralsChange.changeCode)
                 .embededInNavigation(
+                    router: changeCodeRouter,
                     options: [.navigationType(type: .large)],
                     tracking: ForeverNavigationDetentType.changeCode
                 )

--- a/Projects/hCoreUI/Sources/Views/SuccessScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/SuccessScreen.swift
@@ -4,13 +4,16 @@ import hCore
 public struct SuccessScreen: View {
     let title: String?
     let subTitle: String?
+    let formPosition: ContentPosition?
 
     public init(
         title: String? = nil,
-        subtitle: String? = nil
+        subtitle: String? = nil,
+        formPosition: ContentPosition? = nil
     ) {
         self.title = title
         self.subTitle = subtitle
+        self.formPosition = formPosition
     }
 
     public init(
@@ -19,13 +22,15 @@ public struct SuccessScreen: View {
     ) {
         self.title = successViewTitle
         self.subTitle = successViewBody
+        self.formPosition = nil
     }
 
     public var body: some View {
         StateView(
             type: .success,
             title: title ?? "",
-            bodyText: subTitle
+            bodyText: subTitle,
+            formPosition: formPosition
         )
     }
 }


### PR DESCRIPTION
Fixed issue reported [here](https://www.notion.so/hedviginsurance/iOS-Design-fixes-1f8c3f71cb0a80d9a1c7c8d48398eb5a?p=1f3c3f71cb0a80038ec9ff34bd6266ed&pm=s)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
