### PR TITLE
Fade nav bar bottom border using Compose scroll offset

### DIFF
--- a/Projects/Home/Sources/Screens/HelpCenter/PuppyGuideHosts.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/PuppyGuideHosts.swift
@@ -16,7 +16,12 @@ struct PuppyGuideListHost: UIViewControllerRepresentable {
                     router?.push(PuppyGuideRoute.article(storyName: storyName))
                 }
             },
-            swipeBackController: bridge
+            swipeBackController: bridge,
+            onScrollOffsetChanged: { [bridge] offsetDp in
+                DispatchQueue.main.async {
+                    bridge.setScrollOffset(CGFloat(offsetDp.floatValue))
+                }
+            }
         )
         let host = SwipeBackToggleHostingController(child: composeVC)
         bridge.host = host
@@ -37,7 +42,12 @@ struct PuppyArticleHost: UIViewControllerRepresentable {
             navigateUp: { [weak router] in
                 DispatchQueue.main.async { router?.pop() }
             },
-            swipeBackController: bridge
+            swipeBackController: bridge,
+            onScrollOffsetChanged: { [bridge] offsetDp in
+                DispatchQueue.main.async {
+                    bridge.setScrollOffset(CGFloat(offsetDp.floatValue))
+                }
+            }
         )
         let host = SwipeBackToggleHostingController(child: composeVC)
         bridge.host = host

--- a/Projects/Home/Sources/Screens/HelpCenter/SwipeBackToggleHostingController.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/SwipeBackToggleHostingController.swift
@@ -2,8 +2,20 @@
 import SwiftUI
 import UIKit
 
+@MainActor
 final class SwipeBackToggleHostingController: UIViewController {
     private let child: UIViewController
+    // Compose doesn't expose its real scroll position through any native UIScrollView,
+    // so we use a hidden dummy one as the nav bar's tracked content scroll view and
+    // forward Compose's scroll offset onto its contentOffset. iOS then drives the
+    // scroll-edge appearance transition the standard way.
+    private let trackingScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.backgroundColor = .clear
+        return scrollView
+    }()
 
     init(child: UIViewController) {
         self.child = child
@@ -14,16 +26,31 @@ final class SwipeBackToggleHostingController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.addSubview(trackingScrollView)
+        NSLayoutConstraint.activate([
+            trackingScrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            trackingScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            trackingScrollView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            trackingScrollView.heightAnchor.constraint(equalTo: view.heightAnchor, constant: 1),
+        ])
+        setContentScrollView(trackingScrollView)
         addChild(child)
         child.view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(child.view)
+        trackingScrollView.addSubview(child.view)
+        child.view.insetsLayoutMarginsFromSafeArea = true
         NSLayoutConstraint.activate([
-            child.view.topAnchor.constraint(equalTo: view.topAnchor),
-            child.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            child.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            child.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            child.view.topAnchor.constraint(equalTo: trackingScrollView.topAnchor),
+            child.view.bottomAnchor.constraint(equalTo: trackingScrollView.bottomAnchor),
+            child.view.widthAnchor.constraint(equalTo: trackingScrollView.widthAnchor),
+            child.view.heightAnchor.constraint(equalTo: trackingScrollView.heightAnchor),
         ])
         child.didMove(toParent: self)
+    }
+
+    func setScrollOffset(_ offset: CGFloat) {
+        let y = min(1, max(0, offset))
+        guard y != trackingScrollView.contentOffset.y else { return }
+        trackingScrollView.contentOffset = CGPoint(x: 0, y: y)
     }
 
     // NavigationStack on iOS 18+/26 uses a private pan recognizer for swipe-back
@@ -45,6 +72,14 @@ final class SwipeBackBridge: NSObject, IosSwipeBackController {
     weak var host: SwipeBackToggleHostingController?
 
     func setSwipeBackEnabled(isEnabled: Bool) {
-        host?.setSwipeBackEnabled(isEnabled)
+        Task { [host] in
+            await host?.setSwipeBackEnabled(isEnabled)
+        }
+    }
+
+    func setScrollOffset(_ offset: CGFloat) {
+        Task { [host] in
+            await host?.setScrollOffset(offset)
+        }
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -82,7 +82,7 @@ public enum ExternalDependencies: CaseIterable {
         case .umbrella:
             if isLocalUmbrellaMode { return [] }
             return [
-                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260513081147"))
+                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260515135038"))
             ]
         case .kmpNativeCoroutines:
             return [


### PR DESCRIPTION
## Summary
- Bridge Compose's scroll offset onto a hidden tracking `UIScrollView` registered via `setContentScrollView`, so iOS drives the standard nav-bar scroll-edge appearance transition for the puppy guide list and article screens.
- Add `onScrollOffsetChanged` wiring in `PuppyGuideListHost` / `PuppyArticleHost` and a `setScrollOffset` path on `SwipeBackBridge` -> `SwipeBackToggleHostingController`.
- Bump umbrella to pick up the new Kotlin callback parameter.

## Test plan
- [ ] Open the puppy guide list — nav bar bottom border fades in as content scrolls under it and fades out at top
- [ ] Open a puppy guide article — same fade behavior
- [ ] Swipe-back gesture still works on both screens
- [ ] No regressions on HelpCenter start view

🤖 Generated with [Claude Code](https://claude.com/claude-code)