### PR TITLE
chore: unify URLOpener around async open(_:) with requiresAuthorization

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -89,7 +89,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
         if settings.authorizationStatus == .denied {
-            DispatchQueue.main.async { Dependencies.urlOpener.open(settingsUrl) }
+            await Dependencies.urlOpener.open(settingsUrl)
         } else {
             do {
                 let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -1146,7 +1146,7 @@ class LoggedInNavigationViewModel: ObservableObject {
         }
         let schema = urlComponent?.scheme
         if let finalUrl = urlComponent?.url {
-            if schema == "https" || schema == "http" {
+            if (schema == "https" || schema == "http") && !finalUrl.requiresAuthorization {
                 let vc = SFSafariViewController(url: finalUrl)
                 vc.modalPresentationStyle = .pageSheet
                 vc.preferredControlTintColor = .brand(.primaryText())
@@ -1155,7 +1155,7 @@ class LoggedInNavigationViewModel: ObservableObject {
                 if Bundle.main.urlSchemes.contains(schema ?? "") {
                     return
                 }
-                Dependencies.urlOpener.open(url)
+                Task { await Dependencies.urlOpener.open(finalUrl) }
             }
         }
     }

--- a/Projects/App/Sources/Screens/LaunchScreen/NotLoggedInView.swift
+++ b/Projects/App/Sources/Screens/LaunchScreen/NotLoggedInView.swift
@@ -138,7 +138,7 @@ class NotLoggedViewModel: ObservableObject {
             .appending("utm_source", value: "ios")
             .appending("utm_medium", value: "hedvig-app")
             .appending("utm_campaign", value: "se")
-        Dependencies.urlOpener.open(webUrl)
+        Task { await Dependencies.urlOpener.open(webUrl) }
     }
 
     enum ViewState {

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/DefaultURLOpener.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/DefaultURLOpener.swift
@@ -5,8 +5,13 @@ import hCore
 class DefaultURLOpener: URLOpener {
     @Inject private var authorizationCodeClient: AuthorizationCodeClient
 
-    public func openWithAuthorizationCode(_ url: URL) async {
-        var urlToOpen = url
+    public func open(_ url: URL) async {
+        log.info("Opening URL: \(url.absoluteString)", error: nil, attributes: nil)
+        let urlToOpen = url.requiresAuthorization ? await urlWithAuthorizationCode(url) : url
+        await UIApplication.shared.open(urlToOpen)
+    }
+
+    private func urlWithAuthorizationCode(_ url: URL) async -> URL {
         do {
             let code = try await authorizationCodeClient.getAuthorizationCode().authorizationCode
             if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
@@ -14,17 +19,12 @@ class DefaultURLOpener: URLOpener {
                 queryItems.append(URLQueryItem(name: "authorization_code", value: code))
                 components.queryItems = queryItems
                 if let authorizedURL = components.url {
-                    urlToOpen = authorizedURL
+                    return authorizedURL
                 }
             }
         } catch {
             log.error("Failed to get authorization code", error: error, attributes: nil)
         }
-        await UIApplication.shared.open(urlToOpen)
-    }
-
-    public func open(_ url: URL) {
-        log.info("Opening URL: \(url.absoluteString)", error: nil, attributes: nil)
-        UIApplication.shared.open(url)
+        return url
     }
 }

--- a/Projects/Authentication/Sources/OTP/OpenEmailClientButton.swift
+++ b/Projects/Authentication/Sources/OTP/OpenEmailClientButton.swift
@@ -21,7 +21,7 @@ struct EmailClient {
             return
         }
 
-        Dependencies.urlOpener.open(url)
+        Task { await Dependencies.urlOpener.open(url) }
     }
 }
 

--- a/Projects/Authentication/Sources/SEBankID/BankIDLoginQRView.swift
+++ b/Projects/Authentication/Sources/SEBankID/BankIDLoginQRView.swift
@@ -188,7 +188,7 @@ class BankIDViewModel: ObservableObject {
         if let url = URL(string: "bankid:///?autostarttoken=\(token)&redirect=\(urlScheme)://bankid") {
             log.info("BANK ID APP started", error: nil, attributes: ["token": token])
             if UIApplication.shared.canOpenURL(url) {
-                Dependencies.urlOpener.open(url)
+                Task { await Dependencies.urlOpener.open(url) }
             }
         }
     }

--- a/Projects/Chat/Sources/Views/ImagesView.swift
+++ b/Projects/Chat/Sources/Views/ImagesView.swift
@@ -101,7 +101,7 @@ class ImagesViewModel: ObservableObject {
         guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
             return
         }
-        Dependencies.urlOpener.open(settingsUrl)
+        Task { await Dependencies.urlOpener.open(settingsUrl) }
     }
 }
 

--- a/Projects/CrossSell/Sources/View/Components/CrossSellButtonComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellButtonComponent.swift
@@ -17,7 +17,7 @@ struct CrossSellButtonComponent: View {
                         if let urlString = crossSell.webActionURL, let url = URL(string: urlString) {
                             Task {
                                 isCrossSellLoading = true
-                                await Dependencies.urlOpener.openWithAuthorizationCode(url)
+                                await Dependencies.urlOpener.open(url)
                                 isCrossSellLoading = false
                                 vm.vc?.dismiss(animated: true)
                             }

--- a/Projects/CrossSell/Sources/View/CrossSellingItem.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingItem.swift
@@ -13,7 +13,7 @@ struct CrossSellingItem: View {
         if let urlString = crossSell.webActionURL, let url = URL(string: urlString) {
             Task {
                 isCrossSellLoading = true
-                await Dependencies.urlOpener.openWithAuthorizationCode(url)
+                await Dependencies.urlOpener.open(url)
                 isCrossSellLoading = false
             }
         } else {

--- a/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
@@ -208,14 +208,16 @@ public struct HelpCenterNavigation<Content: View>: View {
                     urlComponent?.scheme = "https"
                 }
                 let schema = urlComponent?.scheme
+                let requiresAuthorization = urlComponent?.queryItems?
+                    .contains(where: { $0.name == "requiresAuthorization" && $0.value == "true" }) ?? false
                 if let finalUrl = urlComponent?.url {
-                    if schema == "https" || schema == "http" {
+                    if (schema == "https" || schema == "http") && !requiresAuthorization {
                         let vc = SFSafariViewController(url: finalUrl)
                         vc.modalPresentationStyle = .pageSheet
                         vc.preferredControlTintColor = .brand(.primaryText())
                         UIApplication.shared.getTopViewController()?.present(vc, animated: true)
                     } else {
-                        Dependencies.urlOpener.open(url)
+                        Task { await Dependencies.urlOpener.open(url) }
                     }
                 }
             case .changeTierFoundBetterPriceStarted, .changeTierMissingCoverageAndTermsStarted:

--- a/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
@@ -208,8 +208,7 @@ public struct HelpCenterNavigation<Content: View>: View {
                     urlComponent?.scheme = "https"
                 }
                 let schema = urlComponent?.scheme
-                let requiresAuthorization = urlComponent?.queryItems?
-                    .contains(where: { $0.name == "requiresAuthorization" && $0.value == "true" }) ?? false
+                let requiresAuthorization = url.requiresAuthorization
                 if let finalUrl = urlComponent?.url {
                     if (schema == "https" || schema == "http") && !requiresAuthorization {
                         let vc = SFSafariViewController(url: finalUrl)

--- a/Projects/Home/Sources/Screens/CommonClaims/FirstVetView.swift
+++ b/Projects/Home/Sources/Screens/CommonClaims/FirstVetView.swift
@@ -37,7 +37,7 @@ public struct FirstVetView: View {
                                         if let url = URL(
                                             string: partner.url
                                         ) {
-                                            Dependencies.urlOpener.open(url)
+                                            Task { await Dependencies.urlOpener.open(url) }
                                         }
                                     }
                                 )

--- a/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
@@ -112,7 +112,7 @@ private class DirectDebitWebview: UIView {
                 if isLoading {
                     didFailToLoadWebViewSignal.send(true)
                     if let url {
-                        Dependencies.urlOpener.open(url)
+                        Task { await Dependencies.urlOpener.open(url) }
                     } else {
                         self?.showErrorAlert = true
                     }

--- a/Projects/Payment/Sources/Screens/ConnectPayments/TrustlyScriptHandler.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/TrustlyScriptHandler.swift
@@ -16,7 +16,7 @@ public class TrustlyWKScriptOpenURLScheme: NSObject, WKScriptMessageHandler {
         {
             let canOpenApplicationUrl = UIApplication.shared.canOpenURL(appUrl)
             if canOpenApplicationUrl {
-                Dependencies.urlOpener.open(appUrl)
+                Task { await Dependencies.urlOpener.open(appUrl) }
             }
             let template = "%@(%@,\"%@\");"
             let js = String(format: template, callback, String(canOpenApplicationUrl), urlscheme)

--- a/Projects/Profile/Sources/Views/Screens/Legal/InformationScreen.swift
+++ b/Projects/Profile/Sources/Views/Screens/Legal/InformationScreen.swift
@@ -37,7 +37,7 @@ struct InformationScreen: View {
                 hCoreUIAssets.arrowNorthEast.view
             }
             .onTap {
-                Dependencies.urlOpener.open(item.url)
+                Task { await Dependencies.urlOpener.open(item.url) }
             }
         }
     }

--- a/Projects/Profile/Sources/Views/Screens/SettingsScreen/SettingsView.swift
+++ b/Projects/Profile/Sources/Views/Screens/SettingsScreen/SettingsView.swift
@@ -39,7 +39,7 @@ struct SettingsView: View {
                                     guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
                                         return
                                     }
-                                    DispatchQueue.main.async { Dependencies.urlOpener.open(settingsUrl) }
+                                    Task { await Dependencies.urlOpener.open(settingsUrl) }
                                 } else {
                                     NotificationCenter.default.post(name: .registerForPushNotifications, object: nil)
                                 }

--- a/Projects/SubmitClaimChat/Sources/Views/ClaimContactCard.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/ClaimContactCard.swift
@@ -66,7 +66,7 @@ struct ParnerButtonView: View {
                         overrideColorSchema ? .secondaryAlt : .primary,
                         content: .init(title: model.buttonText ?? ""),
                         {
-                            Dependencies.urlOpener.open(url)
+                            Task { await Dependencies.urlOpener.open(url) }
                         }
                     )
                     .colorScheme(overrideColorSchema ? .light : colorSchema)
@@ -80,7 +80,7 @@ struct ParnerButtonView: View {
                         getPhoneNumberButtonType(),
                         content: .init(title: L10n.submitClaimGlobalAssistanceCallLabel(phoneNumber)),
                         {
-                            Dependencies.urlOpener.open(url)
+                            Task { await Dependencies.urlOpener.open(url) }
                         }
                     )
                     .colorScheme(overrideColorSchema ? getPhoneNumberSchema() : colorSchema)

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimDeflectView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimDeflectView.swift
@@ -175,7 +175,7 @@ public struct SubmitClaimDeflectScreen: View {
                                     )
                                 ),
                                 {
-                                    Dependencies.urlOpener.open(url)
+                                    Task { await Dependencies.urlOpener.open(url) }
                                 }
                             )
                         }

--- a/Projects/SubmitClaimChat/Sources/Views/VoiceRecording/VoiceRecorder.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/VoiceRecording/VoiceRecorder.swift
@@ -126,7 +126,7 @@ public final class VoiceRecorder: ObservableObject {
             guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
                 throw VoiceRecorderError.permissionDenied
             }
-            Dependencies.urlOpener.open(settingsUrl)
+            await Dependencies.urlOpener.open(settingsUrl)
             throw VoiceRecorderError.permissionDenied
         case .granted:
             break

--- a/Projects/hCore/Sources/Helpers/UrlOpener.swift
+++ b/Projects/hCore/Sources/Helpers/UrlOpener.swift
@@ -3,8 +3,7 @@ import SwiftUI
 
 @MainActor
 public protocol URLOpener {
-    func open(_ url: URL)
-    func openWithAuthorizationCode(_ url: URL) async
+    func open(_ url: URL) async
 }
 
 extension Dependencies {

--- a/Projects/hCore/Sources/URL+RequiresAuthorization.swift
+++ b/Projects/hCore/Sources/URL+RequiresAuthorization.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension URL {
+    public var requiresAuthorization: Bool {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return false }
+        return components.queryItems?
+            .contains(where: { $0.name == "requiresAuthorization" && $0.value == "true" }) ?? false
+    }
+}

--- a/Projects/hCore/Sources/Viewable/WKWebView+OpenBankId.swift
+++ b/Projects/hCore/Sources/Viewable/WKWebView+OpenBankId.swift
@@ -11,7 +11,7 @@ class OpenBankIdHandler: NSObject, WKURLSchemeHandler {
         webView.stopLoading()
 
         if UIApplication.shared.canOpenURL(url) {
-            Dependencies.urlOpener.open(url)
+            Task { await Dependencies.urlOpener.open(url) }
         } else {
             let alert = UIAlertController(
                 title: L10n.trustlyMissingBankIdAppAlertTitle,

--- a/Projects/hCoreUI/Sources/MarkdownTextView.swift
+++ b/Projects/hCoreUI/Sources/MarkdownTextView.swift
@@ -186,7 +186,7 @@ class CustomTextView: UITextView, UITextViewDelegate {
         if emailMasking.isValid(text: URL.absoluteString) {
             let emailURL = "mailto:" + URL.absoluteString
             if let url = Foundation.URL(string: emailURL) {
-                Dependencies.urlOpener.open(url)
+                Task { await Dependencies.urlOpener.open(url) }
             }
         } else {
             ImpactGenerator.light()

--- a/Projects/hCoreUI/Sources/Views/FileSourcePickerView.swift
+++ b/Projects/hCoreUI/Sources/Views/FileSourcePickerView.swift
@@ -32,7 +32,7 @@ private struct FileSourcePickerView: ViewModifier {
                             guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
                                 return
                             }
-                            Dependencies.urlOpener.open(settingsUrl)
+                            await Dependencies.urlOpener.open(settingsUrl)
                         case .authorized, .limited:
                             showImagePicker = true
                         @unknown default:

--- a/Projects/hCoreUI/Sources/Views/UpdateAppScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/UpdateAppScreen.swift
@@ -40,7 +40,7 @@ public struct UpdateAppScreen: View {
                 .init(
                     buttonTitle: L10n.embarkUpdateAppButton,
                     buttonAction: {
-                        Dependencies.urlOpener.open(Environment.current.appStoreURL)
+                        Task { await Dependencies.urlOpener.open(Environment.current.appStoreURL) }
                         onSelected()
                     }
                 ),


### PR DESCRIPTION
## Summary
- Drop `openWithAuthorizationCode(_:)` from the `URLOpener` protocol. The auth-code flow is now triggered by inspecting the URL for `?requiresAuthorization=true` inside `DefaultURLOpener.open(_:)`, so callers no longer need to know whether a given URL requires auth.
- Add `URL.requiresAuthorization` extension in hCore, shared between `DefaultURLOpener` and `LoggedInNavigation.openUrl` (which now routes auth-requiring HTTPS URLs through `urlOpener` instead of `SFSafariViewController`).
- Adjust all call sites across the app to `await` the new async `open(_:)`.

## Test plan
- [ ] Tap a cross-sell item that opens an external auth URL → URL opens with `authorization_code` appended
- [ ] Tap a regular external link (legal, FAQ, settings, app store) → opens normally without auth code
- [ ] Trigger BankID flow → `bankid://` scheme still opens the BankID app
- [ ] Open device Settings from a permission-denied prompt (photos, mic, push, camera) → Settings app opens
- [ ] Open email client from OTP screen → mail app opens
- [ ] In-app help center deep links that go through `openUrl(url:)` still open in `SFSafariViewController` when no `requiresAuthorization=true` is present
- [ ] Run `tuist generate` after pulling to refresh the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)