### PR TITLE
GEN-3900: iOS26 auth updates

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/AuthenticationClientAuthLib.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/AuthenticationClientAuthLib.swift
@@ -6,16 +6,6 @@ import Foundation
 import hCore
 import hGraphQL
 
-protocol HttpClientEngine {
-    func send(request: URLRequest) async throws -> (Data, URLResponse)
-}
-
-struct URLSessionHttpClientEngine: HttpClientEngine {
-    func send(request: URLRequest) async throws -> (Data, URLResponse) {
-        try await URLSession.shared.data(for: request)
-    }
-}
-
 final public class AuthenticationClientAuthLib: AuthenticationClient {
     public init() {}
 
@@ -106,8 +96,7 @@ final public class AuthenticationClientAuthLib: AuthenticationClient {
         do {
             let authUrl = Environment.current.authUrl
             AuthenticationService.logAuthResourceStart(authUrl.absoluteString, authUrl)
-            let repository = self.networkAuthRepository
-            let data = try await repository.startLoginAttempt(
+            let data = try await self.networkAuthRepository.startLoginAttempt(
                 loginMethod: .seBankid,
                 market: .se,
                 personalNumber: nil,

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -2,7 +2,8 @@ import ProjectDescription
 
 let config = Config(
     compatibleXcodeVersions: .list([
-        .upToNextMajor(.init(16, 0, 0))
+        .upToNextMajor(.init(16, 0, 0)),
+        .upToNextMajor(.init(26, 0, 0)),
     ]),
     cloud: nil,
     swiftVersion: nil,


### PR DESCRIPTION
## [GEN-3900]

- Needed to make a few adjustment to auth in order to be compatible with iOS26

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
