### PR TITLE
Cross price when addon is removed on summary screen

### DIFF
--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummaryScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummaryScreen.swift
@@ -237,7 +237,7 @@ private struct ContractCardView: View {
                 newPremium: contract.netPremium,
                 currentPremium: vm.removedContracts.contains(contract.id) ? nil : contract.grossPremium
             )
-            .hWithStrikeThroughPrice(setTo: .crossOldPrice)
+            .hWithStrikeThroughPrice(setTo: vm.removedContracts.contains(contract.id) ? .crossNewPrice : .crossOldPrice)
         }
     }
 


### PR DESCRIPTION
## [APP-XXX]

- Fix for cross price when addon is removed on summary screen
- [Reported here](https://www.notion.so/hedviginsurance/Removed-addon-price-not-crossed-250c3f71cb0a808a97bbd0737d36bc10)

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
