### PR TITLE
Fix for cross sell tap dismiss not working

### DIFF
--- a/Projects/hCoreUI/Sources/PresentationStyle+Detented.swift
+++ b/Projects/hCoreUI/Sources/PresentationStyle+Detented.swift
@@ -737,16 +737,25 @@ public class BlurredSheetPresenationController: UISheetPresentationController {
         useBlur: Bool
     ) {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+
         effectView = useBlur ? PassThroughEffectView(effect: UIBlurEffect(style: .light)) : nil
         effectView?.clipsToBounds = true
         self.presentedViewController.view.layer.cornerRadius = 16
         self.presentedViewController.view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTapBackground))
+        effectView?.addGestureRecognizer(tap)
+        effectView?.isUserInteractionEnabled = true
 
         self.detents = [
             .custom(resolver: { context in
                 return 0
             })
         ]
+    }
+
+    @objc private func didTapBackground() {
+        presentedViewController.dismiss(animated: true)
     }
 
     public override func presentationTransitionWillBegin() {


### PR DESCRIPTION
## [APP-XXX]

- Tap on background to dismiss didn't work. Added logic back to fix this.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
