### PR TITLE
Use Eir-specific support text for partner claims

### DIFF
--- a/Projects/Claims/Sources/Models/ClaimModel.swift
+++ b/Projects/Claims/Sources/Models/ClaimModel.swift
@@ -62,12 +62,10 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public let isPartnerClaim: Bool
     public var statusParagraph: String? {
         if isPartnerClaim {
-            switch status {
-            case .beingHandled:
-                return L10n.ClaimStatus.BeingHandled.supportText
-            default:
+            if status == .closed {
                 return nil
             }
+            return L10n.ClaimStatus.Partner.supportText
         }
         switch status {
         case .submitted:

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -983,6 +983,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status.not_covered.support_text" = "Your claim was unfortunately not covered. Please see conversation for more details on the decision.";
 /* Figma */
 "claim_status.paid.support_text" = "We got you covered. You should have received the payment by now. \n\nSee your messages here in the app for more details.";
+"claim_status.partner.support_text" = "Your claim is being reviewed by our motor specialists at Eir.";
 /* Figma */
 "claim_status.submitted.support_text" = "We have received your claim and will start reviewing it soon.";
 /* Figma */
@@ -994,6 +995,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status_detail.add_more_files" = "Add more files";
 "claim_status_detail.added_files" = "Added files";
 "claim_status_detail.documents.title" = "Claim documents";
+"claim_status_detail.email_view.body" = "Open email";
 /* Figma */
 "claim_status_detail.info_error.body" = "The claim audio couldn't be downloaded. Please try again to be able to listen to it.";
 /* Figma */

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -983,6 +983,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status.not_covered.support_text" = "Tyvärr täcks inte din skada. Se konversation för mer information om beslutet.";
 /* Figma */
 "claim_status.paid.support_text" = "Din skada har täckts. Du borde ha fått ersättningen utbetald vid det här laget. \n\nSe dina meddelanden för mer information om hur vi beräknade din ersättning.";
+"claim_status.partner.support_text" = "Din skadeanmälan granskas av våra motorspecialister på Eir.";
 /* Figma */
 "claim_status.submitted.support_text" = "Vi har tagit emot din skadeanmälan och kommer snart att börja granska den.";
 /* Figma */
@@ -994,6 +995,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status_detail.add_more_files" = "Lägg till fler";
 "claim_status_detail.added_files" = "Tillagda filer";
 "claim_status_detail.documents.title" = "Försäkringsdokument";
+"claim_status_detail.email_view.body" = "Öppna mail";
 /* Figma */
 "claim_status_detail.info_error.body" = "Det gick inte att ladda ned din inspelade skadeanmälan. Försök igen för att kunna lyssna på den.";
 /* Figma */


### PR DESCRIPTION
## Summary
- Replace the status-dependent partner-claim paragraph in `ClaimModel.statusParagraph` with `L10n.ClaimStatus.Partner.supportText` for any non-closed partner claim; closed partner claims still render no paragraph.
- Add the new `claim_status.partner.support_text` key (en + sv-SE) synced from Lokalise: "Your claim is being reviewed by our motor specialists at Eir." / "Din skadeanmälan granskas av våra motorspecialister på Eir."
- Pulls in `claim_status_detail.email_view.body` ("Open email" / "Öppna mail") from the same Lokalise sync; not consumed by code yet, available for follow-up if an email affordance is added.

Stacked on top of `feat/show-car-claims`.

## Test plan
- [ ] Open a partner claim with status `.beingHandled` — paragraph reads "Your claim is being reviewed by our motor specialists at Eir."
- [ ] Open a partner claim with status `.submitted` — same Eir paragraph appears (was previously empty)
- [ ] Open a closed partner claim — no paragraph rendered
- [ ] Open a non-partner claim — paragraph copy unchanged for `.submitted` / `.beingHandled` / `.closed` outcomes
- [ ] Verify Swedish locale renders the translated copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)