### PR TITLE
Set darker colour of divider for dark mode

### DIFF
--- a/Projects/hCoreUI/Sources/hColor/hColor.swift
+++ b/Projects/hCoreUI/Sources/hColor/hColor.swift
@@ -720,7 +720,7 @@ public struct hBorderColor {
     public static var secondary: some hColor {
         hColorScheme(
             light: hGrayscaleTranslucentLight.greyScaleTranslucent300,
-            dark: hGrayscaleTranslucentDark.greyScaleTranslucent800
+            dark: hGrayscaleTranslucentDark.greyScaleTranslucent900
         )
     }
 


### PR DESCRIPTION
Reported issue [here](https://www.notion.so/hedviginsurance/1f3c3f71cb0a81ff97f4fb1868e6ad69?v=1f3c3f71cb0a8115a533000cbd526cbb&p=22cc3f71cb0a806a8b8ff1b0bd9582b5&pm=s).
It looks like they want to have darker version of the divider for the dark mode.

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
