### PR TITLE
GEN-3897: iOS26 Tab bar fix

### DIFF
--- a/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
+++ b/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
@@ -337,24 +337,26 @@ public struct DefaultStyling {
                 let selectedColor = hFillColor.Opaque.primary.colorFor(.init(style) ?? .light, .base).color.uiColor()
                 let nonSelecetedColor = hFillColor.Translucent.secondary.colorFor(.init(style) ?? .light, .base).color
                     .uiColor()
+
+                let font = Fonts.fontFor(style: .finePrint, withoutFontMultipler: true)
+
                 itemAppearance.normal.iconColor = nonSelecetedColor
                 itemAppearance.normal.titleTextAttributes = [
-                    .font: Fonts.fontFor(style: .finePrint, withoutFontMultipler: true),
-                    .foregroundColor: nonSelecetedColor,
+                    .foregroundColor: nonSelecetedColor
                 ]
+
                 itemAppearance.selected.iconColor = selectedColor
                 itemAppearance.selected.titleTextAttributes = [
-                    .font: Fonts.fontFor(style: .finePrint, withoutFontMultipler: true),
-                    .foregroundColor: selectedColor,
+                    .foregroundColor: selectedColor
                 ]
                 itemAppearance.focused.iconColor = selectedColor
                 itemAppearance.focused.titleTextAttributes = [
-                    .font: Fonts.fontFor(style: .finePrint, withoutFontMultipler: true),
+                    .font: font,
                     .foregroundColor: selectedColor,
                 ]
                 itemAppearance.disabled.iconColor = nonSelecetedColor
                 itemAppearance.disabled.titleTextAttributes = [
-                    .font: Fonts.fontFor(style: .finePrint, withoutFontMultipler: true),
+                    .font: font,
                     .foregroundColor: nonSelecetedColor,
                 ]
             }


### PR DESCRIPTION
## [GEN-3897]

- **GEN-3897** iOS26 added a background to selected background to selected tab and the tab was too wide, taking up space at next tab.
- **Solution:** Removed .font trait for these since these doesn't contribute to anything and made the background too wide.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
