### PR TITLE
chore: Set AI background for submit claim flow

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimDeflectView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimDeflectView.swift
@@ -46,18 +46,15 @@ public struct SubmitClaimDeflectScreen: View {
                     contentSection
                     questionsSection
                 }
-                .padding(.top, .padding8)
+                .padding(.top, .padding16)
             }
-            .sectionContainerStyle(.negative)
+            .sectionContainerStyle(.transparent)
             .hWithoutHorizontalPadding([.section])
         }
         .hFormAttachToBottom {
             bottomAttachedView
         }
-        .hFormBottomBackgroundColor(
-            model.hasSupportView
-                ? .gradient(from: hBackgroundColor.primary, to: hSurfaceColor.Opaque.primary) : .default
-        )
+        .hFormBottomBackgroundColor(.aiPoweredGradient)
         .edgesIgnoringSafeArea(.bottom)
     }
 
@@ -76,17 +73,19 @@ public struct SubmitClaimDeflectScreen: View {
 
     @ViewBuilder
     private var partnersSection: some View {
-        hRow {
-            VStack(spacing: .padding16) {
-                partnerInfoHeader
-                VStack(spacing: .padding8) {
-                    ForEach(model.partners, id: \.id) { partner in
-                        ClaimContactCard(model: partner)
+        if (model.title != nil && model.infoText != nil) || !model.partners.isEmpty {
+            hRow {
+                VStack(spacing: .padding16) {
+                    partnerInfoHeader
+                    VStack(spacing: .padding8) {
+                        ForEach(model.partners, id: \.id) { partner in
+                            ClaimContactCard(model: partner)
+                        }
                     }
                 }
             }
+            .verticalPadding(0)
         }
-        .verticalPadding(0)
     }
 
     @ViewBuilder
@@ -146,7 +145,7 @@ public struct SubmitClaimDeflectScreen: View {
                         NotificationCenter.default.post(name: .openDeepLink, object: url)
                     }
                 )
-                .sectionContainerStyle(.opaque)
+                .sectionContainerStyle(.transparent)
                 .hWithoutHorizontalPadding([])
             }
         }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
@@ -294,7 +294,7 @@ struct FormFieldView: View {
                     withBorder: false
                 )
                 .hFieldSize(.large)
-                .fullyWrapped(true)
+                .capsuleShape(true)
                 .onTapGesture {
                     fieldViewModel.value = tag
                 }
@@ -347,7 +347,7 @@ struct SubmitClaimFormResultView: View {
                 .foregroundColor(fieldTextColor(for: item))
                 .hPillStyle(color: .grey, colorLevel: .two, withBorder: false)
                 .hFieldSize(.large)
-                .fullyWrapped(true)
+                .capsuleShape(true)
                 .accessibilityLabel(value.getAccessibilityLabelDate)
         case let .searchResult(value):
             SingleSelectValueView(item: value.displayValue, onTap: nil)

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
@@ -268,7 +268,7 @@ struct FormFieldView: View {
         }
         if let selectedItem = fieldViewModel.selectedSearchItem {
             SingleSelectValueView(item: selectedItem.displayValue, onTap: presentSearch)
-                .sectionContainerStyle(.opaque)
+                .sectionContainerStyle(.translucent)
                 .accessibilityHint(L10n.voiceoverDoubleClickTo + " " + L10n.voiceoverChangeValue)
         } else {
             DropdownView(
@@ -293,7 +293,8 @@ struct FormFieldView: View {
                     colorLevel: .two,
                     withBorder: false
                 )
-                .hFieldSize(.capsuleShape)
+                .hFieldSize(.large)
+                .fullyWrapped(true)
                 .onTapGesture {
                     fieldViewModel.value = tag
                 }
@@ -345,7 +346,8 @@ struct SubmitClaimFormResultView: View {
             hText(value)
                 .foregroundColor(fieldTextColor(for: item))
                 .hPillStyle(color: .grey, colorLevel: .two, withBorder: false)
-                .hFieldSize(.capsuleShape)
+                .hFieldSize(.large)
+                .fullyWrapped(true)
                 .accessibilityLabel(value.getAccessibilityLabelDate)
         case let .searchResult(value):
             SingleSelectValueView(item: value.displayValue, onTap: nil)

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSingleSelectView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSingleSelectView.swift
@@ -48,7 +48,7 @@ struct SubmitClaimSingleSelectView: View {
                     minWidth: .padding60
                 )
                 .hFieldSize(.large)
-                .fullyWrapped(true)
+                .capsuleShape(true)
                 .transition(.submitClaimOptionAppear)
                 .onTapGesture { selectOption(id: option.id) }
                 .accessibilityAddTraits(.isButton)
@@ -135,7 +135,7 @@ struct SubmitClaimSingleSelectResultView: View {
                 withBorder: false
             )
             .hFieldSize(.large)
-            .fullyWrapped(true)
+            .capsuleShape(true)
         }
     }
 }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSingleSelectView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSingleSelectView.swift
@@ -47,7 +47,8 @@ struct SubmitClaimSingleSelectView: View {
                     withBorder: false,
                     minWidth: .padding60
                 )
-                .hFieldSize(.capsuleShape)
+                .hFieldSize(.large)
+                .fullyWrapped(true)
                 .transition(.submitClaimOptionAppear)
                 .onTapGesture { selectOption(id: option.id) }
                 .accessibilityAddTraits(.isButton)
@@ -133,7 +134,8 @@ struct SubmitClaimSingleSelectResultView: View {
                 colorLevel: .two,
                 withBorder: false
             )
-            .hFieldSize(.capsuleShape)
+            .hFieldSize(.large)
+            .fullyWrapped(true)
         }
     }
 }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSuccessView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSuccessView.swift
