### PR TITLE
Support the claim chat Information step (RND-2030)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
@@ -162,6 +162,23 @@ class ClaimIntentClientOctopus: ClaimIntentClient {
         }
     }
 
+    func claimIntentSubmitInformation(stepId: String) async throws -> ClaimIntentType? {
+        let input = OctopusGraphQL.ClaimIntentSubmitInformationInput(stepId: stepId)
+        let mutation = OctopusGraphQL.ClaimIntentSubmitInformationMutation(input: input)
+
+        do {
+            let data = try await octopus.client.mutation(mutation: mutation)
+            if let userError = data?.claimIntentSubmitInformation.userError, let message = userError.message {
+                throw ClaimIntentError.error(message: message)
+            }
+
+            let intent = data?.claimIntentSubmitInformation.intent
+            return try handleStep(intentFragment: intent?.fragments.claimIntentFragment)
+        } catch {
+            throw try logClaimIntentError(error)
+        }
+    }
+
     func claimIntentSkipStep(stepId: String) async throws -> ClaimIntentType? {
         let mutation = OctopusGraphQL.ClaimIntentSkipStepMutation(stepId: stepId)
 
@@ -355,6 +372,14 @@ extension ClaimIntentStepContent {
             )
         } else if let deflectMessage = fragment.asClaimIntentStepContentDeflectionMessage {
             self = .deflectMessage(model: .init(message: deflectMessage.message))
+        } else if let information = fragment.asClaimIntentStepContentInformation {
+            self = .information(
+                model: .init(
+                    notice: information.notice,
+                    severity: information.severity.asSeverity,
+                    buttonTitle: information.buttonTitle
+                )
+            )
         } else {
             throw ClaimIntentError.unknownStep
         }
@@ -422,6 +447,23 @@ extension GraphQLEnum<OctopusGraphQL.ClaimIntentStepContentSelectStyle> {
             }
         case .unknown:
             return .pill
+        }
+    }
+}
+
+extension GraphQLEnum<OctopusGraphQL.ClaimIntentStepContentInformationSeverity> {
+    // Unknown severities degrade to .info instead of failing the flow
+    public var asSeverity: ClaimIntentStepContentInformation.Severity {
+        switch self {
+        case .case(let severity):
+            switch severity {
+            case .info:
+                return .info
+            case .critical:
+                return .critical
+            }
+        case .unknown:
+            return .info
         }
     }
 }

--- a/Projects/App/Tests/ClaimIntentInformationMappingTests.swift
+++ b/Projects/App/Tests/ClaimIntentInformationMappingTests.swift
@@ -1,0 +1,48 @@
+import Apollo
+@preconcurrency import XCTest
+import hGraphQL
+
+@testable import SubmitClaimChat
+@testable import Ugglan
+
+@MainActor
+final class ClaimIntentInformationMappingTests: XCTestCase {
+    func testInformationFragmentMappingSuccess() async throws {
+        let fragment = try await OctopusGraphQL.ClaimIntentStepContentFragment(
+            data: Self.informationFragmentJSON(severity: "CRITICAL")
+        )
+
+        let content = try ClaimIntentStepContent(fragment: fragment)
+
+        guard case let .information(model) = content else {
+            XCTFail("Expected information content")
+            return
+        }
+        XCTAssertEqual(model.notice, "Seek emergency accommodation.")
+        XCTAssertEqual(model.severity, .critical)
+        XCTAssertEqual(model.buttonTitle, "I understand")
+    }
+
+    func testUnknownInformationSeverityDegradesToInfoSuccess() async throws {
+        let fragment = try await OctopusGraphQL.ClaimIntentStepContentFragment(
+            data: Self.informationFragmentJSON(severity: "SOMETHING_UNEXPECTED")
+        )
+
+        let content = try ClaimIntentStepContent(fragment: fragment)
+
+        guard case let .information(model) = content else {
+            XCTFail("Expected information content")
+            return
+        }
+        XCTAssertEqual(model.severity, .info)
+    }
+
+    private nonisolated static func informationFragmentJSON(severity: String) -> [String: Any] {
+        [
+            "__typename": "ClaimIntentStepContentInformation",
+            "notice": "Seek emergency accommodation.",
+            "severity": severity,
+            "buttonTitle": "I understand",
+        ]
+    }
+}

--- a/Projects/SubmitClaimChat/Sources/Models/ClaimIntentStepHandler.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/ClaimIntentStepHandler.swift
@@ -226,6 +226,8 @@ enum ClaimIntentStepHandlerFactory {
                 service: service,
                 mainHandler: mainHandler
             )
