### PR TITLE
GEN-4316: Only show “Hedvig Service Team” if first message after automation

### DIFF
--- a/Projects/Chat/Sources/Views/ChatScreen.swift
+++ b/Projects/Chat/Sources/Views/ChatScreen.swift
@@ -151,7 +151,7 @@ public struct ChatScreen: View {
                 if message.sender == .automation {
                     hText("\(L10n.chatSenderAutomation) ∙ ")
                 }
-                if message.sender == .hedvig {
+                if messageVm.showHedvigTimeStamp(message: message) {
                     hText("\(L10n.chatSenderHedvig) ∙ ")
                 }
                 hText(message.timeStampString)

--- a/Projects/Chat/Sources/Views/ChatScreen.swift
+++ b/Projects/Chat/Sources/Views/ChatScreen.swift
@@ -150,8 +150,7 @@ public struct ChatScreen: View {
             } else {
                 if message.sender == .automation {
                     hText("\(L10n.chatSenderAutomation) ∙ ")
-                }
-                if messageVm.showHedvigTimeStamp(message: message) {
+                } else if message == messageVm.firstHedvigMessageAfterAutomation {
                     hText("\(L10n.chatSenderHedvig) ∙ ")
                 }
                 hText(message.timeStampString)

--- a/Projects/Chat/Sources/Views/ChatScreenViewModel.swift
+++ b/Projects/Chat/Sources/Views/ChatScreenViewModel.swift
@@ -31,6 +31,20 @@ public class ChatMessageViewModel: ObservableObject {
     @Published var messages: [Message] = []
     @Published var isFetchingPreviousMessages = false
 
+    func showHedvigTimeStamp(message: Message) -> Bool {
+        let hasAutomatedMessages = messages.first(where: { $0.sender == .automation }) != nil
+        return message.sender == .hedvig && hasAutomatedMessages && isFirstHedvigMessage(currentMessageId: message.id)
+    }
+
+    private func isFirstHedvigMessage(currentMessageId: String) -> Bool {
+        guard let currentMessageIndex = messages.firstIndex(where: { $0.id == currentMessageId }),
+            currentMessageIndex != 0
+        else { return false }
+        let previousMessage = messages[currentMessageIndex + 1]
+
+        return previousMessage.sender != .hedvig
+    }
+
     public init(
         chatService: ChatServiceProtocol
     ) {

--- a/Projects/Chat/Sources/Views/ChatScreenViewModel.swift
+++ b/Projects/Chat/Sources/Views/ChatScreenViewModel.swift
@@ -39,15 +39,6 @@ public class ChatMessageViewModel: ObservableObject {
     private var hasAutomation: Bool = false
     private(set) var firstHedvigMessageAfterAutomation: Message?
 
-    private func isFirstHedvigMessage(currentMessageId: String) -> Bool {
-        guard let currentMessageIndex = messages.firstIndex(where: { $0.id == currentMessageId }),
-            currentMessageIndex != 0
-        else { return false }
-        let previousMessage = messages[currentMessageIndex + 1]
-
-        return previousMessage.sender != .hedvig
-    }
-
     public init(
         chatService: ChatServiceProtocol
     ) {

--- a/Projects/Chat/Sources/Views/MessageView.swift
+++ b/Projects/Chat/Sources/Views/MessageView.swift
@@ -104,9 +104,9 @@ struct MessageView: View {
             displayString = message.trimmedText
         case let .file(file):
             displayString = file.mimeType.isImage ? L10n.voiceoverChatImage : L10n.voiceoverChatFile
-        case let .deepLink(url):
+        case .deepLink:
             displayString = L10n.chatSentALink
-        case let .otherLink(url):
+        case .otherLink:
             displayString = L10n.chatSentALink
         default:
             break


### PR DESCRIPTION
## [GEN-4316]

- This regards [this slack conversation] (https://hedviginsurance.slack.com/archives/C08C1DG4TFD/p1759482879804499)
- Show only "Hedvig Service Team" if it's the first Hedvig sent message after automation

## Checklist

- [ ] Dark/light mode verification
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
