### PR TITLE
Feat/x sell addons storefront changes

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
@@ -98,6 +98,8 @@ extension AddonCrossSell {
             description: data.description,
             buttonText: data.buttonTitle,
             deepLink: data.deepLink,
+            banner: data.banner,
+            benefits: data.benefits,
             imageUrl: URL(string: data.pillowImageLarge.src)
         )
     }

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
@@ -96,9 +96,9 @@ extension AddonCrossSell {
             id: data.id,
             title: data.title,
             description: data.description,
-            buttonText: data.buttonTitle,
+            buttonText: data.buttonText,
             deepLink: data.deepLink,
-            banner: data.banner,
+            bannerText: data.bannerText,
             benefits: data.benefits,
             imageUrl: URL(string: data.pillowImageLarge.src)
         )

--- a/Projects/CrossSell/Sources/Models/CrossSellModels.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellModels.swift
@@ -35,11 +35,12 @@ public enum RecommendedCrossSell: Codable, Equatable, Hashable, Sendable, Identi
         }
     }
 
-    /// Optional banner text; addon recommendations don't carry one, so callers fall back to a default.
+    /// Optional banner text. Both insurance and addon recommendations may omit it,
+    /// in which case callers fall back to a default.
     public var bannerText: String? {
         switch self {
         case let .insurance(insurance): return insurance.bannerText
-        case .addon: return nil
+        case let .addon(addon): return addon.banner
         }
     }
 }
@@ -50,6 +51,10 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
     let description: String
     let buttonText: String
     let deepLink: String
+    /// Optional banner text shown above the card; callers fall back to a default when nil.
+    let banner: String?
+    /// Benefit rows shown as a checkmark list; empty when there are none.
+    let benefits: [String]
     let imageUrl: URL?
 
     public init(
@@ -58,6 +63,8 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
         description: String,
         buttonText: String,
         deepLink: String,
+        banner: String? = nil,
+        benefits: [String] = [],
         imageUrl: URL?
     ) {
         self.id = id
@@ -65,6 +72,8 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
         self.description = description
         self.buttonText = buttonText
         self.deepLink = deepLink
+        self.banner = banner
+        self.benefits = benefits
         self.imageUrl = imageUrl
     }
 }

--- a/Projects/CrossSell/Sources/Models/CrossSellModels.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellModels.swift
@@ -40,7 +40,7 @@ public enum RecommendedCrossSell: Codable, Equatable, Hashable, Sendable, Identi
     public var bannerText: String? {
         switch self {
         case let .insurance(insurance): return insurance.bannerText
-        case let .addon(addon): return addon.banner
+        case let .addon(addon): return addon.bannerText
         }
     }
 }
@@ -52,7 +52,7 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
     let buttonText: String
     let deepLink: String
     /// Optional banner text shown above the card; callers fall back to a default when nil.
-    let banner: String?
+    let bannerText: String?
     /// Benefit rows shown as a checkmark list; empty when there are none.
     let benefits: [String]
     let imageUrl: URL?
@@ -63,7 +63,7 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
         description: String,
         buttonText: String,
         deepLink: String,
-        banner: String? = nil,
+        bannerText: String? = nil,
         benefits: [String] = [],
         imageUrl: URL?
     ) {
@@ -72,7 +72,7 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
         self.description = description
         self.buttonText = buttonText
         self.deepLink = deepLink
-        self.banner = banner
+        self.bannerText = bannerText
         self.benefits = benefits
         self.imageUrl = imageUrl
     }

