### PR TITLE
eng: Track visible SwiftUI screens for chat banner suppression

### DIFF
--- a/Projects/App/Sources/AppDelegate+Notifications.swift
+++ b/Projects/App/Sources/AppDelegate+Notifications.swift
@@ -120,19 +120,15 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
             guard let notificationType = getNotificationType(from: notification.request.content.userInfo) else {
                 return true
             }
-            guard let topPresentedVCDescription = UIApplication.shared.getTopVisibleVc()?.debugDescription else {
-                return true
-            }
 
             if notificationType != .NEW_MESSAGE { return true }
-            let listToCheck: [String] = [
-                String(describing: HomeScreen.self),
-                .init(describing: ClaimDetailView.self),
-                .init(describing: InboxView.self),
-                .init(describing: ChatScreen.self),
-            ]
-            let shouldShow = !listToCheck.contains(where: { $0 == topPresentedVCDescription })
-            return shouldShow
+            let chatSurfaceOnTop = VisibleScreenTracker.isAnyVisible([
+                HomeScreen.self,
+                ClaimDetailView.self,
+                InboxView.self,
+                ChatScreen.self,
+            ])
+            return !chatSurfaceOnTop
         }()
 
         return shouldShowNotification ? [.badge, .banner, .sound] : []

--- a/Projects/Chat/Sources/Views/ChatScreen.swift
+++ b/Projects/Chat/Sources/Views/ChatScreen.swift
@@ -39,6 +39,7 @@ public struct ChatScreen: View {
                 isTargetedForDropdown: $isTargetedForDropdown
             )
         )
+        .trackVisibility(as: ChatScreen.self)
     }
 
     @ViewBuilder

--- a/Projects/Chat/Sources/Views/InboxView.swift
+++ b/Projects/Chat/Sources/Views/InboxView.swift
@@ -28,6 +28,7 @@ public struct InboxView: View {
                 )
             )
         )
+        .trackVisibility(as: InboxView.self)
     }
 
     @ViewBuilder

--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -88,6 +88,7 @@ public struct ClaimDetailView: View {
                 })
             )
         )
+        .trackVisibility(as: ClaimDetailView.self)
     }
 
     @ViewBuilder

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -167,7 +167,6 @@ class HomeVM: ObservableObject {
                 guard VisibleScreenTracker.isVisible(HomeScreen.self) else { return }
                 let store: HomeStore = globalPresentableStoreContainer.get()
                 store.send(.fetchChatNotifications)
-                print("FETCHD AT \(Date())")
             }
     }
 

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -45,6 +45,7 @@ extension HomeScreen {
         }
         .sectionContainerStyle(.transparent)
         .hFormContentPosition(.center)
+        .trackVisibility(as: HomeScreen.self)
         .onAppear {
             vm.fetchHomeState()
         }
@@ -163,12 +164,10 @@ class HomeVM: ObservableObject {
         chatNotificationPullTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
         chatNotificationPullTimerCancellable = chatNotificationPullTimer.receive(on: RunLoop.main)
             .sink { _ in
-                let currentVCDescription = UIApplication.shared.getTopVisibleVc()?.debugDescription
-                let compareToDescirption = String(describing: HomeScreen.self)
-                if currentVCDescription == compareToDescirption {
-                    let store: HomeStore = globalPresentableStoreContainer.get()
-                    store.send(.fetchChatNotifications)
-                }
+                guard VisibleScreenTracker.isVisible(HomeScreen.self) else { return }
+                let store: HomeStore = globalPresentableStoreContainer.get()
+                store.send(.fetchChatNotifications)
+                print("FETCHD AT \(Date())")
             }
     }
 

--- a/Projects/hCore/Sources/UIApplication+GetTopViewController.swift
+++ b/Projects/hCore/Sources/UIApplication+GetTopViewController.swift
@@ -60,34 +60,6 @@ extension UIApplication {
             .first?
             .rootViewController
     }
