### PR TITLE
Fixed renewal  in number of days

### DIFF
--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -220,8 +220,8 @@ struct ContractInformationView: View {
         {
             hSection {
                 InfoCard(
-                    text: days == 0
-                        ? L10n.dashboardRenewalPrompterBodyTomorrow : L10n.dashboardRenewalPrompterBody(days),
+                    text: days == 1
+                        ? L10n.dashboardRenewalPrompterBodyTomorrow : L10n.dashboardRenewalPrompterBody(days + 1),
                     type: .info
                 )
                 .buttons([

--- a/Projects/Home/Sources/Screens/Components/RenewalCard.swift
+++ b/Projects/Home/Sources/Screens/Components/RenewalCard.swift
@@ -95,7 +95,7 @@ public struct RenewalCardView: View {
                     if upcomingRenewalContracts.count == 1 {
                         InfoCard(
                             text: L10n.dashboardRenewalPrompterBody(
-                                renewalDate.daysBetween(start: Date())
+                                renewalDate.daysBetween(start: Date()) + 1
                             ),
                             type: .info
                         )
@@ -112,8 +112,9 @@ public struct RenewalCardView: View {
                             .daysBetween(start: Date())
                     {
                         InfoCard(
-                            text: days == 0
-                                ? L10n.dashboardRenewalPrompterBodyTomorrow : L10n.dashboardRenewalPrompterBody(days),
+                            text: days == 1
+                                ? L10n.dashboardRenewalPrompterBodyTomorrow
+                                : L10n.dashboardRenewalPrompterBody(days + 1),
                             type: .info
                         )
                         .buttons([


### PR DESCRIPTION
We have issue with renewal in % days.
For next images taken on 19.06 with a renewal scheduled on 01.07 we had ...in 11 days... but should be 12.
Not sure if I am right here, but seems like we had 1 day off.
| Header | Header |
|--------|--------|
| ![Screenshot 2025-06-19 at 15 47 45](https://github.com/user-attachments/assets/da81228c-7910-4dd7-af62-e7d3d8e52b43) | ![Screenshot 2025-06-19 at 15 47 48-1](https://github.com/user-attachments/assets/bc2ca845-0980-47be-b809-07bdacc85edc) | 



## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
