### PR TITLE
Render young dog as a card and a not-young dog as a quick action

### DIFF
--- a/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/HelpCenterStartView.swift
@@ -8,7 +8,7 @@ import hCoreUI
 
 public struct HelpCenterStartView: View {
     @StateObject var vm = HelpCenterStartViewModel()
-    @State private var puppyGuideAvailable: Bool = false
+    @State private var puppyGuideDisplay: PuppyGuideDisplay?
     @State private var puppyGuideCancellable: PuppyGuideAvailabilityCancellable?
     let onQuickAction: (QuickAction) -> Void
     @EnvironmentObject var router: NavigationRouter
@@ -17,6 +17,15 @@ public struct HelpCenterStartView: View {
         onQuickAction: @escaping (QuickAction) -> Void
     ) {
         self.onQuickAction = onQuickAction
+    }
+
+    private enum PuppyGuideDisplay {
+        case fullCard
+        case quickAction
+    }
+
+    private var showsFullPuppyGuideCard: Bool {
+        puppyGuideDisplay == .fullCard
     }
 
     public var body: some View {
@@ -38,7 +47,7 @@ public struct HelpCenterStartView: View {
                             .padding(.top, 20)
                         } else {
                             ZStack {
-                                if puppyGuideAvailable {
+                                if showsFullPuppyGuideCard {
                                     puppyGuideEntry
                                         .transition(.opacity)
                                 } else {
@@ -55,7 +64,7 @@ public struct HelpCenterStartView: View {
                                     .transition(.opacity)
                                 }
                             }
-                            .animation(.smooth, value: puppyGuideAvailable)
+                            .animation(.smooth, value: showsFullPuppyGuideCard)
                             .padding(.top, 24)
                             .padding(.bottom, 48)
                             VStack(alignment: .leading, spacing: .padding8) {
@@ -65,8 +74,11 @@ public struct HelpCenterStartView: View {
                             }
                             .accessibilityElement(children: .combine)
                             .padding(.bottom, 40)
-                            displayQuickActions(from: vm.quickActions)
-                                .padding(.bottom, 40)
+                            displayQuickActions(
+                                from: vm.quickActions,
+                                showPuppyGuideRow: puppyGuideDisplay == .quickAction
+                            )
+                            .padding(.bottom, 40)
                             displayTopics()
                                 .padding(.bottom, 40)
                             if let helpCenterModel = vm.helpCenterModel {
@@ -107,8 +119,16 @@ public struct HelpCenterStartView: View {
             vm.updateColors()
         }
         .task {
-            puppyGuideCancellable = PuppyGuideAvailabilityKt.observePuppyGuideAvailability { available in
-                DispatchQueue.main.async { puppyGuideAvailable = available.boolValue }
+            puppyGuideCancellable = PuppyGuideAvailabilityKt.observePuppyGuideAvailability { presentation in
+                let display: PuppyGuideDisplay?
+                if presentation is PuppyGuidePresentation.FullCard {
+                    display = .fullCard
+                } else if presentation is PuppyGuidePresentation.QuickAction {
+                    display = .quickAction
+                } else {
+                    display = nil
+                }
+                DispatchQueue.main.async { puppyGuideDisplay = display }
             }
         }
         .onDisappear {
@@ -154,8 +174,8 @@ public struct HelpCenterStartView: View {
     }
 
     @ViewBuilder
-    func displayQuickActions(from quickActions: [QuickAction]) -> some View {
-        if !quickActions.isEmpty {
+    func displayQuickActions(from quickActions: [QuickAction], showPuppyGuideRow: Bool = false) -> some View {
+        if !quickActions.isEmpty || showPuppyGuideRow {
             VStack(alignment: .leading, spacing: .padding4) {
                 HelpCenterPill(title: L10n.hcQuickActionsTitle, color: .green)
                     .padding(.bottom, .padding4)
@@ -163,6 +183,11 @@ public struct HelpCenterStartView: View {
                 ForEach(quickActions, id: \.displayTitle) { [onQuickAction] quickAction in
                     QuickActionView(quickAction: quickAction) {
                         onQuickAction(quickAction)
+                    }
+                }
+                if showPuppyGuideRow {
+                    PuppyGuideQuickActionRow { [weak router] in
+                        router?.push(PuppyGuideRoute.list)
                     }
                 }
             }

--- a/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents/HelpCenterQuickActionView.swift
+++ b/Projects/Home/Sources/Screens/HelpCenter/ReusableComponents/HelpCenterQuickActionView.swift
@@ -33,6 +33,29 @@ struct QuickActionView: View {
     }
 }
 
+struct PuppyGuideQuickActionRow: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        hSection {
+            hRow {
+                VStack(alignment: .leading, spacing: 0) {
+                    hText(L10n.puppyGuideTitle)
+
+                    hText(L10n.puppyGuideSubtitle, style: .label)
+                        .foregroundColor(hTextColor.Opaque.secondary)
+                }
+                Spacer()
+            }
+            .withChevronAccessory
+            .verticalPadding(.padding12)
+            .onTap(onTap)
+        }
+        .hWithoutHorizontalPadding([.section])
+        .sectionContainerStyle(.opaque)
+    }
+}
+
 #Preview {
     QuickActionView(quickAction: .travelInsurance, onQuickAction: {})
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -82,7 +82,7 @@ public enum ExternalDependencies: CaseIterable {
         case .umbrella:
             if isLocalUmbrellaMode { return [] }
             return [
-                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260528090951"))
+                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260528131143"))
             ]
         case .kmpNativeCoroutines:
             return [

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -82,7 +82,7 @@ public enum ExternalDependencies: CaseIterable {
         case .umbrella:
             if isLocalUmbrellaMode { return [] }
             return [
-                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260527001340"))
+                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260528090951"))
             ]
         case .kmpNativeCoroutines:
             return [


### PR DESCRIPTION
Android sibling commit:
https://github.com/HedvigInsurance/android/commit/0fefc7c1aac690cbc2006348b13aedef72f9434d

| Young | Old |
| --- | --- |
| <img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/1fdd9f10-3543-4aa6-a0c9-3d31a4524534" /> | <img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/9ee8cd43-a896-4cbf-9697-3206ca5a824a" /> |


