### PR TITLE
feat: enable connect direct debit button while on Kivra (GEN-5168)

### DIFF
--- a/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
+++ b/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
@@ -39,8 +39,8 @@ public struct PaymentsNavigation: View {
                         CampaignNavigation()
                     case .history:
                         PaymentHistoryView()
-                    case let .paymentMethod(data):
-                        PaymentMethodScreen(data: data)
+                    case let .paymentMethod:
+                        PaymentMethodScreen()
                     }
                 }
         }
@@ -63,7 +63,7 @@ private enum PaymentsDetentActions: TrackingViewNameProtocol {
 public enum PaymentsRouterAction: Hashable, TrackingViewNameProtocol, NavigationTitleProtocol {
     case discounts
     case history
-    case paymentMethod(data: PaymentChargeData)
+    case paymentMethod
 
     public var nameForTracking: String {
         switch self {

--- a/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
+++ b/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
@@ -39,7 +39,7 @@ public struct PaymentsNavigation: View {
                         CampaignNavigation()
                     case .history:
                         PaymentHistoryView()
-                    case let .paymentMethod:
+                    case .paymentMethod:
                         PaymentMethodScreen()
                     }
                 }

--- a/Projects/Payment/Sources/Screens/PaymentsMethodScreen.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsMethodScreen.swift
@@ -88,11 +88,6 @@ struct PaymentMethodScreen: View {
                 )
             )
         }
-    //    return PaymentsNavigation(paymentsNavigationVm: .init())
-    //        .environmentObject(NavigationRouter())
-    //        .task {
-
-    //        }
 }
 
 struct PaymentMethodView: View {

--- a/Projects/Payment/Sources/Screens/PaymentsMethodScreen.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsMethodScreen.swift
@@ -4,35 +4,44 @@ import hCore
 import hCoreUI
 
 struct PaymentMethodScreen: View {
-    let data: PaymentChargeData
+    @EnvironmentObject var paymentsNavigationVM: PaymentsNavigationViewModel
 
     var body: some View {
-        hForm {
-            PaymentMethodView(data: data, withDate: true)
-                .hWithoutHorizontalPadding([.row, .divider])
-        }
-        .hFormAttachToBottom {
-            if data.chargeMethod == .trustly {
-                ConnectPaymentBottomView(alwaysShowButton: true)
-            } else if data.chargeMethod == .kivra {
-                hSection {
-                    InfoCard(
-                        text:
-                            L10n.kivraNotificationBoxText,
-                        type: .info
-                    )
-                    .buttons(
-                        [
-                            .init(
-                                buttonTitle: L10n.openChat,
-                                buttonAction: {
-                                    NotificationCenter.default.post(name: .openChat, object: ChatType.newConversation)
-                                }
-                            )
-                        ]
-                    )
+        PresentableStoreLens(
+            PaymentStore.self,
+            getter: { state in
+                state.paymentStatusData?.paymentChargeData
+            }
+        ) { paymentChargeData in
+            if let paymentChargeData {
+                hForm {
+                    PaymentMethodView(data: paymentChargeData, withDate: true)
+                        .hWithoutHorizontalPadding([.row, .divider])
                 }
-                .sectionContainerStyle(.transparent)
+                .hFormAttachToBottom {
+                    if paymentChargeData.chargeMethod == .trustly {
+                        ConnectPaymentBottomView(alwaysShowButton: true)
+                    } else if paymentChargeData.chargeMethod == .kivra {
+                        hSection {
+                            InfoCard(
+                                text:
+                                    L10n.kivraNotificationBoxText,
+                                type: .info
+                            )
+                            .buttons(
+                                [
+                                    .init(
+                                        buttonTitle: L10n.profilePaymentConnectDirectDebitButton,
+                                        buttonAction: {
+                                            paymentsNavigationVM.connectPaymentVm.set()
+                                        }
+                                    )
+                                ]
+                            )
+                        }
+                        .sectionContainerStyle(.transparent)
+                    }
+                }
             }
         }
     }
@@ -41,17 +50,49 @@ struct PaymentMethodScreen: View {
 #Preview {
     Localization.Locale.currentLocale.send(.en_SE)
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
+    Dependencies.shared.add(module: Module { () -> hPaymentClient in hPaymentClientDemo() })
 
-    return PaymentMethodScreen(
-        data: .init(
-            paymentMethod: "method",
-            bankName: "bank name",
-            account: "account",
-            mandate: nil,
-            dueDate: 26,
-            chargeMethod: .trustly
-        )
-    )
+    return PaymentMethodScreen()
+        .environmentObject(PaymentsNavigationViewModel())
+        .task {
+            let store: PaymentStore = globalPresentableStoreContainer.get()
+            store.send(
+                .setPaymentStatus(
+                    data: .init(
+                        status: .active,
+                        paymentChargeData: .init(
+                            paymentMethod: nil,
+                            bankName: nil,
+                            account: nil,
+                            mandate: nil,
+                            dueDate: 27,
+                            chargeMethod: .kivra
+                        )
+                    )
+                )
+            )
+            await delay(2)
+            store.send(
+                .setPaymentStatus(
+                    data: .init(
+                        status: .active,
+                        paymentChargeData: .init(
+                            paymentMethod: "method",
+                            bankName: "Nordea",
+                            account: "*****123",
+                            mandate: nil,
+                            dueDate: 27,
+                            chargeMethod: .trustly
+                        )
+                    )
+                )
+            )
+        }
+    //    return PaymentsNavigation(paymentsNavigationVm: .init())
+    //        .environmentObject(NavigationRouter())
+    //        .task {
+
+    //        }
 }
 
 struct PaymentMethodView: View {

--- a/Projects/Payment/Sources/Screens/PaymentsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsView.swift
@@ -44,7 +44,7 @@ public struct PaymentsView: View {
                         discounts
                         paymentHistory
                         if let data = statusData?.paymentChargeData {
-                            connectedPaymentMethod(data: data)
+                            connectedPaymentMethod
                         }
                     }
                 }
@@ -155,7 +155,7 @@ public struct PaymentsView: View {
         }
     }
 
-    private func connectedPaymentMethod(data: PaymentChargeData) -> some View {
+    private var connectedPaymentMethod: some View {
         hRow {
             hCoreUIAssets.payments.view
                 .foregroundColor(hTextColor.Opaque.primary)
@@ -164,7 +164,7 @@ public struct PaymentsView: View {
         }
         .withChevronAccessory
         .onTap {
-            router.push(PaymentsRouterAction.paymentMethod(data: data))
+            router.push(PaymentsRouterAction.paymentMethod)
         }
     }
 

--- a/Projects/Payment/Sources/Service/Protocols/PaymentClientDemo.swift
+++ b/Projects/Payment/Sources/Service/Protocols/PaymentClientDemo.swift
@@ -139,11 +139,11 @@ public class hPaymentClientDemo: hPaymentClient {
             status: .noNeedToConnect,
             paymentChargeData: .init(
                 paymentMethod: nil,
-                bankName: "Connected bank",
-                account: "****1234",
+                bankName: nil,
+                account: nil,
                 mandate: nil,
                 dueDate: nil,
-                chargeMethod: .trustly
+                chargeMethod: .kivra
             )
         )
     }

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -615,6 +615,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "PROFILE_MY_INFO_TITLE" = "Contact info";
 "PROFILE_NOTIFICATIONS_STATUS_OFF" = "Turned off";
 "PROFILE_NOTIFICATIONS_STATUS_ON" = "Turned on";
+"PROFILE_PAYMENT_CONNECT_DIRECT_DEBIT_BUTTON" = "Connect payment";
 "PROFILE_TITLE" = "Your profile";
 "PUPPY_GUIDE_GO_BUTTON" = "Go to guides";
 "PUPPY_GUIDE_INFO" = "In the puppy guide, you’ll find helpful articles covering everything from the first vet visit to choosing the right food.";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -615,6 +615,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "PROFILE_MY_INFO_TITLE" = "Kontaktinfo";
 "PROFILE_NOTIFICATIONS_STATUS_OFF" = "Avaktiverad";
 "PROFILE_NOTIFICATIONS_STATUS_ON" = "Aktiverad";
+"PROFILE_PAYMENT_CONNECT_DIRECT_DEBIT_BUTTON" = "Koppla autogiro";
 "PROFILE_TITLE" = "Din profil";
 "PUPPY_GUIDE_GO_BUTTON" = "Se guider";
 "PUPPY_GUIDE_INFO" = "I valpguiden hittar du användbara artiklar som hjälper dig med allt från första veterinärbesöket till hur du väljer rätt foder.";


### PR DESCRIPTION
## Summary
- Enables the "Connect payment" button on the payment method screen when the user's charge method is Kivra
- Refactors `PaymentMethodScreen` to read payment data from the store instead of receiving it as a parameter
- Removes `PaymentChargeData` parameter from `PaymentsRouterAction.paymentMethod` navigation case

## Test plan
- [ ] Verify the "Connect payment" button appears on the payment method screen when charge method is Kivra
- [ ] Verify tapping the button triggers the connect payment flow
- [ ] Verify the payment method screen still works correctly for Trustly charge method
- [ ] Verify navigation to payment method screen works without passing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)