### PR TITLE
GEN-3910: iOS26 Help center search bar fix

### DIFF
--- a/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
@@ -66,7 +66,7 @@ public struct HelpCenterStartView: View {
                 }
                 .sectionContainerStyle(.transparent)
                 if !vm.searchInProgress {
-                    SupportView(router: router)
+                    SupportView(router: router, withExtraPadding: true)
                         .padding(.top, .padding40)
                 }
             }

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents/HelpCenterSupportView.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents/HelpCenterSupportView.swift
@@ -7,6 +7,15 @@ struct SupportView: View {
     @PresentableStore var store: HomeStore
     @ObservedObject var router: Router
     @Environment(\.sizeCategory) private var sizeCategory
+    let withExtraPadding: Bool
+
+    init(
+        router: Router,
+        withExtraPadding: Bool? = false
+    ) {
+        self.router = router
+        self.withExtraPadding = withExtraPadding ?? false
+    }
 
     var body: some View {
         hSection {
@@ -31,7 +40,7 @@ struct SupportView: View {
                 buttonView
             }
             .padding(.vertical, .padding32)
-            .supportViewBottomPadding
+            .supportViewBottomPadding(withPadding: withExtraPadding)
         }
         .hWithoutHorizontalPadding([.section])
         .sectionContainerCornerMaskerCorners([.topLeft, .topRight])
@@ -73,11 +82,11 @@ struct SupportView: View {
 }
 
 extension View {
-    var supportViewBottomPadding: some View {
+    func supportViewBottomPadding(withPadding: Bool) -> some View {
         self.padding(
             .bottom,
             {
-                if #available(iOS 26.0, *) {
+                if withPadding, #available(iOS 26.0, *) {
                     return .padding56
                 } else {
                     return .padding8


### PR DESCRIPTION
## [GEN-3910]

- **Problem:** Search bar is moved to bottom in iOS 26 and hides support view.
- **Solution:** Added more padding for iOS26 to not be hidden by search bar
- My first approach was to make the search bar stick to the top but it seems like we would have to create our own custom search bar in that case. Thought this would be easier for now just to make sure that the support view is not hidden and we can update this later on if we feel like it. I also know that we have talked about changing/removing the contact view here so doesn't feel worth spending that much time on it.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
