### PR TITLE
Show handler info on partner claim detail

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/FetchClaimClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/FetchClaimClientOctopus.swift
@@ -112,7 +112,10 @@ extension ClaimModel {
                     .displayDateDDMMMYYYYFormat ?? item.displayValue
                 return .init(displayTitle: item.displayTitle, displayValue: displayValue)
             },
-            isPartnerClaim: true
+            isPartnerClaim: true,
+            handlerEmail: partnerClaim.handlerEmail,
+            exposureDisplayName: partnerClaim.exposureDisplayName,
+            externalId: partnerClaim.externalId
         )
     }
 }

--- a/Projects/Claims/Sources/Models/ClaimModel.swift
+++ b/Projects/Claims/Sources/Models/ClaimModel.swift
@@ -22,7 +22,10 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
         showClaimClosedFlow: Bool,
         infoText: String?,
         displayItems: [ClaimDisplayItem],
-        isPartnerClaim: Bool = false
+        isPartnerClaim: Bool = false,
+        handlerEmail: String? = nil,
+        exposureDisplayName: String? = nil,
+        externalId: String? = nil
     ) {
         self.id = id
         self.status = status
@@ -41,6 +44,9 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
         self.infoText = infoText
         self.displayItems = displayItems
         self.isPartnerClaim = isPartnerClaim
+        self.handlerEmail = handlerEmail
+        self.exposureDisplayName = exposureDisplayName
+        self.externalId = externalId
     }
 
     public let claimType: String
@@ -60,6 +66,9 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public var infoText: String?
     public let displayItems: [ClaimDisplayItem]
     public let isPartnerClaim: Bool
