### PR TITLE
Only top view shouldn't ignore keyboard

### DIFF
--- a/Projects/SubmitClaim/Sources/Views/AudioRecording/SubmitClaimAudioRecordingScreen.swift
+++ b/Projects/SubmitClaim/Sources/Views/AudioRecording/SubmitClaimAudioRecordingScreen.swift
@@ -65,8 +65,6 @@ public struct SubmitClaimAudioRecordingScreen: View {
                 textSection(questions: audioRecordingStep?.textQuestions)
             }
         }
-        .ignoresSafeArea(.keyboard, edges: .bottom)
-        .hFormObserveKeyboard(to: false)
         .hFormAlwaysAttachToBottom {
             Group {
                 if isAudioInput {

--- a/Projects/SubmitClaim/Sources/Views/SingleItem/SubmitClaimSingleItemScreen.swift
+++ b/Projects/SubmitClaim/Sources/Views/SingleItem/SubmitClaimSingleItemScreen.swift
@@ -11,39 +11,42 @@ public struct SubmitClaimSingleItemScreen: View {
     public init() {}
 
     public var body: some View {
-        hForm {}
-            .hFormTitle(
-                title: .init(
-                    .small,
-                    .heading2,
-                    L10n.claimsSingleItemDetails,
-                    alignment: .leading
-                )
+        hForm {
+            hSection {
+                getFields(singleItemStep: claimsNavigationVm.singleItemModel)
+            }
+        }
+        .hFormContentPosition(.bottom)
+        .hFormTitle(
+            title: .init(
+                .small,
+                .heading2,
+                L10n.claimsSingleItemDetails,
+                alignment: .leading
             )
-            .hFormAttachToBottom {
-                hSection {
-                    getFields(singleItemStep: claimsNavigationVm.singleItemModel)
+        )
+        .hFormAttachToBottom {
+            hSection {
+                hContinueButton {
+                    if let singleItemModel = claimsNavigationVm.singleItemModel {
+                        Task {
+                            let step = await vm.singleItemRequest(
+                                context: claimsNavigationVm.currentClaimContext ?? "",
+                                model: singleItemModel
+                            )
 
-                    hContinueButton {
-                        if let singleItemModel = claimsNavigationVm.singleItemModel {
-                            Task {
-                                let step = await vm.singleItemRequest(
-                                    context: claimsNavigationVm.currentClaimContext ?? "",
-                                    model: singleItemModel
-                                )
-
-                                if let step {
-                                    claimsNavigationVm.navigate(data: step)
-                                }
+                            if let step {
+                                claimsNavigationVm.navigate(data: step)
                             }
                         }
                     }
-                    .hButtonIsLoading(vm.viewState == .loading)
-                    .disabled(vm.viewState == .loading)
                 }
-                .sectionContainerStyle(.transparent)
+                .hButtonIsLoading(vm.viewState == .loading)
+                .disabled(vm.viewState == .loading)
             }
-            .claimErrorTrackerForState($vm.viewState)
+        }
+        .sectionContainerStyle(.transparent)
+        .claimErrorTrackerForState($vm.viewState)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Fix for this [ticket](https://www.notion.so/hedviginsurance/iOS-Design-fixes-1f8c3f71cb0a80d9a1c7c8d48398eb5a?p=201c3f71cb0a809ab73eeefcf1821f7e&pm=s).
Now only top presented form is tracking keyboard frame

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
