### PR TITLE
chore: add error handling to inbox view

### DIFF
--- a/Projects/Chat/Sources/Views/InboxView.swift
+++ b/Projects/Chat/Sources/Views/InboxView.swift
@@ -18,6 +18,16 @@ public struct InboxView: View {
         .onPullToRefresh {
             await vm.fetchMessages()
         }
+        .loading($vm.processingState)
+        .hStateViewButtonConfig(
+            .init(
+                actionButton: .init(
+                    buttonAction: { [weak vm] in
+                        vm?.configureFetching()
+                    }
+                )
+            )
+        )
     }
 
     @ViewBuilder
@@ -137,7 +147,7 @@ class InboxViewModel: ObservableObject {
     @Published var conversations: [Conversation] = []
     private var pollTimerCancellable: AnyCancellable?
     private var chatClosedObserver: NSObjectProtocol?
-
+    @Published var processingState: ProcessingState = .success
     func shouldHideDivider(for conversation: Conversation) -> Bool {
         guard let indexOfCurrent = conversations.firstIndex(where: { $0.id == conversation.id }) else {
             return true
@@ -161,7 +171,7 @@ class InboxViewModel: ObservableObject {
         }
     }
 
-    private func configureFetching() {
+    func configureFetching() {
         pollTimerCancellable = nil
         Task {
             await fetchMessages()
@@ -174,16 +184,26 @@ class InboxViewModel: ObservableObject {
                 }
             })
     }
-
     @MainActor
     func fetchMessages() async {
         do {
+            if self.conversations.isEmpty {
+                withAnimation {
+                    processingState = .loading
+                }
+            }
             let conversations = try await service.getConversations()
             withAnimation {
                 self.conversations = conversations
+                self.processingState = .success
             }
-        } catch _ {
-            // TODO: EXCEPTION
+        } catch {
+            if self.conversations.isEmpty {
+                withAnimation {
+                    pollTimerCancellable?.cancel()
+                    processingState = .error(errorMessage: error.localizedDescription)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add loading and error states to `InboxView` when fetching conversations
- Replace empty catch block with proper error state handling and retry button
- Show loading state only when conversation list is empty, preserving existing data on refresh failures

## Test plan
- [ ] Open inbox with no cached conversations and verify loading state appears
- [ ] Simulate network error with empty inbox and verify error state with retry button
- [ ] Verify retry button triggers a new fetch
- [ ] Verify that refresh failures with existing conversations don't show error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)