### PR TITLE
GEN-3920: Make dismiss button align in bubble

### DIFF
--- a/Projects/hCoreUI/Sources/View+dismissButton.swift
+++ b/Projects/hCoreUI/Sources/View+dismissButton.swift
@@ -91,7 +91,7 @@ private struct CloseButtonModifier: ViewModifier {
                     vm.vc?.dismiss(animated: true)
                 } label: {
                     hCoreUIAssets.close.view
-                        .offset(y: CGFloat(-reducedTopSpacing))
+                        .closeButtonOffset(y: CGFloat(-reducedTopSpacing))
                         .foregroundColor(hFillColor.Opaque.primary)
                         .frame(minWidth: 44, minHeight: 44)
                 }
@@ -102,5 +102,16 @@ private struct CloseButtonModifier: ViewModifier {
             .introspect(.viewController, on: .iOS(.v13...)) { vc in
                 vm.vc = vc
             }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func closeButtonOffset(y: CGFloat) -> some View {
+        if #available(iOS 26, *) {
+            self
+        } else {
+            self.offset(y: y)
+        }
     }
 }


### PR DESCRIPTION
## [GEN-3920]

- Dismiss button was outside of bubble in iOS26. Removed offset for iOS26 and higher.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