+        case .information:
+            handler = SubmitClaimInformationStep(claimIntent: claimIntent, service: service, mainHandler: mainHandler)
         }
         handler.alertVm = alertVm
         return handler

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -138,6 +138,24 @@ public enum ClaimIntentStepContent: Sendable {
     case singleSelect(model: ClaimIntentStepContentSelect)
     case deflect(model: Deflection)
     case deflectMessage(model: ClaimIntentStepContentDeflectionMessage)
+    case information(model: ClaimIntentStepContentInformation)
+}
+
+public struct ClaimIntentStepContentInformation: Sendable, Equatable {
+    let notice: String
+    let severity: Severity
+    let buttonTitle: String
+
+    public enum Severity: Sendable {
+        case info
+        case critical
+    }
+
+    public init(notice: String, severity: Severity, buttonTitle: String) {
+        self.notice = notice
+        self.severity = severity
+        self.buttonTitle = buttonTitle
+    }
 }
 
 public struct ClaimIntentStepContentDeflectionMessage: Sendable {

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimInformationStep.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimInformationStep.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import hCore
+
+final class SubmitClaimInformationStep: ClaimIntentStepHandler {
+    override var sender: SubmitClaimChatMessageSender { .hedvig }
+
+    let informationModel: ClaimIntentStepContentInformation
+
+    required init(
+        claimIntent: ClaimIntent,
+        service: ClaimIntentService,
+        mainHandler: @escaping (SubmitClaimEvent) -> Void
+    ) {
+        guard case .information(let model) = claimIntent.currentStep.content else {
+            fatalError("InformationStepHandler initialized with non-information content")
+        }
+        self.informationModel = model
+        super.init(claimIntent: claimIntent, service: service, mainHandler: mainHandler)
+        Task { [weak self] in
+            try await Task.sleep(seconds: ClaimChatConstants.Timing.shortDelay)
+            self?.state.showResults = true
+            if let self, self.informationModel.severity == .critical {
+                UIAccessibility.post(notification: .announcement, argument: self.informationModel.notice)
+            }
+        }
+    }
+
+    override func executeStep() async throws -> ClaimIntentType {
+        guard let result = try await service.claimIntentSubmitInformation(stepId: claimIntent.currentStep.id) else {
+            throw ClaimIntentError.invalidResponse
+        }
+        return result
+    }
+
+    override func accessibilityEditHint() -> String {
+        ""
+    }
+}

--- a/Projects/SubmitClaimChat/Sources/Service/DemoImplementation/ClaimIntentClientDemo.swift
+++ b/Projects/SubmitClaimChat/Sources/Service/DemoImplementation/ClaimIntentClientDemo.swift
@@ -224,6 +224,26 @@ public class ClaimIntentClientDemo: ClaimIntentClient {
         )
     }
 
