### PR TITLE
bug: normalize osVersion to always have 3 components

### DIFF
--- a/Projects/App/Sources/AppDelegate+Unleash.swift
+++ b/Projects/App/Sources/AppDelegate+Unleash.swift
@@ -19,7 +19,12 @@ extension AppDelegate {
             "memberId": memberId,
             "appVersion": Bundle.main.appVersion,
             "market": "SE",
-            "osVersion": UIDevice.current.systemVersion,
+            // Normalize to 3-component semver (e.g. "26" → "26.0.0") since systemVersion can return 1, 2, or 3 components
+            "osVersion": {
+                let components = UIDevice.current.systemVersion.split(separator: ".").map(String.init)
+                let padded = components + Array(repeating: "0", count: max(0, 3 - components.count))
+                return padded.prefix(3).joined(separator: ".")
+            }(),
         ]
 
         let requiredDictionary = optionalDictionary.compactMapValues { $0 }


### PR DESCRIPTION
## Summary
- Normalizes `UIDevice.current.systemVersion` to always return a 3-component version string (e.g. `"26"` → `"26.0.0"`, `"26.2"` → `"26.2.0"`)
- Prevents inconsistent version formats being sent to Unleash

## Test plan
- [ ] Verify on a device/simulator that the osVersion context value has 3 components

🤖 Generated with [Claude Code](https://claude.com/claude-code)