-
-    /// Returns visible ViewController
-    ///
-    /// - Returns: If the top presented ViewController is NavigationViewController
-    /// returns last ViewController
-    @MainActor
-    public func getTopVisibleVc(from vc: UIViewController? = nil) -> UIViewController? {
-        if let vc = vc ?? getRootViewController() {
-            if let presentedVc = vc.presentedViewController {
-                return getTopVisibleVc(from: presentedVc)
-            }
-            if let tabBar = (vc as? UITabBarController) ?? vc.children.first(where: {
-                $0.isKind(of: UITabBarController.self)
-            }) as? UITabBarController,
-                let selectedVc = tabBar.selectedViewController
-            {
-                return getTopVisibleVc(from: selectedVc)
-            } else if let navigation = (vc as? UINavigationController)
-                ?? (vc.children.first(where: { $0.isKind(of: UINavigationController.self) }) as? UINavigationController),
-                let last = navigation.viewControllers.last
-            {
-                return getTopVisibleVc(from: last)
-            } else {
-                return vc
-            }
-        }
-        return nil
-    }
 }
 
 extension UIViewController {

--- a/Projects/hCoreUI/Sources/VisibleScreenTracker.swift
+++ b/Projects/hCoreUI/Sources/VisibleScreenTracker.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+@_spi(Advanced) import SwiftUIIntrospect
+
+@MainActor
+public enum VisibleScreenTracker {
+    private struct Entry {
+        let name: String
+        weak var vc: UIViewController?
+    }
+
+    private static var entries: [Entry] = []
+
+    public static func isVisible<V: View>(_ type: V.Type) -> Bool {
+        isAnyVisible([type])
+    }
+
+    public static func isAnyVisible(_ types: [Any.Type]) -> Bool {
+        entries.removeAll { $0.vc == nil }
+        guard let topVC = leafVisibleVC() else { return false }
+        let names = types.map { String(describing: $0) }
+        for entry in entries.reversed() {
+            guard let vc = entry.vc else { continue }
+            if vc === topVC || vc.isAncestor(of: topVC) {
+                return names.contains(entry.name)
+            }
+        }
+        return false
+    }
+
+    fileprivate static func register(name: String, vc: UIViewController) {
+        entries.removeAll { $0.vc == nil || $0.vc === vc }
+        entries.append(Entry(name: name, vc: vc))
+    }
+
+    private static func leafVisibleVC() -> UIViewController? {
+        var current = UIApplication.shared.getRootViewController()
+        while let presented = current?.presentedViewController {
+            current = presented
+        }
+        while let vc = current {
+            if let tab = (vc as? UITabBarController)
+                ?? vc.children.first(where: { $0 is UITabBarController }) as? UITabBarController,
+                let selected = tab.selectedViewController
+            {
+                current = selected
+            } else if let nav = (vc as? UINavigationController)
+                ?? vc.children.first(where: { $0 is UINavigationController }) as? UINavigationController,
+                let top = nav.topViewController
+            {
+                current = top
+            } else {
+                return vc
+            }
+        }
+        return nil
+    }
+}
+
+extension UIViewController {
+    fileprivate func isAncestor(of vc: UIViewController) -> Bool {
+        var current: UIViewController? = vc.parent
+        while let c = current {
+            if c === self { return true }
+            current = c.parent
+        }
+        return false
+    }
+}
+
+extension View {
+    public func trackVisibility<V: View>(as type: V.Type) -> some View {
+        let name = String(describing: type)
+        return introspect(.viewController, on: .iOS(.v13...)) { vc in
+            VisibleScreenTracker.register(name: name, vc: vc)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The previous suppression check compared `UIHostingController.debugDescription` (`NavigationStackHostingController<AnyView>`) against SwiftUI view type names like `"HomeScreen"` — they never matched, so NEW_MESSAGE banners were never suppressed and the 10s chat-notification poll on `HomeVM` never gated correctly.
- Introduces `VisibleScreenTracker` in `hCoreUI`. Each tracked surface (`HomeScreen`, `InboxView`, `ClaimDetailView`, `ChatScreen`) registers its hosting `UIViewController` via `SwiftUIIntrospect` through a new `.trackVisibility(as:)` modifier.
- At query time the tracker resolves the leaf visible VC by walking `presentedViewController` and descending through tab bar / nav controller chains, then matches it against registered entries. `.parent` traversal stops at modal boundaries, so a foreign modal on top of Home correctly reports "no tracked screen on top".
- Removes the unused `UIApplication.getTopVisibleVc` helper (no remaining callers).

## Test plan

- [ ] Open the app on HomeScreen; send a chat push notification → banner is suppressed
- [ ] Open any modal/sheet over HomeScreen; send a chat push → banner appears
- [ ] Push from HomeScreen to a non-tracked detail view; send a chat push → banner appears
- [ ] Open the chat (`.detent` sheet); send a chat push → banner suppressed
- [ ] Switch to a non-Home tab; send a chat push → banner appears
- [ ] Confirm `HomeVM` 10s `fetchChatNotifications` poll fires only when HomeScreen is the actual top (modal / push / tab switch all pause it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)