### PR TITLE
Check if addonVariant has any contracts

### DIFF
--- a/Projects/Contracts/Sources/View/ContractDocuments.swift
+++ b/Projects/Contracts/Sources/View/ContractDocuments.swift
@@ -28,7 +28,10 @@ struct ContractDocumentsView: View {
                         contractsNavigationViewModel.document = document
                     }
 
-                    if let addonVariant = contract.currentAgreement?.addonVariant {
+                    let addonVariant = contract.currentAgreement?.addonVariant
+                    let addonHasDocuments = addonVariant?.first(where: { !$0.documents.isEmpty }) != nil
+
+                    if let addonVariant = contract.currentAgreement?.addonVariant, addonHasDocuments {
                         ForEach(addonVariant, id: \.self) { addonVariant in
                             addonDocumentSection(for: addonVariant)
                         }

--- a/Projects/Contracts/Sources/View/ContractDocuments.swift
+++ b/Projects/Contracts/Sources/View/ContractDocuments.swift
@@ -28,10 +28,7 @@ struct ContractDocumentsView: View {
                         contractsNavigationViewModel.document = document
                     }
 
-                    let addonVariant = contract.currentAgreement?.addonVariant
-                    let addonHasDocuments = addonVariant?.first(where: { !$0.documents.isEmpty }) != nil
-
-                    if let addonVariant = contract.currentAgreement?.addonVariant, addonHasDocuments {
+                    if let addonVariant = contract.currentAgreement?.addonVariant {
                         ForEach(addonVariant, id: \.self) { addonVariant in
                             addonDocumentSection(for: addonVariant)
                         }
@@ -43,17 +40,19 @@ struct ContractDocumentsView: View {
 
     @ViewBuilder
     private func addonDocumentSection(for addonVariant: AddonVariant) -> some View {
-        hSection {
-            hPill(text: addonVariant.displayName, color: .blue)
-                .hFieldSize(.medium)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(.top, .padding24)
+        if !addonVariant.documents.isEmpty {
+            hSection {
+                hPill(text: addonVariant.displayName, color: .blue)
+                    .hFieldSize(.medium)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.top, .padding24)
 
-        InsuranceTermView(
-            documents: addonVariant.documents
-        ) { document in
-            contractsNavigationViewModel.document = document
+            InsuranceTermView(
+                documents: addonVariant.documents
+            ) { document in
+                contractsNavigationViewModel.document = document
+            }
         }
     }
 


### PR DESCRIPTION
## [APP-XXX]

- Today we show addon pill "header" under contract documents even if documents are empty
- Added check to not display that header if contracts are empty

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