--- a/Projects/CrossSell/Sources/View/Components/CrossSellBannerComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellBannerComponent.swift
@@ -3,7 +3,7 @@ import hCore
 import hCoreUI
 
 struct CrossSellBannerComponent: View {
-    let crossSell: CrossSell
+    let crossSell: RecommendedCrossSell
     var body: some View {
         HStack(alignment: .center, spacing: .padding8) {
             hCoreUIAssets.campaign.view

--- a/Projects/CrossSell/Sources/View/Components/CrossSellPillowComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellPillowComponent.swift
@@ -88,6 +88,22 @@ struct CrossSellPillowComponent: View {
                     .sectionContainerStyle(.transparent)
                 }
                 .multilineTextAlignment(.center)
+                if !addon.benefits.isEmpty {
+                    VStack(alignment: .leading, spacing: .padding10) {
+                        ForEach(Array(addon.benefits.enumerated()), id: \.offset) { _, benefit in
+                            HStack(alignment: .top, spacing: .padding12) {
+                                hCoreUIAssets.checkmark.view
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                                    .accessibilityHidden(true)
+                                hText(benefit)
+                                Spacer(minLength: 0)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, .padding24)
+                    .padding(.top, .padding16)
+                }
             }
         }
         .accessibilityElement(children: .combine)
@@ -133,10 +149,16 @@ struct CrossSellPillowComponent: View {
         crossSell: .addon(
             .init(
                 id: "id",
-                title: "title",
-                description: "description",
+                title: "Travel Insurance Plus",
+                description: "For a safer trip abroad",
                 buttonText: "button title",
                 deepLink: "https://link.dev.hedvigit.com/travel-addon",
+                banner: "Add extra safety when traveling",
+                benefits: [
+                    "Travel up to 60 days in a row",
+                    "Delayed bags and flights",
+                    "Applies to all co-insured",
+                ],
                 imageUrl: URL(
                     string:
                         "https://www.hedvig.com/_next/image?url=https%3A%2F%2Fassets.hedvig.com%2Ff%2F165473%2F832x832%2F0f43046205%2Fhedvig-pillows-pet.png&w=420&q=70&dpl=dpl_5cQgznxvLKNPt4ivb7hDrQ9Gw3di"

--- a/Projects/CrossSell/Sources/View/Components/CrossSellPillowComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellPillowComponent.swift
@@ -90,7 +90,7 @@ struct CrossSellPillowComponent: View {
                 .multilineTextAlignment(.center)
                 if !addon.benefits.isEmpty {
                     VStack(alignment: .leading, spacing: .padding10) {
-                        ForEach(Array(addon.benefits.enumerated()), id: \.offset) { _, benefit in
+                        ForEach(addon.benefits) { benefit in
                             HStack(alignment: .top, spacing: .padding12) {
                                 hCoreUIAssets.checkmark.view
                                     .resizable()
@@ -153,7 +153,7 @@ struct CrossSellPillowComponent: View {
                 description: "For a safer trip abroad",
                 buttonText: "button title",
                 deepLink: "https://link.dev.hedvigit.com/travel-addon",
-                banner: "Add extra safety when traveling",
+                bannerText: "Add extra safety when traveling",
                 benefits: [
                     "Travel up to 60 days in a row",
                     "Delayed bags and flights",

--- a/Projects/CrossSell/Sources/View/CrossSellingCentered.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingCentered.swift
@@ -13,23 +13,46 @@ public struct CrossSellingCentered: View {
 
     public var body: some View {
         hForm {
-            VStack(spacing: .padding48) {
+            VStack(spacing: 0) {
                 CrossSellBannerComponent(crossSell: crossSell)
                 CrossSellPillowComponent(crossSell: crossSell)
+                    .padding(.top, contentTopPadding)
                 VStack(spacing: .padding16) {
                     if case let .insurance(insurance) = crossSell {
                         CrossSellDiscountProgressComponent(crossSell: insurance)
                     }
                     CrossSellButtonComponent(crossSell: crossSell)
                 }
+                .padding(.top, buttonTopPadding)
             }
-            .padding(.bottom, .padding16)
+            .padding(.bottom, bottomPadding)
         }
         .task {
             logStartView(viewId, String(describing: CrossSellingCentered.self))
         }
         .onDisappear {
             logStopView(viewId)
+        }
+    }
+
+    private var contentTopPadding: CGFloat {
+        switch crossSell {
+        case .insurance: return .padding48
+        case .addon: return .padding32
+        }
+    }
+
+    private var buttonTopPadding: CGFloat {
+        switch crossSell {
+        case .insurance: return .padding48
+        case .addon: return .padding40
+        }
+    }
+
+    private var bottomPadding: CGFloat {
+        switch crossSell {
+        case .insurance: return .padding16
+        case .addon: return .padding32
         }
     }
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingCentered.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingCentered.swift
@@ -14,11 +14,7 @@ public struct CrossSellingCentered: View {
     public var body: some View {
         hForm {
             VStack(spacing: .padding48) {
-                if case let .insurance(insurance) = crossSell {
-                    CrossSellBannerComponent(crossSell: insurance)
-                } else {
-                    Spacing(height: 48)
-                }
+                CrossSellBannerComponent(crossSell: crossSell)
                 CrossSellPillowComponent(crossSell: crossSell)
                 VStack(spacing: .padding16) {
                     if case let .insurance(insurance) = crossSell {

--- a/Projects/CrossSell/Sources/View/CrossSellingModal.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingModal.swift
@@ -13,8 +13,8 @@ public struct CrossSellingModal: View {
 
     public var body: some View {
         VStack(spacing: 0) {
-            if case let .insurance(insurance) = crossSells.recommended {
-                CrossSellBannerComponent(crossSell: insurance)
+            if let recommended = crossSells.recommended {
+                CrossSellBannerComponent(crossSell: recommended)
             }
             hForm {
                 VStack(spacing: .padding48) {

--- a/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
+++ b/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
@@ -17,13 +17,14 @@ final class RecommendedCrossSellTests: XCTestCase {
         )
     }
 
-    private func makeAddon(id: String = "addon-id") -> AddonCrossSell {
+    private func makeAddon(id: String = "addon-id", banner: String? = nil) -> AddonCrossSell {
         .init(
             id: id,
             title: "title",
             description: "description",
             buttonText: "button text",
             deepLink: "https://link.dev.hedvigit.com/travel-addon",
+            banner: banner,
             imageUrl: nil
         )
     }
@@ -35,10 +36,17 @@ final class RecommendedCrossSellTests: XCTestCase {
         assert(recommended.bannerText == "Save 15%")
     }
 
-    func testAddonForwardsIdAndHasNoBannerText() {
-        let recommended: RecommendedCrossSell = .addon(makeAddon(id: "2"))
+    func testAddonForwardsIdAndBannerText() {
+        let recommended: RecommendedCrossSell = .addon(makeAddon(id: "2", banner: "Add extra safety when traveling"))
 
         assert(recommended.id == "2")
+        assert(recommended.bannerText == "Add extra safety when traveling")
+    }
+
+    func testAddonWithoutBannerHasNoBannerText() {
+        let recommended: RecommendedCrossSell = .addon(makeAddon(id: "3"))
+
+        assert(recommended.id == "3")
         assert(recommended.bannerText == nil)
     }
 

--- a/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
+++ b/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
@@ -17,14 +17,14 @@ final class RecommendedCrossSellTests: XCTestCase {
         )
     }
 
-    private func makeAddon(id: String = "addon-id", banner: String? = nil) -> AddonCrossSell {
+    private func makeAddon(id: String = "addon-id", bannerText: String? = nil) -> AddonCrossSell {
         .init(
             id: id,
             title: "title",
             description: "description",
             buttonText: "button text",
             deepLink: "https://link.dev.hedvigit.com/travel-addon",
-            banner: banner,
+            bannerText: bannerText,
             imageUrl: nil
         )
     }
@@ -37,7 +37,9 @@ final class RecommendedCrossSellTests: XCTestCase {
     }
 
     func testAddonForwardsIdAndBannerText() {
-        let recommended: RecommendedCrossSell = .addon(makeAddon(id: "2", banner: "Add extra safety when traveling"))
+        let recommended: RecommendedCrossSell = .addon(
+            makeAddon(id: "2", bannerText: "Add extra safety when traveling")
+        )
 
         assert(recommended.id == "2")
         assert(recommended.bannerText == "Add extra safety when traveling")

--- a/Projects/Home/Sources/Navigation/HomeNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HomeNavigation.swift
@@ -48,13 +48,14 @@ public class HomeNavigationViewModel: ObservableObject {
 
             Task { @MainActor in
                 let crossSells = try await crossSellInfo.getCrossSell()
-                // The centered presentation only supports an insurance cross-sell today;
-                // addon recommendations fall back to the detent until their UI is wired up.
-                if let recommendedInsurance = crossSells.recommended, crossSells.others.isEmpty {
-                    self?.navBarItems.isNewOfferPresentedCenter = recommendedInsurance
+                // A recommendation (insurance or addon) on its own uses the centered presentation;
+                // combined with other cross-sells it uses the modal, and other-sells-only uses the detent.
+                // A response with nothing to show does not present a sheet at all.
+                if let recommended = crossSells.recommended, crossSells.others.isEmpty {
+                    self?.navBarItems.isNewOfferPresentedCenter = recommended
                 } else if crossSells.recommended != nil {
                     self?.navBarItems.isNewOfferPresentedModal = crossSells
-                } else {
+                } else if !crossSells.others.isEmpty {
                     self?.navBarItems.isNewOfferPresentedDetent = crossSells
                 }
 

--- a/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
@@ -9,9 +9,9 @@ query CrossSell($input: CrossSellInput!) {
 			  id
 			  title
 			  description
-			  buttonText: buttonTitle
+			  buttonText
 			  deepLink
-			  bannerText: banner
+			  bannerText
 			  benefits
 			  pillowImageLarge {
 				  ...StoryblokImageAssetFragment

--- a/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
@@ -9,9 +9,9 @@ query CrossSell($input: CrossSellInput!) {
 			  id
 			  title
 			  description
-			  buttonTitle
+			  buttonText: buttonTitle
 			  deepLink
-			  banner
+			  bannerText: banner
 			  benefits
 			  pillowImageLarge {
 				  ...StoryblokImageAssetFragment

--- a/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
@@ -11,6 +11,8 @@ query CrossSell($input: CrossSellInput!) {
 			  description
 			  buttonTitle
 			  deepLink
+			  banner
+			  benefits
 			  pillowImageLarge {
 				  ...StoryblokImageAssetFragment
 			  }


### PR DESCRIPTION
Example insurance shown after a flow

p.s: I had to hard-code showing this because trying to finish the change tier flow was presenting an issue with the sheet auto-dismissing before allowing me to confirm the changes.

| not scrolled | scrolled |
| - | - |
| <img width="960" height="2079" alt="Screenshot 2026-07-08 at 3 53 28 PM" src="https://github.com/user-attachments/assets/bd9d95f7-99d0-4ce1-a22b-c9f5dde546f6" /> | <img width="960" height="2079" alt="Screenshot 2026-07-08 at 3 53 47 PM" src="https://github.com/user-attachments/assets/4552c7be-1cc1-402e-8a10-86ded55268cc" /> |