@@ -29,6 +29,7 @@ public struct SubmitClaimSuccessView: View {
                 )
             )
         )
+        .hFormBottomBackgroundColor(.aiPoweredGradient)
     }
 }
 

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
@@ -149,7 +149,7 @@ struct ClaimStepResultView: View {
                 .foregroundColor(hTextColor.Translucent.secondary)
                 .hPillStyle(color: .grey, colorLevel: .two, withBorder: false)
                 .hFieldSize(.large)
-                .fullyWrapped(true)
+                .capsuleShape(true)
                 .accessibilityHidden(true)
         } else if viewModel.state.showResults {
             if let viewModel = viewModel as? SubmitClaimAudioStep {
@@ -174,7 +174,7 @@ struct ClaimStepResultView: View {
                 withBorder: false
             )
             .hFieldSize(.large)
-            .fullyWrapped(true)
+            .capsuleShape(true)
             .hPillAttributes(attributes: [.withChevron])
             .accessibilityHint(editHint)
             .accessibilityFocused($isEditButtonFocused)

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
@@ -148,7 +148,8 @@ struct ClaimStepResultView: View {
             hText(L10n.claimChatSkippedStep)
                 .foregroundColor(hTextColor.Translucent.secondary)
                 .hPillStyle(color: .grey, colorLevel: .two, withBorder: false)
-                .hFieldSize(.capsuleShape)
+                .hFieldSize(.large)
+                .fullyWrapped(true)
                 .accessibilityHidden(true)
         } else if viewModel.state.showResults {
             if let viewModel = viewModel as? SubmitClaimAudioStep {
@@ -172,7 +173,8 @@ struct ClaimStepResultView: View {
                 colorLevel: .two,
                 withBorder: false
             )
-            .hFieldSize(.capsuleShape)
+            .hFieldSize(.large)
+            .fullyWrapped(true)
             .hPillAttributes(attributes: [.withChevron])
             .accessibilityHint(editHint)
             .accessibilityFocused($isEditButtonFocused)

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
@@ -79,6 +79,7 @@ public struct SubmitClaimChatScreen: View {
                 .onAppear {
                     scrollCoordinator.scrollViewHeight = proxy.size.height
                 }
+                .hFormBottomBackgroundColor(.aiPoweredGradient)
                 .onChange(of: proxy.size) { value in
                     scrollCoordinator.scrollViewHeight = value.height
                 }

--- a/Projects/hCoreUI/Sources/Pill/hPill.swift
+++ b/Projects/hCoreUI/Sources/Pill/hPill.swift
@@ -21,7 +21,8 @@ public struct hPill: View {
     let withBorder: Bool
     let minWidth: CGFloat?
 
-    @Environment(\.hFieldSize) var fieldSize
+    @Environment(\.fullyWrapped) var fullyWrapped
+    @Environment(\.hFieldSize) var hFieldSize
     @Environment(\.sizeCategory) var sizeCategory
     @Environment(\.hPillAttributes) var attributes
 
@@ -41,8 +42,11 @@ public struct hPill: View {
     }
 
     private var getFontStyle: HFontTextStyle {
-        switch fieldSize {
-        case .large, .capsuleShape:
+        if fullyWrapped {
+            return .body1
+        }
+        switch hFieldSize {
+        case .large:
             return .body1
         default:
             return .label
@@ -66,7 +70,8 @@ fileprivate struct PillModifier: ViewModifier {
     let colorLevel: PillColor.PillColorLevel
     let withBorder: Bool
     let minWidth: CGFloat?
-    @Environment(\.hFieldSize) var fieldSize
+    @Environment(\.hFieldSize) var hFieldSize
+    @Environment(\.fullyWrapped) var fullyWrapped
     func body(content: Content) -> some View {
         content
             .padding(.horizontal, getHorizontalPadding)
@@ -87,50 +92,58 @@ fileprivate struct PillModifier: ViewModifier {
     }
 
     private var getHorizontalPadding: CGFloat {
-        switch fieldSize {
+        if fullyWrapped {
+            return .padding14
+        }
+        switch hFieldSize {
         case .small:
             return .padding6
         case .medium:
             return .padding10
         case .large, .extraLarge:
             return .padding12
-        case .capsuleShape:
-            return .padding14
         }
     }
 
     private var getTopPadding: CGFloat {
-        switch fieldSize {
+        if fullyWrapped {
+            return 7
+        }
+        switch hFieldSize {
         case .small:
             return 3
         case .medium:
             return 6.5
-        case .large, .capsuleShape, .extraLarge:
+        case .large, .extraLarge:
             return 7
         }
     }
 
     private var getBottomPadding: CGFloat {
-        switch fieldSize {
+        if fullyWrapped {
+            return 9
+        }
+        switch hFieldSize {
         case .small:
             return 3
         case .medium:
             return 7.5
-        case .large, .capsuleShape, .extraLarge:
+        case .large, .extraLarge:
             return 9
         }
     }
 
     private var getCornerRadius: CGFloat {
-        switch fieldSize {
+        if fullyWrapped {
+            return .cornerRadiusXXL
+        }
+        switch hFieldSize {
         case .small:
             return .cornerRadiusXS
         case .medium:
             return .cornerRadiusS
         case .large:
             return .cornerRadiusM
-        case .capsuleShape:
-            return .cornerRadiusXXL
         case .extraLarge:
             return .cornerRadiusXL
         }
@@ -298,6 +311,16 @@ extension EnvironmentValues {
 extension View {
     public func hPillAttributes(attributes: [hPillAttrubutes]) -> some View {
         environment(\.hPillAttributes, attributes)
+    }
+}
+
+extension EnvironmentValues {
+    @Entry public var fullyWrapped: Bool = false
+}
+
+extension View {
+    public func fullyWrapped(_ fullyWrapped: Bool) -> some View {
+        environment(\.fullyWrapped, fullyWrapped)
     }
 }
 

--- a/Projects/hCoreUI/Sources/Pill/hPill.swift
+++ b/Projects/hCoreUI/Sources/Pill/hPill.swift
@@ -21,8 +21,8 @@ public struct hPill: View {
     let withBorder: Bool
     let minWidth: CGFloat?
 
-    @Environment(\.fullyWrapped) var fullyWrapped
-    @Environment(\.hFieldSize) var hFieldSize
+    @Environment(\.capsuleShape) var capsuleShape
+    @Environment(\.hFieldSize) var fieldSize
     @Environment(\.sizeCategory) var sizeCategory
     @Environment(\.hPillAttributes) var attributes
 
@@ -42,10 +42,10 @@ public struct hPill: View {
     }
 
     private var getFontStyle: HFontTextStyle {
-        if fullyWrapped {
+        if capsuleShape {
             return .body1
         }
-        switch hFieldSize {
+        switch fieldSize {
         case .large:
             return .body1
         default:
@@ -70,8 +70,8 @@ fileprivate struct PillModifier: ViewModifier {
     let colorLevel: PillColor.PillColorLevel
     let withBorder: Bool
     let minWidth: CGFloat?
-    @Environment(\.hFieldSize) var hFieldSize
-    @Environment(\.fullyWrapped) var fullyWrapped
+    @Environment(\.hFieldSize) var fieldSize
+    @Environment(\.capsuleShape) var capsuleShape
     func body(content: Content) -> some View {
         content
             .padding(.horizontal, getHorizontalPadding)
@@ -92,10 +92,10 @@ fileprivate struct PillModifier: ViewModifier {
     }
 
     private var getHorizontalPadding: CGFloat {
-        if fullyWrapped {
+        if capsuleShape {
             return .padding14
         }
-        switch hFieldSize {
+        switch fieldSize {
         case .small:
             return .padding6
         case .medium:
@@ -106,10 +106,10 @@ fileprivate struct PillModifier: ViewModifier {
     }
 
     private var getTopPadding: CGFloat {
-        if fullyWrapped {
+        if capsuleShape {
             return 7
         }
-        switch hFieldSize {
+        switch fieldSize {
         case .small:
             return 3
         case .medium:
@@ -120,10 +120,10 @@ fileprivate struct PillModifier: ViewModifier {
     }
 
     private var getBottomPadding: CGFloat {
-        if fullyWrapped {
+        if capsuleShape {
             return 9
         }
-        switch hFieldSize {
+        switch fieldSize {
         case .small:
             return 3
         case .medium:
@@ -134,10 +134,10 @@ fileprivate struct PillModifier: ViewModifier {
     }
 
     private var getCornerRadius: CGFloat {
-        if fullyWrapped {
+        if capsuleShape {
             return .cornerRadiusXXL
         }
-        switch hFieldSize {
+        switch fieldSize {
         case .small:
             return .cornerRadiusXS
         case .medium:
@@ -315,12 +315,12 @@ extension View {
 }
 
 extension EnvironmentValues {
-    @Entry public var fullyWrapped: Bool = false
+    @Entry public var capsuleShape: Bool = false
 }
 
 extension View {
-    public func fullyWrapped(_ fullyWrapped: Bool) -> some View {
-        environment(\.fullyWrapped, fullyWrapped)
+    public func capsuleShape(_ capsuleShape: Bool) -> some View {
+        environment(\.capsuleShape, capsuleShape)
     }
 }
 

--- a/Projects/hCoreUI/Sources/hForm/RadioFields/hRadioField.swift
+++ b/Projects/hCoreUI/Sources/hForm/RadioFields/hRadioField.swift
@@ -204,8 +204,6 @@ extension hFieldSize {
             return 20
         case .medium:
             return 19
-        case .capsuleShape:
-            return 19
         }
     }
 
@@ -216,8 +214,6 @@ extension hFieldSize {
         case .large, .extraLarge:
             return 10
         case .medium:
-            return 11.5
-        case .capsuleShape:
             return 11.5
         }
     }
@@ -233,8 +229,6 @@ extension hFieldSize {
         case .large, .extraLarge:
             return 9
         case .medium:
-            return 12.5
-        case .capsuleShape:
             return 12.5
         }
     }

--- a/Projects/hCoreUI/Sources/hForm/hCounterField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hCounterField.swift
@@ -187,8 +187,6 @@ extension hFieldSize {
             return 15
         case .medium:
             return 15
-        case .capsuleShape:
-            return 15
         }
     }
 

--- a/Projects/hCoreUI/Sources/hForm/hFieldBackground.swift
+++ b/Projects/hCoreUI/Sources/hForm/hFieldBackground.swift
@@ -181,7 +181,7 @@ struct hFieldLabel: View {
 
     private var font: HFontTextStyle {
         switch size {
-        case .small, .medium, .capsuleShape:
+        case .small, .medium:
             return .body1
         case .large, .extraLarge:
             return .body2

--- a/Projects/hCoreUI/Sources/hForm/hFloatingTextField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hFloatingTextField.swift
@@ -304,23 +304,20 @@ public enum BackgroundOption: Sendable {
 
 public enum hFieldSize: Hashable, Sendable {
     case small
+    case medium
     case large
     case extraLarge
-    case medium
-    case capsuleShape
 
     var horizontalPadding: CGFloat {
         switch self {
         case .small:
             return .padding14
+        case .medium:
+            return .padding16
         case .large:
             return .padding16
         case .extraLarge:
             return .padding16
-        case .medium:
-            return .padding16
-        case .capsuleShape:
-            return 100
         }
     }
 }
@@ -404,7 +401,6 @@ extension hFieldSize {
         case .small: return -13
         case .medium: return -14
         case .large: return -15
-        case .capsuleShape: return -14
         case .extraLarge: return -15
         }
     }
@@ -419,7 +415,6 @@ extension hFieldSize {
         case .medium: return .body1
         case .large: return .body2
         case .extraLarge: return .body2
-        case .capsuleShape: return .body1
         }
     }
 }

--- a/Projects/hCoreUI/Sources/hForm/hSection.swift
+++ b/Projects/hCoreUI/Sources/hForm/hSection.swift
@@ -160,14 +160,8 @@ struct hSectionContainerStyleModifier: ViewModifier {
         case .transparent:
             content
         case .translucent:
-            Group {
-                if #available(iOS 26.0, *) {
-                    content.background(hSurfaceColor.Translucent.secondary)
-                } else {
-                    content.background(hSurfaceColor.Opaque.primary)
-                }
-            }
-            .clipShape(hRoundedRectangle(cornerRadius: .cornerRadiusL, corners: maskedCorners))
+            content.background(hSurfaceColor.Translucent.secondary)
+                .clipShape(hRoundedRectangle(cornerRadius: .cornerRadiusL, corners: maskedCorners))
         case .opaque:
             content.background(
                 hSurfaceColor.Opaque.primary


### PR DESCRIPTION
## Summary
- Apply `.aiPoweredGradient` background to submit claim chat, deflect, and success screens
- Replace `.capsuleShape` enum case in `hFieldSize` with a separate `.capsuleShape()` environment modifier on pills, decoupling shape from field size
- Use `.translucent` section style in form fields and `.transparent` in deflect view
- Simplify `.translucent` section container to always use translucent background
- Conditionally hide partners section when no content is available

## Test plan
- [ ] Verify submit claim chat flow renders with AI gradient background
- [ ] Verify deflect and success screens show the gradient
- [ ] Verify pill/tag selections still render with capsule shape styling
- [ ] Verify form fields and single-select options display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)