+    public func claimIntentSubmitInformation(stepId: String) async throws -> ClaimIntentType? {
+        .intent(
+            model: .init(
+                currentStep: .init(
+                    content: .form(
+                        model: .init(
+                            fields: []
+                        )
+                    ),
+                    id: "id",
+                    text: ""
+                ),
+                id: "",
+                isSkippable: false,
+                isRegrettable: false,
+                progress: 0
+            )
+        )
+    }
+
     public func claimIntentSkipStep(stepId: String) async throws -> ClaimIntentType? {
         .intent(
             model: .init(

--- a/Projects/SubmitClaimChat/Sources/Service/Protocols/ClaimIntentClient.swift
+++ b/Projects/SubmitClaimChat/Sources/Service/Protocols/ClaimIntentClient.swift
@@ -18,6 +18,7 @@ public protocol ClaimIntentClient {
     func claimIntentSubmitSelect(stepId: String, selectedValue: String) async throws -> ClaimIntentType?
     func claimIntentSubmitSummary(stepId: String) async throws -> ClaimIntentType?
     func claimIntentSubmitTask(stepId: String) async throws -> ClaimIntentType?
+    func claimIntentSubmitInformation(stepId: String) async throws -> ClaimIntentType?
     func claimIntentSkipStep(stepId: String) async throws -> ClaimIntentType?
     func claimIntentRegretStep(stepId: String) async throws -> ClaimIntentType?
     func getNextStep(claimIntentId: String) async throws -> ClaimIntentType?
@@ -87,6 +88,11 @@ class ClaimIntentService {
 
     func claimIntentSubmitSelect(stepId: String, selectedValue: String) async throws -> ClaimIntentType? {
         let data = try await client.claimIntentSubmitSelect(stepId: stepId, selectedValue: selectedValue)
+        return data
+    }
+
+    func claimIntentSubmitInformation(stepId: String) async throws -> ClaimIntentType? {
+        let data = try await client.claimIntentSubmitInformation(stepId: stepId)
         return data
     }
 

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimInformationView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimInformationView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct SubmitClaimInformationResultView: View {
+    @ObservedObject var viewModel: SubmitClaimInformationStep
+
+    var body: some View {
+        InfoCard(
+            text: viewModel.informationModel.notice,
+            type: viewModel.informationModel.severity == .critical ? .error : .info
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityNotice)
+    }
+
+    // Convey the severity to VoiceOver users, since the card color alone doesn't
+    private var accessibilityNotice: String {
+        let model = viewModel.informationModel
+        return model.severity == .critical
+            ? L10n.terminationFlowImportantInformationTitle + ": " + model.notice
+            : model.notice
+    }
+}
+
+struct SubmitClaimInformationView: View {
+    @ObservedObject var viewModel: SubmitClaimInformationStep
+
+    var body: some View {
+        hSection {
+            hButton(
+                .large,
+                .primary,
+                content: .init(title: viewModel.informationModel.buttonTitle)
+            ) { [weak viewModel] in
+                viewModel?.submitResponse()
+            }
+            .hButtonIsLoading(viewModel.state.isLoading)
+            .accessibilityHint(L10n.generalContinueButton)
+        }
+        .sectionContainerStyle(.transparent)
+    }
+}
+
+#Preview{
+    let demo = ClaimIntentClientDemo()
+    Dependencies.shared.add(module: Module { () -> ClaimIntentClient in demo })
+    let criticalStep = SubmitClaimInformationStep(
+        claimIntent: .init(
+            currentStep: .init(
+                content: .information(
+                    model: .init(
+                        notice:
+                            "Since your home is currently uninhabitable and you have nowhere to stay, please contact "
+                            + "us immediately or seek temporary emergency accommodation.",
+                        severity: .critical,
+                        buttonTitle: "I understand"
+                    )
+                ),
+                id: "step-id-critical",
+                text: nil
+            ),
+            id: "intent-id",
+            isSkippable: false,
+            isRegrettable: false,
+            progress: 0.8
+        ),
+        service: ClaimIntentService()
+    ) { _ in
+    }
+    let infoStep = SubmitClaimInformationStep(
+        claimIntent: .init(
+            currentStep: .init(
+                content: .information(
+                    model: .init(
+                        notice: "Your claim will be handled within 24 hours.",
+                        severity: .info,
+                        buttonTitle: "I understand"
+                    )
+                ),
+                id: "step-id-info",
+                text: nil
+            ),
+            id: "intent-id",
+            isSkippable: false,
+            isRegrettable: false,
+            progress: 0.8
+        ),
+        service: ClaimIntentService()
+    ) { _ in
+    }
+    return VStack(spacing: .padding16) {
+        SubmitClaimInformationResultView(viewModel: criticalStep)
+        SubmitClaimInformationResultView(viewModel: infoStep)
+        SubmitClaimInformationView(viewModel: infoStep)
+    }
+    .padding(.horizontal, .padding16)
+}

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimInformationView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimInformationView.swift
@@ -42,7 +42,7 @@ struct SubmitClaimInformationView: View {
     }
 }
 
-#Preview{
+#Preview {
     let demo = ClaimIntentClientDemo()
     Dependencies.shared.add(module: Module { () -> ClaimIntentClient in demo })
     let criticalStep = SubmitClaimInformationStep(

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatMessageView.swift
@@ -66,7 +66,7 @@ struct SubmitClaimChatMessageView: View {
 extension ClaimIntentStepHandler {
     var maxWidth: CGFloat {
         switch claimIntent.currentStep.content {
-        case .summary, .singleSelect, .deflect, .deflectMessage, .audioRecording, .form:
+        case .summary, .singleSelect, .deflect, .deflectMessage, .audioRecording, .form, .information:
             return .infinity
         default:
             return 300
@@ -119,6 +119,8 @@ struct ClaimStepView: View {
                 SubmitClaimDeflectStepView(model: viewModel.deflectModel)
             } else if let viewModel = viewModel as? SubmitClaimDeflectMessageStep {
                 SubmitClaimDeflectMessageStepView(model: viewModel.deflectMessageModel)
+            } else if let viewModel = viewModel as? SubmitClaimInformationStep {
+                SubmitClaimInformationView(viewModel: viewModel)
             }
             if viewModel.isSkippable && !viewModel.state.disableSkip {
                 hSection {
@@ -164,6 +166,8 @@ struct ClaimStepResultView: View {
                 SubmitClaimFormResultView(viewModel: viewModel)
             } else if let viewModel = viewModel as? SubmitClaimTaskStep {
                 SubmitClaimTaskResultView(viewModel: viewModel)
+            } else if let viewModel = viewModel as? SubmitClaimInformationStep {
+                SubmitClaimInformationResultView(viewModel: viewModel)
             }
         }
         if viewModel.isRegrettable && viewModel.state.isStepExecuted {
@@ -179,21 +183,25 @@ struct ClaimStepResultView: View {
             .accessibilityHint(editHint)
             .accessibilityFocused($isEditButtonFocused)
             .onTapGesture { [weak viewModel] in
-                alertVm.alertModel = .init(
-                    type: .edit,
-                    message: L10n.claimChatEditExplanation,
-                    action: {
-                        Task {
-                            await viewModel?.regret()
-                        }
-                    },
-                    onClose: {
-                        isEditButtonFocused = true
-                    }
-                )
+                showEditAlert(for: viewModel)
             }
             .accessibilityAddTraits(.isButton)
         }
+    }
+
+    private func showEditAlert(for viewModel: ClaimIntentStepHandler?) {
+        alertVm.alertModel = .init(
+            type: .edit,
+            message: L10n.claimChatEditExplanation,
+            action: {
+                Task {
+                    await viewModel?.regret()
+                }
+            },
+            onClose: {
+                isEditButtonFocused = true
+            }
+        )
     }
 
     private var editHint: String {

--- a/Projects/SubmitClaimChat/Tests/MockData.swift
+++ b/Projects/SubmitClaimChat/Tests/MockData.swift
@@ -1,0 +1,112 @@
+import Foundation
+import hCore
+
+@testable import SubmitClaimChat
+
+@MainActor
+struct MockData {
+    @discardableResult
+    static func createMockClaimIntentClient(
+        submitInformation: @escaping SubmitInformation = { _ in
+            .intent(model: .informationStep(stepId: "next-step-id", severity: .info))
+        }
+    ) -> MockClaimIntentClient {
+        let client = MockClaimIntentClient(submitInformation: submitInformation)
+        Dependencies.shared.add(module: Module { () -> ClaimIntentClient in client })
+        return client
+    }
+}
+
+typealias SubmitInformation = @MainActor (String) async throws -> ClaimIntentType?
+
+@MainActor
+class MockClaimIntentClient: ClaimIntentClient {
+    var events = [Event]()
+    var submitInformation: SubmitInformation
+
+    enum Event: Equatable {
+        case claimIntentSubmitInformation(stepId: String)
+    }
+
+    init(submitInformation: @escaping SubmitInformation) {
+        self.submitInformation = submitInformation
+    }
+
+    func startClaimIntent(input: StartClaimInput) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitAudio(fileId: String?, freeText: String?, stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitFile(stepId: String, fileIds: [String]) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitForm(fields: [FieldValue], stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitSelect(stepId: String, selectedValue: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitSummary(stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitTask(stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentSubmitInformation(stepId: String) async throws -> ClaimIntentType? {
+        events.append(.claimIntentSubmitInformation(stepId: stepId))
+        return try await submitInformation(stepId)
+    }
+
+    func claimIntentSkipStep(stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentRegretStep(stepId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func getNextStep(claimIntentId: String) async throws -> ClaimIntentType? {
+        throw ClaimIntentError.invalidResponse
+    }
+
+    func claimIntentFormFieldSearch(
+        stepId: String,
+        fieldId: String,
+        query: String
+    ) async throws -> FormFieldSearchResult {
+        throw ClaimIntentError.invalidResponse
+    }
+}
+
+extension ClaimIntent {
+    static func informationStep(
+        stepId: String,
+        severity: ClaimIntentStepContentInformation.Severity
+    ) -> ClaimIntent {
+        .init(
+            currentStep: .init(
+                content: .information(
+                    model: .init(
+                        notice: "Seek emergency accommodation.",
+                        severity: severity,
+                        buttonTitle: "I understand"
+                    )
+                ),
+                id: stepId,
+                text: nil
+            ),
+            id: "intent-id",
+            isSkippable: false,
+            isRegrettable: false,
+            progress: 0.8
+        )
+    }
+}

--- a/Projects/SubmitClaimChat/Tests/SubmitClaimInformationStepTests.swift
+++ b/Projects/SubmitClaimChat/Tests/SubmitClaimInformationStepTests.swift
@@ -1,0 +1,75 @@
+@preconcurrency import XCTest
+import hCore
+
+@testable import SubmitClaimChat
+
+@MainActor
+final class SubmitClaimInformationStepTests: XCTestCase {
+    weak var sut: MockClaimIntentClient?
+
+    override func tearDown() async throws {
+        Dependencies.shared.remove(for: ClaimIntentClient.self)
+        try await Task.sleep(nanoseconds: 100)
+        XCTAssertNil(sut)
+    }
+
+    func testCreateHandlerForInformationContentSuccess() {
+        let mockClient = MockData.createMockClaimIntentClient()
+        sut = mockClient
+
+        let handler = ClaimIntentStepHandlerFactory.createHandler(
+            for: .informationStep(stepId: "step-id", severity: .critical),
+            service: ClaimIntentService(),
+            alertVm: SubmitClaimChatScreenAlertViewModel(),
+            mainHandler: { _ in }
+        )
+
+        let informationHandler = handler as? SubmitClaimInformationStep
+        XCTAssertNotNil(informationHandler)
+        XCTAssertEqual(informationHandler?.informationModel.severity, .critical)
+        XCTAssertEqual(informationHandler?.informationModel.buttonTitle, "I understand")
+    }
+
+    func testExecuteStepSubmitInformationSuccess() async throws {
+        let mockClient = MockData.createMockClaimIntentClient(submitInformation: { _ in
+            .intent(model: .informationStep(stepId: "next-step-id", severity: .info))
+        })
+        sut = mockClient
+
+        let handler = SubmitClaimInformationStep(
+            claimIntent: .informationStep(stepId: "step-id", severity: .info),
+            service: ClaimIntentService(),
+            mainHandler: { _ in }
+        )
+
+        let result = try await handler.executeStep()
+
+        XCTAssertEqual(mockClient.events, [.claimIntentSubmitInformation(stepId: "step-id")])
+        guard case let .intent(model) = result else {
+            XCTFail("Expected the next intent to be returned")
+            return
+        }
+        XCTAssertEqual(model.currentStep.id, "next-step-id")
+    }
+
+    func testExecuteStepSubmitInformationFailure() async {
+        let mockClient = MockData.createMockClaimIntentClient(submitInformation: { _ in
+            throw ClaimIntentError.error(message: "error")
+        })
+        sut = mockClient
+
+        let handler = SubmitClaimInformationStep(
+            claimIntent: .informationStep(stepId: "step-id", severity: .critical),
+            service: ClaimIntentService(),
+            mainHandler: { _ in }
+        )
+
+        do {
+            _ = try await handler.executeStep()
+            XCTFail("Expected executeStep to throw")
+        } catch {
+            XCTAssertTrue(error is ClaimIntentError)
+        }
+        XCTAssertEqual(mockClient.events, [.claimIntentSubmitInformation(stepId: "step-id")])
+    }
+}

--- a/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
@@ -92,6 +92,11 @@ fragment ClaimIntentStepContentFragment on ClaimIntentStepContent {
     ... on ClaimIntentStepContentDeflectionMessage {
         message
     }
+    ... on ClaimIntentStepContentInformation {
+        notice
+        severity
+        buttonTitle
+    }
 }
 
 fragment DeflectFragment on ClaimIntentStepContentDeflection {

--- a/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntentSubmitInformation.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntentSubmitInformation.graphql
@@ -1,0 +1,10 @@
+mutation ClaimIntentSubmitInformation($input: ClaimIntentSubmitInformationInput!) {
+  claimIntentSubmitInformation(input: $input) {
+    intent {
+        ...ClaimIntentFragment
+    }
+    userError {
+      message
+    }
+  }
+}


### PR DESCRIPTION
## Why

The agent-driven claim flow in claims-service can return a `ClaimIntentStepContentInformation` step, but iOS had no fragment selection or model case for it, so the step mapping failed and the member dead-ended. This exact gap broke Android fire-claim submissions on staging, so this mirrors the Android fix (HedvigInsurance/android#3017).

## What

- Add `ClaimIntentStepContentInformation` (`notice`, `severity`, `buttonTitle`) to `ClaimIntentStepContentFragment` and a new `ClaimIntentSubmitInformation` mutation.
- Add a `.information` case to `ClaimIntentStepContent` with a model struct; unknown severities degrade to `INFO` instead of failing the flow.
- Add `claimIntentSubmitInformation(stepId:)` to `ClaimIntentClient` (protocol, Octopus, and demo implementations) plus a `SubmitClaimInformationStep` handler.
- Render the notice as an `InfoCard` (red for `CRITICAL`, blue for `INFO`) with a server-driven acknowledge button that submits and advances the flow; critical notices are announced to VoiceOver.
- Tests for the step handler and the fragment→model mapping (including the unknown-severity degrade).
