### PR TITLE
Instead of showing variant documents, show ones from UpsellTravelAddonQuoteFragment

### DIFF
--- a/Projects/Addons/Sources/Models/AddonOffer.swift
+++ b/Projects/Addons/Sources/Models/AddonOffer.swift
@@ -81,7 +81,7 @@ public struct AddonQuote: Identifiable, Equatable, Hashable, Sendable {
     let displayItems: [AddonDisplayItem]
     let price: MonetaryAmount?
     let addonVariant: AddonVariant?
-
+    public let documents: [hPDFDocument]
     public init(
         displayName: String?,
         quoteId: String,
@@ -89,7 +89,8 @@ public struct AddonQuote: Identifiable, Equatable, Hashable, Sendable {
         addonSubtype: String,
         displayItems: [AddonDisplayItem],
         price: MonetaryAmount?,
-        addonVariant: AddonVariant?
+        addonVariant: AddonVariant?,
+        documents: [hPDFDocument]
     ) {
         self.displayName = displayName
         self.quoteId = quoteId
@@ -98,6 +99,7 @@ public struct AddonQuote: Identifiable, Equatable, Hashable, Sendable {
         self.displayItems = displayItems
         self.price = price
         self.addonVariant = addonVariant
+        self.documents = documents
     }
 }
 

--- a/Projects/Addons/Sources/Models/AddonOffer.swift
+++ b/Projects/Addons/Sources/Models/AddonOffer.swift
@@ -81,7 +81,7 @@ public struct AddonQuote: Identifiable, Equatable, Hashable, Sendable {
     let displayItems: [AddonDisplayItem]
     let price: MonetaryAmount?
     let addonVariant: AddonVariant?
-    public let documents: [hPDFDocument]
+    let documents: [hPDFDocument]
     public init(
         displayName: String?,
         quoteId: String,

--- a/Projects/Addons/Sources/Service/DemoImplementation/AddonsClientDemo.swift
+++ b/Projects/Addons/Sources/Service/DemoImplementation/AddonsClientDemo.swift
@@ -14,7 +14,8 @@ public class AddonsClientDemo: AddonsClient {
                 .init(displayTitle: "Insured people", displayValue: "You+1"),
             ],
             price: .init(amount: "49", currency: "SEK"),
-            addonVariant: nil
+            addonVariant: nil,
+            documents: []
         )
 
         let addons: AddonOffer = .init(
@@ -40,7 +41,8 @@ public class AddonsClientDemo: AddonsClient {
                         perils: [],
                         product: "",
                         termsVersion: ""
-                    )
+                    ),
+                    documents: []
                 ),
             ]
         )

--- a/Projects/Addons/Sources/Views/AddonSelectSubOptionScreen.swift
+++ b/Projects/Addons/Sources/Views/AddonSelectSubOptionScreen.swift
@@ -113,7 +113,11 @@ struct AddonSelectSubOptionScreen: View {
             perils: [],
             product: "",
             termsVersion: ""
-        )
+        ),
+        documents: [
+            .init(displayName: "dodument1", url: "www.hedvig.com", type: .unknown)
+
+        ]
     )
 
     AddonSelectSubOptionScreen(
@@ -144,7 +148,8 @@ struct AddonSelectSubOptionScreen: View {
                         perils: [],
                         product: "",
                         termsVersion: ""
-                    )
+                    ),
+                    documents: []
                 ),
             ]
         ),

--- a/Projects/Addons/Sources/Views/ChangeAddonSummaryScreen.swift
+++ b/Projects/Addons/Sources/Views/ChangeAddonSummaryScreen.swift
@@ -29,7 +29,7 @@ extension ChangeAddonViewModel {
             ),
             netPremium: selectedQuote?.price,
             grossPremium: addonOffer?.currentAddon?.price,
-            documents: selectedQuote?.addonVariant?.documents ?? [],
+            documents: selectedQuote?.documents ?? [],
             onDocumentTap: { document in
                 changeAddonNavigationVm.document = document
             },

--- a/Projects/Addons/Tests/ViewModelTests/AddonsViewModelTests.swift
+++ b/Projects/Addons/Tests/ViewModelTests/AddonsViewModelTests.swift
@@ -29,7 +29,8 @@ final class AddonsViewModelTests: XCTestCase {
                 perils: [],
                 product: "product",
                 termsVersion: "termsVersion"
-            )
+            ),
+            documents: []
         )
 
         let addonModel: AddonOffer = .init(
@@ -52,7 +53,8 @@ final class AddonsViewModelTests: XCTestCase {
                         perils: [],
                         product: "product",
                         termsVersion: "termsVersion"
-                    )
+                    ),
+                    documents: []
                 ),
             ]
         )

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/AddonsClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/AddonsClientOctopus.swift
@@ -31,7 +31,8 @@ class AddonsClientOctopus: AddonsClient {
                         .init(fragment: $0.fragments.upsellTravelAddonDisplayItemFragment)
                     },
                     price: .init(fragment: currentAddon.premium.fragments.moneyFragment),
-                    addonVariant: nil
+                    addonVariant: nil,
+                    documents: []
                 )
             }()
             let addonData = AddonOffer(
@@ -80,6 +81,9 @@ extension AddonQuote {
         let displayItems: [AddonDisplayItem] = fragment.displayItems.map {
             .init(fragment: $0.fragments.upsellTravelAddonDisplayItemFragment)
         }
+        let documents = fragment.documents.compactMap { document in
+            hPDFDocument(displayName: document.displayName, url: document.url, type: .unknown)
+        }
         self.init(
             displayName: fragment.displayName,
             quoteId: fragment.quoteId,
@@ -87,7 +91,8 @@ extension AddonQuote {
             addonSubtype: fragment.addonSubtype,
             displayItems: displayItems,
             price: .init(fragment: fragment.premium.fragments.moneyFragment),
-            addonVariant: .init(fragment: fragment.addonVariant.fragments.addonVariantFragment)
+            addonVariant: .init(fragment: fragment.addonVariant.fragments.addonVariantFragment),
+            documents: documents
         )
     }
 }

--- a/Projects/hGraphQL/GraphQL/Octopus/Addons/UpsellTravelAddonOffer.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/Addons/UpsellTravelAddonOffer.graphql
@@ -36,6 +36,10 @@ fragment UpsellTravelAddonQuoteFragment on UpsellTravelAddonQuote {
     addonVariant {
         ...AddonVariantFragment
     }
+	documents {
+	  displayName
+	  url
+	}
 }
 
 fragment UpsellTravelAddonDisplayItemFragment on UpsellTravelAddonDisplayItem {


### PR DESCRIPTION
## [APP-XXX]

- Introducing new field for documents in addon flow

background: [slack](https://hedviginsurance.slack.com/archives/C09DF7AB28G/p1756456399847199)
## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