+    public let handlerEmail: String?
+    public let exposureDisplayName: String?
+    public let externalId: String?
     public var statusParagraph: String? {
         if isPartnerClaim {
             if status == .closed {

--- a/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
+++ b/Projects/Claims/Sources/Service/DemoImplementation/FetchClaimDetailsClientDemo.swift
@@ -41,10 +41,12 @@ public class FetchClaimDetailsClientDemo: hFetchClaimDetailsClient {
             showClaimClosedFlow: false,
             infoText: nil,
             displayItems: [
-                .init(displayTitle: "Damage date", displayValue: "20 Apr 2026"),
-                .init(displayTitle: "Registration number", displayValue: "ABC 123"),
+                .init(displayTitle: "Damage date", displayValue: "20 Apr 2026")
             ],
-            isPartnerClaim: true
+            isPartnerClaim: true,
+            handlerEmail: "claims@eir.se",
+            exposureDisplayName: "ABC 123",
+            externalId: "EIR-2026-000123"
         )
     }
 

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -186,6 +186,9 @@ public struct ClaimDetailView: View {
                             }
                             .accessibilityElement(children: .combine)
                         }
+                        if claim.isPartnerClaim {
+                            partnerInfoRows(claim: claim)
+                        }
                     }
                 }
                 .withHeader(
@@ -196,6 +199,58 @@ public struct ClaimDetailView: View {
                 .sectionContainerStyle(.transparent)
             }
             .padding(.vertical, .padding8)
+        }
+    }
+
+    @ViewBuilder
+    private func partnerInfoRows(claim: ClaimModel) -> some View {
+        if let exposure = claim.exposureDisplayName, !exposure.isEmpty {
+            HStack {
+                hText(L10n.ClaimStatus.ClaimDetails.exposureDisplayName)
+                    .foregroundColor(hTextColor.Opaque.secondary)
+                Spacer()
+                hText(exposure)
+                    .foregroundColor(hTextColor.Opaque.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        }
+        if let externalId = claim.externalId, !externalId.isEmpty {
+            copyableRow(
+                title: L10n.ClaimStatus.ClaimDetails.externalId,
+                value: externalId
+            )
+        }
+        if let handlerEmail = claim.handlerEmail, !handlerEmail.isEmpty {
+            copyableRow(
+                title: L10n.ClaimStatus.ClaimDetails.handlerEmail,
+                value: handlerEmail
+            )
+        }
+    }
+
+    private func copyableRow(title: String, value: String) -> some View {
+        hRow {
+            HStack {
+                hText(title)
+                    .foregroundColor(hTextColor.Opaque.secondary)
+                Spacer()
+                hText(value)
+                    .foregroundColor(hTextColor.Opaque.secondary)
+            }
+        }
+        .withCustomAccessory {
+            hCoreUIAssets.copy.view
+                .accessibilityHidden(true)
+        }
+        .onTap {
+            UIPasteboard.general.string = value
+            Toasts.shared.displayToastBar(
+                toast: .init(
+                    type: .campaign,
+                    icon: hCoreUIAssets.checkmark.view,
+                    text: L10n.General.copied
+                )
+            )
         }
     }
 

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -304,7 +304,7 @@ private enum ClaimDetailDetentType: TrackingViewNameProtocol {
     case fileUpload
 }
 
-#Preview {
+#Preview{
     Dependencies.shared.add(module: Module { () -> hFetchClaimsClient in FetchClaimsClientDemo() })
     Dependencies.shared.add(module: Module { () -> hFetchClaimDetailsClient in FetchClaimDetailsClientDemo() })
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
@@ -341,6 +341,42 @@ private enum ClaimDetailDetentType: TrackingViewNameProtocol {
     return ClaimDetailView(
         claim: claim,
         type: .claim(id: "claimId")
+    )
+}
+
+#Preview("Partner claim"){
+    Dependencies.shared.add(module: Module { () -> hFetchClaimsClient in FetchClaimsClientDemo() })
+    Dependencies.shared.add(module: Module { () -> hFetchClaimDetailsClient in FetchClaimDetailsClientDemo() })
+    Dependencies.shared.add(module: Module { () -> DateService in DateService() })
+    Dependencies.shared.add(module: Module { () -> FeatureFlagsClient in FeatureFlagsDemo() })
+
+    let claim = ClaimModel(
+        id: "partnerClaimId",
+        status: .beingHandled,
+        outcome: nil,
+        submittedAt: "2026-04-20".localDateToDate,
+        signedAudioURL: nil,
+        memberFreeText: nil,
+        payoutAmount: nil,
+        targetFileUploadUri: "",
+        claimType: "Car damage",
+        productVariant: nil,
+        conversation: nil,
+        appealInstructionsUrl: nil,
+        isUploadingFilesEnabled: false,
+        showClaimClosedFlow: false,
+        infoText: nil,
+        displayItems: [
+            .init(displayTitle: "Damage date", displayValue: "20 Apr 2026")
+        ],
+        isPartnerClaim: true,
+        handlerEmail: "claims@eir.se",
+        exposureDisplayName: "ABC 123",
+        externalId: "EIR-2026-000123"
+    )
+    return ClaimDetailView(
+        claim: claim,
+        type: .partnerClaim(id: "partnerClaimId")
     )
 }
 

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -229,20 +229,20 @@ public struct ClaimDetailView: View {
     }
 
     private func copyableRow(title: String, value: String) -> some View {
-        hRow {
-            HStack {
-                hText(title)
-                    .foregroundColor(hTextColor.Opaque.secondary)
-                Spacer()
-                hText(value)
-                    .foregroundColor(hTextColor.Opaque.secondary)
-            }
-        }
-        .withCustomAccessory {
+        HStack {
+            hText(title)
+                .foregroundColor(hTextColor.Opaque.secondary)
+            Spacer()
+            hText(value)
+                .foregroundColor(hTextColor.Opaque.secondary)
             hCoreUIAssets.copy.view
+                .foregroundColor(hTextColor.Opaque.secondary)
                 .accessibilityHidden(true)
         }
-        .onTap {
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .onTapGesture {
             UIPasteboard.general.string = value
             Toasts.shared.displayToastBar(
                 toast: .init(

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -969,6 +969,9 @@ We want members to submit a bug report to us directly instead of writing bad rev
 /* Figma */
 "claim_status.being_handled_reopened.support_text" = "We have reopened your claim and one of our insurance specialists is reviewing it. We'll get back to you soon with an update.";
 "claim_status.claim_details.button" = "Show details";
+"claim_status.claim_details.exposure_display_name" = "Reg nr";
+"claim_status.claim_details.external_id" = "Ärendenummer";
+"claim_status.claim_details.handler_email" = "E-mail";
 "claim_status.claim_details.info_text" = "Is something missing? Send us a message here in the app.";
 "claim_status.claim_details.submitted" = "Submitted";
 "claim_status.claim_details.title" = "Claim details";

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -613,6 +613,8 @@ A message is then appended under the image next to the timestamp to indicate tha
 "PAYOUT_METHOD_SWISH_DESCRIPTION" = "Instant payout with Swish";
 "PAYOUT_METHOD_TRUSTLY_DESCRIPTION" = "Payout via Trustly";
 "PAYOUT_MISSING_INFO" = "You haven’t added a payout method yet. Add one to receive payouts.";
+"PAYOUT_NO_PAYOUT_OPTIONS_SUBTITLE" = "Add one to receive payouts";
+"PAYOUT_NO_PAYOUT_OPTIONS_TITLE" = "No payout method added";
 "PAYOUT_PAGE_HEADING" = "Payout account";
 "PAYOUT_SELECT_PAYOUT_METHOD" = "Choose payout method";
 /* Label that hints the user to slide up in order to reveal more info */
@@ -969,9 +971,9 @@ We want members to submit a bug report to us directly instead of writing bad rev
 /* Figma */
 "claim_status.being_handled_reopened.support_text" = "We have reopened your claim and one of our insurance specialists is reviewing it. We'll get back to you soon with an update.";
 "claim_status.claim_details.button" = "Show details";
-"claim_status.claim_details.exposure_display_name" = "Reg nr";
-"claim_status.claim_details.external_id" = "Ärendenummer";
-"claim_status.claim_details.handler_email" = "E-mail";
+"claim_status.claim_details.exposure_display_name" = "Reg. no.";
+"claim_status.claim_details.external_id" = "Reference number";
+"claim_status.claim_details.handler_email" = "Email";
 "claim_status.claim_details.info_text" = "Is something missing? Send us a message here in the app.";
 "claim_status.claim_details.submitted" = "Submitted";
 "claim_status.claim_details.title" = "Claim details";
@@ -986,7 +988,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status.not_covered.support_text" = "Your claim was unfortunately not covered. Please see conversation for more details on the decision.";
 /* Figma */
 "claim_status.paid.support_text" = "We got you covered. You should have received the payment by now. \n\nSee your messages here in the app for more details.";
-"claim_status.partner.support_text" = "Your claim is being reviewed by our motor specialists at Eir.";
+"claim_status.partner.support_text" = "This claim is handled by our external partner Eir by email.\nAlready in contact with them? Reply to your existing email thread to keep all claim details in one conversation.";
 /* Figma */
 "claim_status.submitted.support_text" = "We have received your claim and will start reviewing it soon.";
 /* Figma */

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -969,6 +969,9 @@ We want members to submit a bug report to us directly instead of writing bad rev
 /* Figma */
 "claim_status.being_handled_reopened.support_text" = "Vi har återöppnat din skadeanmälan och en av våra försäkringsspecialister granskar den. Vi hör av oss snart med en uppdatering.";
 "claim_status.claim_details.button" = "Se detaljer";
+"claim_status.claim_details.exposure_display_name" = "Reg nr";
+"claim_status.claim_details.external_id" = "Ärendenummer";
+"claim_status.claim_details.handler_email" = "E-mail";
 "claim_status.claim_details.info_text" = "Saknas något? Skicka ett meddelande till oss här i appen.";
 "claim_status.claim_details.submitted" = "Inskickad";
 "claim_status.claim_details.title" = "Detaljer om skadeanmälan";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -613,6 +613,8 @@ A message is then appended under the image next to the timestamp to indicate tha
 "PAYOUT_METHOD_SWISH_DESCRIPTION" = "Snabb utbetalning med Swish";
 "PAYOUT_METHOD_TRUSTLY_DESCRIPTION" = "Utbetalning via Trustly";
 "PAYOUT_MISSING_INFO" = "Du har inte lagt till någon utbetalningsmetod än. Lägg till en för att vi ska kunna betala ut till dig.";
+"PAYOUT_NO_PAYOUT_OPTIONS_SUBTITLE" = "Lägg till en för att få utbetalningar";
+"PAYOUT_NO_PAYOUT_OPTIONS_TITLE" = "Ingen utbetalningsmetod tillagd";
 "PAYOUT_PAGE_HEADING" = "Utbetalningskonto";
 "PAYOUT_SELECT_PAYOUT_METHOD" = "Välj utbetalningsmetod";
 /* Label that hints the user to slide up in order to reveal more info */
@@ -986,7 +988,7 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "claim_status.not_covered.support_text" = "Tyvärr täcks inte din skada. Se konversation för mer information om beslutet.";
 /* Figma */
 "claim_status.paid.support_text" = "Din skada har täckts. Du borde ha fått ersättningen utbetald vid det här laget. \n\nSe dina meddelanden för mer information om hur vi beräknade din ersättning.";
-"claim_status.partner.support_text" = "Din skadeanmälan granskas av våra motorspecialister på Eir.";
+"claim_status.partner.support_text" = "Den här skadan hanteras av vår externa partner Eir via mail.\nRedan i kontakt med dem? Svara i din befintliga mailtråd så att all skadeinformation hålls samlad i en och samma konversation.";
 /* Figma */
 "claim_status.submitted.support_text" = "Vi har tagit emot din skadeanmälan och kommer snart att börja granska den.";
 /* Figma */


### PR DESCRIPTION
## Summary

- Adds three new rows to the **Claim details** section on partner (Eir) claim detail screens: **Reg nr** (`exposureDisplayName`, read-only), **Ärendenummer** (`externalId`, tap-to-copy), **E-mail** (`handlerEmail`, tap-to-copy).
- Wires three new optional `String?` properties on `ClaimModel`, populated from `OctopusGraphQL.PartnerClaimFragment` in `init(partnerClaim:)`. Regular `ClaimModel` callers compile unchanged via `nil` defaults.
- Tap-to-copy uses `UIPasteboard.general.string` + the existing `Toasts.shared.displayToastBar` "Copied" pattern (mirrors `Profile/.../InformationScreen.swift`).

## Stacked on

This PR targets `feat/show-car-claims` (where the parent `chore/partner-claim-eir-support-text` work lives via PR #2409).

## Test plan

- [ ] Open a partner claim → confirm four rows under "Claim details" in order: backend `displayItems` (e.g. Date of incident) → Reg nr → Ärendenummer → E-mail
- [ ] Tap Ärendenummer → "Copied" toast, value in clipboard
- [ ] Tap E-mail → "Copied" toast, value in clipboard
- [ ] Tap Reg nr → no copy action (no copy icon, read-only)
- [ ] Regular (non-partner) claims unchanged: no extra rows
- [ ] Per-row hide-when-empty: nulling any of the three values hides only that row

🤖 Generated with [Claude Code](https://claude.com/claude-code)