### PR TITLE
chore: Refactor payout navigation into dedicated PayoutNavigation view

### DIFF
--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -778,6 +778,14 @@ struct HomeTab: View {
                 )
             }
         )
+        .detent(
+            presented: $loggedInVm.isPayoutMethodPresented,
+            presentationStyle: .detent(
+                style: [.large]),
+            options: .constant([.alwaysOpenOnTop])
+        ) {
+            PayoutNavigation(paymentsNavigationVm: loggedInVm.paymentsNavigationVm)
+        }
     }
 
     private func openClaimDetails(claim: ClaimModel?, type: ClaimDetailsType) -> some View {
@@ -847,7 +855,7 @@ class LoggedInNavigationViewModel: ObservableObject {
     @Published var isFaqPresented: FAQModel?
     @Published var askForPushNotification = false
     @Published var isReviewContactInfoPresented = false
-
+    @Published var isPayoutMethodPresented = false
     private var deeplinkToBeOpenedAfterLogin: URL?
     private var cancellables = Set<AnyCancellable>()
     weak var tabBar: UITabBarController? {

--- a/Projects/Payment/Sources/Models/PaymentStatusData.swift
+++ b/Projects/Payment/Sources/Models/PaymentStatusData.swift
@@ -75,7 +75,10 @@ public enum PaymentMethodStatus: Codable, Equatable, Sendable, Hashable {
     case unknown
 }
 
-public enum PaymentProvider: Codable, Equatable, Sendable, Hashable {
+public enum PaymentProvider: Codable, Equatable, Sendable, Hashable, Identifiable {
+    public var id: String {
+        self.asString
+    }
     case trustly
     case swish
     case nordea

--- a/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
+++ b/Projects/Payment/Sources/Navigation/PaymentNavigation.swift
@@ -8,9 +8,7 @@ import hCoreUI
 @MainActor
 public class PaymentsNavigationViewModel: ObservableObject {
     private var paymentStoreSubscription: AnyCancellable?
-    @Published var showNordeaSetup = false
-    @Published var showSwishPayoutSetup = false
-    var paymentStatusViewModel: PaymentStatusViewModel?
+    public private(set) var paymentStatusViewModel: PaymentStatusViewModel?
     public var connectPaymentVm = ConnectPaymentViewModel()
 
     public init() {
@@ -31,7 +29,7 @@ public class PaymentsNavigationViewModel: ObservableObject {
     }
 }
 
-class PaymentStatusViewModel: ObservableObject {
+public class PaymentStatusViewModel: ObservableObject {
     @Published var paymentStatusData: PaymentStatusData
 
     init(paymentStatusData: PaymentStatusData) {
@@ -69,35 +67,35 @@ public struct PaymentsNavigation: View {
                         PaymentHistoryView()
                     case .paymentMethod:
                         PaymentMethodScreen()
+                    case .payoutMethod:
+                        if let vm = paymentsNavigationVm.paymentStatusViewModel {
+                            PayoutSelectedMethodScreen(vm: vm)
+                        }
                     }
                 }
-                .routerDestination(for: PayoutRouterAction.self) { routerAction in
+                .routerDestination(for: PayoutRouterActions.self) { routerAction in
                     switch routerAction {
-                    case .payoutMethod:
+                    case .selectedPayoutMethod:
+                        if let vm = paymentsNavigationVm.paymentStatusViewModel {
+                            PayoutSelectedMethodScreen(vm: vm)
+                        }
+                    case .changePayoutMethod:
+                        if let vm = paymentsNavigationVm.paymentStatusViewModel {
+                            PayoutChangeMethodScreen(vm: vm)
+                        }
+                    }
+                }
+                .routerDestination(for: PayoutRouterActions.self) { routerAction in
+                    switch routerAction {
+                    case .selectedPayoutMethod:
                         PayoutSelectedMethodScreen(vm: paymentsNavigationVm.paymentStatusViewModel!)
-                    case .setupPayoutMethod:
+                    case .changePayoutMethod:
                         PayoutChangeMethodScreen(vm: paymentsNavigationVm.paymentStatusViewModel!)
                     }
                 }
         }
         .environmentObject(paymentsNavigationVm)
         .handleConnectPayment(with: paymentsNavigationVm.connectPaymentVm)
-        .detent(
-            presented: $paymentsNavigationVm.showNordeaSetup,
-            presentationStyle: .detent(style: [.height])
-        ) {
-            NordeaPayoutSetupScreen() { [weak router] in
-                router?.pop()
-            }
-        }
-        .detent(
-            presented: $paymentsNavigationVm.showSwishPayoutSetup,
-            presentationStyle: .detent(style: [.height])
-        ) {
-            SwishPayoutSetupScreen() { [weak router] in
-                router?.pop()
-            }
-        }
     }
 }
 
@@ -111,33 +109,12 @@ private enum PaymentsDetentActions: TrackingViewNameProtocol {
 
     case paymentsView
 }
-enum PayoutRouterAction: Hashable, TrackingViewNameProtocol, NavigationTitleProtocol {
-    case payoutMethod
-    case setupPayoutMethod
-
-    var nameForTracking: String {
-        switch self {
-        case .payoutMethod:
-            return .init(describing: PayoutSelectedMethodScreen.self)
-        case .setupPayoutMethod:
-            return .init(describing: PayoutChangeMethodScreen.self)
-        }
-    }
-
-    var navigationTitle: String? {
-        switch self {
-        case .payoutMethod:
-            return L10n.payoutPageHeading
-        case .setupPayoutMethod:
-            return L10n.payoutSelectPayoutMethod
-        }
-    }
-}
 
 enum PaymentsRouterAction: Hashable, TrackingViewNameProtocol, NavigationTitleProtocol {
     case discounts
     case history
     case paymentMethod
+    case payoutMethod
 
     var nameForTracking: String {
         switch self {
@@ -147,17 +124,21 @@ enum PaymentsRouterAction: Hashable, TrackingViewNameProtocol, NavigationTitlePr
             return .init(describing: PaymentHistoryView.self)
         case .paymentMethod:
             return .init(describing: PaymentMethodScreen.self)
+        case .payoutMethod:
+            return .init(describing: PayoutSelectedMethodScreen.self)
         }
     }
 
     var navigationTitle: String? {
         switch self {
         case .discounts:
-            L10n.paymentsDiscountsSectionTitle
+            return L10n.paymentsDiscountsSectionTitle
         case .history:
-            L10n.paymentHistoryTitle
+            return L10n.paymentHistoryTitle
         case .paymentMethod:
-            L10n.PaymentDetails.NavigationBar.title
+            return L10n.PaymentDetails.NavigationBar.title
+        case .payoutMethod:
+            return L10n.payoutPageHeading
         }
     }
 }

--- a/Projects/Payment/Sources/Navigation/PayoutNavigation.swift
+++ b/Projects/Payment/Sources/Navigation/PayoutNavigation.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+public struct PayoutNavigation: View {
+    @StateObject private var router = NavigationRouter()
+    @ObservedObject private var paymentsNavigationVm: PaymentsNavigationViewModel
+
+    public init(
+        paymentsNavigationVm: PaymentsNavigationViewModel
+    ) {
+        self.paymentsNavigationVm = paymentsNavigationVm
+    }
+
+    public var body: some View {
+        if let paymentStatusViewModel = paymentsNavigationVm.paymentStatusViewModel {
+            hNavigationStack(router: router, tracking: PayoutRouterActions.selectedPayoutMethod) {
+                PayoutSelectedMethodScreen(vm: paymentStatusViewModel)
+                    .navigationTitle(L10n.payoutPageHeading)
+                    .withDismissButton()
+                    .routerDestination(for: PayoutRouterActions.self) { action in
+                        switch action {
+                        case .selectedPayoutMethod:
+                            PayoutSelectedMethodScreen(vm: paymentStatusViewModel)
+                        case .changePayoutMethod:
+                            PayoutChangeMethodScreen(vm: paymentStatusViewModel)
+                        }
+                    }
+            }
+        }
+    }
+}
+
+enum PayoutRouterActions: Hashable, TrackingViewNameProtocol, NavigationTitleProtocol {
+    case selectedPayoutMethod
+    case changePayoutMethod
+
+    var nameForTracking: String {
+        switch self {
+        case .selectedPayoutMethod:
+            return String(describing: PayoutSelectedMethodScreen.self)
+        case .changePayoutMethod:
+            return String(describing: PayoutChangeMethodScreen.self)
+        }
+    }
+
+    public var navigationTitle: String? {
+        switch self {
+        case .selectedPayoutMethod:
+            return L10n.payoutPageHeading
+        case .changePayoutMethod:
+            return L10n.payoutSelectPayoutMethod
+        }
+    }
+}

--- a/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
@@ -238,12 +238,16 @@ public struct DirectDebitSetup: View {
     @State var activeAlert: AlertType?
     @State var showNotSupported: Bool = false
 
-    @StateObject var router = NavigationRouter()
+    @StateObject private var ownedRouter = NavigationRouter()
+    @ObservedObject private var externalRouter: NavigationRouter
+    private var hasExternalRouter: Bool
+    var router: NavigationRouter { hasExternalRouter ? externalRouter : ownedRouter }
     let setupType: SetupType
     let onSuccess: (() -> Void)?
 
     public init(
         setupType: SetupType? = nil,
+        router: NavigationRouter? = nil,
         onSuccess: (() -> Void)? = nil
     ) {
         let finalSetupType: SetupType = {
@@ -258,6 +262,8 @@ public struct DirectDebitSetup: View {
         showNotSupported = !Dependencies.featureFlags().isConnectPaymentEnabled
         self.setupType = finalSetupType
         self.onSuccess = onSuccess
+        self.hasExternalRouter = router != nil
+        self._externalRouter = ObservedObject(wrappedValue: router ?? NavigationRouter())
     }
 
     public var body: some View {

--- a/Projects/Payment/Sources/Screens/PaymentsView.swift
+++ b/Projects/Payment/Sources/Screens/PaymentsView.swift
@@ -191,11 +191,7 @@ public struct PaymentsView: View {
         }
         .withChevronAccessory
         .onTap {
-            if data.payoutMethods.isEmpty, !data.availablePayoutMethods.isEmpty {
-                router.push(PayoutRouterAction.setupPayoutMethod)
-            } else if !data.payinMethods.isEmpty {
-                router.push(PayoutRouterAction.payoutMethod)
-            }
+            router.push(PaymentsRouterAction.payoutMethod)
         }
     }
 }

--- a/Projects/Payment/Sources/Screens/Payout/NordeaPayoutSetupScreen.swift
+++ b/Projects/Payment/Sources/Screens/Payout/NordeaPayoutSetupScreen.swift
@@ -20,13 +20,11 @@ struct NordeaPayoutSetupScreen: View {
                 accountField
             }
         }
+        .hFormContentPosition(.compact)
         .hFormAttachToBottom {
             bottomContent
         }
         .disabled(vm.isLoading)
-        .hFormContentPosition(.compact)
-        .navigationTitle(L10n.bankPayoutMethodCardTitle)
-        .embededInNavigation(router: router, tracking: self)
     }
 
     private var clearingField: some View {
@@ -81,15 +79,11 @@ struct NordeaPayoutSetupScreen: View {
             .large,
             .primary,
             content: .init(title: L10n.generalSaveButton)
-        ) { [weak vm, weak router, onSuccess] in
+        ) { [weak vm, onSuccess] in
             Task {
                 if let success = await vm?.save() {
                     if success {
-                        let store: PaymentStore = globalPresentableStoreContainer.get()
-                        store.send(.fetchPaymentStatus)
                         onSuccess?()
-                        router?.dismiss()
-                        Toasts.success()
                     }
                 }
             }
@@ -102,12 +96,6 @@ struct NordeaPayoutSetupScreen: View {
             return L10n.bankPayoutMethodFormClearingFieldLabel + " - " + bankName
         }
         return L10n.bankPayoutMethodFormClearingFieldLabel
-    }
-}
-
-extension NordeaPayoutSetupScreen: TrackingViewNameProtocol {
-    var nameForTracking: String {
-        .init(describing: NordeaPayoutSetupScreen.self)
     }
 }
 

--- a/Projects/Payment/Sources/Screens/Payout/PayoutChangeMethodScreen.swift
+++ b/Projects/Payment/Sources/Screens/Payout/PayoutChangeMethodScreen.swift
@@ -1,11 +1,14 @@
+import PresentableStore
 import SwiftUI
 import hCore
 import hCoreUI
 
 struct PayoutChangeMethodScreen: View {
     @ObservedObject var vm: PaymentStatusViewModel
-    @EnvironmentObject var paymentNavigationVm: PaymentsNavigationViewModel
     @EnvironmentObject var router: NavigationRouter
+    @StateObject private var paymentMethodRouter = NavigationRouter()
+    @State private var showConnectPayoutMethod: PaymentProvider?
+
     var body: some View {
         hForm {
             VStack(spacing: .padding4) {
@@ -21,21 +24,44 @@ struct PayoutChangeMethodScreen: View {
                         }
                         .withChevronAccessory
                         .onTap {
-                            switch method.provider {
-                            case .trustly:
-                                paymentNavigationVm.connectPaymentVm.set(
-                                    onSuccess: { [weak router] in
-                                        router?.pop()
-                                    }
-                                )
-                            case .invoice: break
-                            case .nordea: paymentNavigationVm.showNordeaSetup = true
-                            case .swish: paymentNavigationVm.showSwishPayoutSetup = true
-                            case .unknown: break
-                            }
+                            showConnectPayoutMethod = method.provider
                         }
                     }
                 }
+            }
+        }
+        .detent(
+            item: $showConnectPayoutMethod,
+            presentationStyle: showConnectPayoutMethod?.detentPresentationStyle ?? .detent(style: [.large]),
+            options: .constant(showConnectPayoutMethod?.options ?? [])
+        ) { [weak router, weak paymentMethodRouter] paymentProvider in
+            let onSuccess = { [weak paymentMethodRouter] in
+                let store: PaymentStore = globalPresentableStoreContainer.get()
+                store.send(.fetchPaymentStatus)
+                paymentMethodRouter?.dismiss()
+                router?.pop()
+                Toasts.success()
+            }
+            switch paymentProvider {
+            case .nordea:
+                NordeaPayoutSetupScreen(onSuccess: onSuccess)
+                    .navigationTitle(PaymentProvider.nordea.payoutTitle)
+                    .embededInNavigation(
+                        router: paymentMethodRouter ?? NavigationRouter(),
+                        tracking: PaymentProvider.nordea
+                    )
+            case .swish:
+                SwishPayoutSetupScreen(onSuccess: onSuccess)
+                    .navigationTitle(PaymentProvider.swish.payoutTitle)
+                    .embededInNavigation(
+                        router: paymentMethodRouter ?? NavigationRouter(),
+                        tracking: PaymentProvider.swish
+                    )
+            case .trustly:
+                DirectDebitSetup(router: paymentMethodRouter, onSuccess: onSuccess)
+            case .invoice, .unknown:
+                UpdateAppScreen() {}
+                    .withAlertDismiss()
             }
         }
     }
@@ -83,4 +109,47 @@ extension PaymentProvider {
     )
     .environmentObject(NavigationRouter())
     .environmentObject(PaymentsNavigationViewModel())
+}
+
+@MainActor
+extension PaymentProvider {
+    fileprivate var detentPresentationStyle: DetentPresentationStyle {
+        switch self {
+        case .trustly, .unknown, .invoice:
+            return .detent(style: [.large])
+        case .swish, .nordea:
+            return .detent(style: [.height])
+        }
+    }
+
+    fileprivate var options: DetentPresentationOption {
+        switch self {
+        case .trustly:
+            return [.disableDismissOnScroll, .withoutGrabber]
+        case .swish, .nordea, .unknown, .invoice:
+            return []
+        }
+    }
+}
+
+@MainActor
+extension PaymentProvider: TrackingViewNameProtocol, NavigationTitleProtocol {
+    public var nameForTracking: String {
+        switch self {
+        case .trustly:
+            String(describing: DirectDebitSetup.self)
+        case .swish:
+            String(describing: SwishPayoutSetupScreen.self)
+        case .nordea:
+            String(describing: NordeaPayoutSetupScreen.self)
+        case .invoice:
+            String(describing: UpdateAppScreen.self)
+        case .unknown:
+            String(describing: UpdateAppScreen.self)
+        }
+    }
+
+    public var navigationTitle: String? {
+        payoutTitle
+    }
 }

--- a/Projects/Payment/Sources/Screens/Payout/PayoutSelectedMethodScreen.swift
+++ b/Projects/Payment/Sources/Screens/Payout/PayoutSelectedMethodScreen.swift
@@ -1,28 +1,71 @@
-import PresentableStore
 import SwiftUI
 import hCore
 import hCoreUI
 
-struct PayoutSelectedMethodScreen: View {
+public struct PayoutSelectedMethodScreen: View {
     @ObservedObject var vm: PaymentStatusViewModel
     @EnvironmentObject var router: NavigationRouter
-    var body: some View {
-        hForm {
-            VStack(spacing: .padding8) {
+
+    public init(vm: PaymentStatusViewModel) {
+        self.vm = vm
+    }
+
+    public var body: some View {
+        content
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if vm.paymentStatusData.defaultPayoutMethod == nil {
+            hForm {
                 hSection {
-                    hFloatingField(
-                        value: vm.paymentStatusData.payoutAccountDisplayValue,
-                        placeholder: vm.paymentStatusData.payoutAccountDisplayTitle,
-                        error: nil,
-                        onTap: {}
-                    )
-                    .hFieldTrailingView {
-                        hCoreUIAssets.lock.view
-                            .foregroundColor(hTextColor.Translucent.secondary)
+                    VStack(spacing: .padding16) {
+                        hCoreUIAssets.infoFilled.view
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(hSignalColor.Blue.element)
+
+                        hText(L10n.payoutMissingInfo)
+                            .multilineTextAlignment(.center)
                     }
-                    .hBackgroundOption(option: [.locked])
-                    .disabled(true)
                 }
+                .sectionContainerStyle(.transparent)
+            }
+            .hFormAttachToBottom {
+                hSection {
+                    hButton(
+                        .large,
+                        .primary,
+                        content: .init(title: L10n.payoutAddPayoutMethod),
+                        {
+                            router.push(PayoutRouterActions.changePayoutMethod)
+                        }
+                    )
+                }
+            }
+            .hFormContentPosition(.center)
+            .sectionContainerStyle(.transparent)
+        } else {
+            hForm {
+                VStack(spacing: .padding8) {
+                    hSection {
+                        hFloatingField(
+                            value: vm.paymentStatusData.payoutAccountDisplayValue,
+                            placeholder: vm.paymentStatusData.payoutAccountDisplayTitle,
+                            error: nil,
+                            onTap: {}
+                        )
+                        .hFieldTrailingView {
+                            hCoreUIAssets.lock.view
+                                .foregroundColor(hTextColor.Translucent.secondary)
+                        }
+                        .hBackgroundOption(option: [.locked])
+                        .disabled(true)
+                    }
+                }
+                .padding(.top, .padding16)
+            }
+            .hFormAttachToBottom {
                 if vm.paymentStatusData.payoutMethods.hasMethodInProgress {
                     hSection {
                         InfoCard(text: L10n.myPaymentUpdatingMessage, type: .info)
@@ -37,9 +80,7 @@ struct PayoutSelectedMethodScreen: View {
                             .primary,
                             content: .init(title: L10n.changePayoutMethodButtonLabel),
                             {
-                                router.push(
-                                    PayoutRouterAction.setupPayoutMethod
-                                )
+                                router.push(PayoutRouterActions.changePayoutMethod)
                             }
                         )
                     }
@@ -167,6 +208,39 @@ extension PaymentStatusData {
                         details: .bankAccount(account: "3300-920123132", bank: "Nordea")
                     )
                 ],
+                availableMethods: [
+                    .init(provider: .nordea, supportsPayin: false, supportsPayout: true),
+                    .init(provider: .swish, supportsPayin: false, supportsPayout: true),
+                    .init(provider: .trustly, supportsPayin: true, supportsPayout: true),
+                ]
+            )
+        )
+    )
+    .environmentObject(NavigationRouter())
+}
+
+#Preview("PayoutSelectedMethodScreen - no default payout") {
+    PayoutSelectedMethodScreen(
+        vm: .init(
+            paymentStatusData: .init(
+                status: .active,
+                chargingDay: nil,
+                defaultPayinMethod: .init(
+                    provider: .invoice,
+                    status: .active,
+                    isDefault: true,
+                    details: .invoice(delivery: .kivra, email: nil)
+                ),
+                payinMethods: [
+                    .init(
+                        provider: .invoice,
+                        status: .active,
+                        isDefault: true,
+                        details: .invoice(delivery: .kivra, email: nil)
+                    )
+                ],
+                defaultPayoutMethod: nil,
+                payoutMethods: [],
                 availableMethods: [
                     .init(provider: .nordea, supportsPayin: false, supportsPayout: true),
                     .init(provider: .swish, supportsPayin: false, supportsPayout: true),

--- a/Projects/Payment/Sources/Screens/Payout/SwishPayoutSetupScreen.swift
+++ b/Projects/Payment/Sources/Screens/Payout/SwishPayoutSetupScreen.swift
@@ -1,4 +1,3 @@
-import PresentableStore
 import SwiftUI
 import hCore
 import hCoreUI
@@ -18,13 +17,11 @@ struct SwishPayoutSetupScreen: View {
                 phoneNumberField
             }
         }
+        .hFormContentPosition(.compact)
         .hFormAttachToBottom {
             bottomContent
         }
         .disabled(vm.isLoading)
-        .hFormContentPosition(.compact)
-        .navigationTitle("Swish")
-        .embededInNavigation(router: router, tracking: self)
     }
 
     private var phoneNumberField: some View {
@@ -67,14 +64,10 @@ struct SwishPayoutSetupScreen: View {
             .large,
             .primary,
             content: .init(title: L10n.generalSaveButton)
-        ) { [weak vm, weak router, onSuccess] in
+        ) { [weak vm, onSuccess] in
             Task {
                 if let success = await vm?.save(), success {
-                    let store: PaymentStore = globalPresentableStoreContainer.get()
-                    store.send(.fetchPaymentStatus)
                     onSuccess?()
-                    router?.dismiss()
-                    Toasts.success()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Extract payout setup flow into a standalone `PayoutNavigation` component with detent-based presentation
- Consolidate Nordea, Swish, and Trustly provider handling into a single navigation flow
- Simplify `PaymentNavigation` by removing provider-specific state (`showNordeaSetup`, `showSwishPayoutSetup`) and routing logic (`PayoutRouterAction`)
- Move "change payout method" button logic to trigger the new unified payout sheet

## Test plan
- [ ] Verify payout method selection screen displays correctly
- [ ] Test Nordea payout setup flow end-to-end
- [ ] Test Swish payout setup flow end-to-end
- [ ] Verify changing payout method from the selected method screen works
- [ ] Confirm success toasts appear after successful setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)