### PR TITLE
Render structured claim summary answers (RND-2030)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
@@ -336,9 +336,10 @@ extension ClaimIntentStepContent {
                             return .init(
                                 title: answer.title,
                                 value: .files(
-                                    files.files.map {
-                                        .init(
-                                            url: URL(string: $0.url)!,
+                                    files.files.compactMap {
+                                        guard let url = URL(string: $0.url) else { return nil }
+                                        return .init(
+                                            url: url,
                                             contentType: .findBy(mimeType: $0.contentType),
                                             fileName: $0.fileName
                                         )

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
@@ -318,7 +318,37 @@ extension ClaimIntentStepContent {
                     items: summary.items.map {
                         .init(title: $0.title, value: $0.value)
                     },
-                    freeTexts: summary.freeTexts
+                    freeTexts: summary.freeTexts,
+                    keyDetails: summary.keyDetails.map {
+                        .init(title: $0.title, value: $0.value)
+                    },
+                    answers: summary.answers.compactMap { answer in
+                        let value = answer.value
+                        if let text = value.asClaimIntentStepContentSummaryAnswerText {
+                            return .init(title: answer.title, value: .text(text.text))
+                        } else if let audio = value.asClaimIntentStepContentSummaryAnswerAudio {
+                            guard let url = URL(string: audio.url) else { return nil }
+                            return .init(
+                                title: answer.title,
+                                value: .audio(url: url, transcript: audio.transcript)
+                            )
+                        } else if let files = value.asClaimIntentStepContentSummaryAnswerFiles {
+                            return .init(
+                                title: answer.title,
+                                value: .files(
+                                    files.files.map {
+                                        .init(
+                                            url: URL(string: $0.url)!,
+                                            contentType: .findBy(mimeType: $0.contentType),
+                                            fileName: $0.fileName
+                                        )
+                                    }
+                                )
+                            )
+                        } else {
+                            return nil
+                        }
+                    }
                 )
             )
         } else if let singleStep = fragment.asClaimIntentStepContentSelect {

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
@@ -324,19 +324,19 @@ extension ClaimIntentStepContent {
                     },
                     answers: summary.answers.compactMap { answer in
                         let value = answer.value
-                        if let text = value.asClaimIntentStepContentSummaryAnswerText {
-                            return .init(title: answer.title, value: .text(text.text))
-                        } else if let audio = value.asClaimIntentStepContentSummaryAnswerAudio {
-                            guard let url = URL(string: audio.url) else { return nil }
+                        if let answerText = value.asClaimIntentStepContentSummaryAnswerText {
+                            return .init(title: answer.title, value: .text(answerText.text))
+                        } else if let answerAudio = value.asClaimIntentStepContentSummaryAnswerAudio {
+                            guard let url = URL(string: answerAudio.url) else { return nil }
                             return .init(
                                 title: answer.title,
-                                value: .audio(url: url, transcript: audio.transcript)
+                                value: .audio(url: url, transcript: answerAudio.transcript)
                             )
-                        } else if let files = value.asClaimIntentStepContentSummaryAnswerFiles {
+                        } else if let answerFiles = value.asClaimIntentStepContentSummaryAnswerFiles {
                             return .init(
                                 title: answer.title,
                                 value: .files(
-                                    files.files.compactMap {
+                                    answerFiles.files.compactMap {
                                         guard let url = URL(string: $0.url) else { return nil }
                                         return .init(
                                             url: url,

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -304,17 +304,23 @@ public struct ClaimIntentStepContentSummary: Sendable, Identifiable, Equatable {
     let fileUploads: [ClaimIntentStepContentSummaryFileUpload]
     let items: [ClaimIntentStepContentSummaryItem]
     let freeTexts: [String]
+    let keyDetails: [ClaimIntentStepContentSummaryItem]
+    let answers: [ClaimIntentStepContentSummaryAnswer]
 
     public init(
         audioRecordings: [ClaimIntentStepContentSummaryAudioRecording],
         fileUploads: [ClaimIntentStepContentSummaryFileUpload],
         items: [ClaimIntentStepContentSummaryItem],
-        freeTexts: [String]
+        freeTexts: [String],
+        keyDetails: [ClaimIntentStepContentSummaryItem] = [],
+        answers: [ClaimIntentStepContentSummaryAnswer] = []
     ) {
         self.audioRecordings = audioRecordings
         self.fileUploads = fileUploads
         self.items = items
         self.freeTexts = freeTexts
+        self.keyDetails = keyDetails
+        self.answers = answers
     }
 
     public struct ClaimIntentStepContentSummaryAudioRecording: Sendable {
@@ -344,6 +350,23 @@ public struct ClaimIntentStepContentSummary: Sendable, Identifiable, Equatable {
         public init(title: String, value: String) {
             self.title = title
             self.value = value
+        }
+    }
+
+    public struct ClaimIntentStepContentSummaryAnswer: Sendable, Identifiable {
+        public let id = UUID()
+        let title: String
+        let value: Value
+
+        public init(title: String, value: Value) {
+            self.title = title
+            self.value = value
+        }
+
+        public enum Value: Sendable {
+            case text(String)
+            case audio(url: URL, transcript: String?)
+            case files([ClaimIntentStepContentSummaryFileUpload])
         }
     }
 }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -20,8 +20,10 @@ struct SubmitClaimSummaryView: View {
                     alignment: .leading,
                     spacing: .padding24
                 ) {
-                    claimDetailsView
-                    showAllAnswersView
+                    VStack(alignment: .leading, spacing: .padding16) {
+                        claimDetailsView
+                        showAllAnswersView
+                    }
                     audioRecordingView
                     uploadedFilesView
                 }
@@ -73,12 +75,13 @@ struct SubmitClaimSummaryView: View {
         if !viewModel.summaryModel.answers.isEmpty {
             hButton(
                 .medium,
-                .secondary,
+                .ghost,
                 content: .init(title: L10n.claimChatShowAllAnswersButton)
             ) {
                 showAllAnswers = true
             }
             .hButtonTakeFullWidth(true)
+            .hButtonWithBorder
         }
     }
 
@@ -119,11 +122,11 @@ struct SubmitClaimSummaryAnswersView: View {
         hForm {
             hSection {
                 VStack(alignment: .leading, spacing: .padding24) {
-                    hText(L10n.ClaimStatus.ClaimDetails.title, style: .heading2)
+                    hText(L10n.ClaimStatus.ClaimDetails.title)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .accessibilityAddTraits(.isHeader)
                     ForEach(answers) { answer in
-                        VStack(alignment: .leading, spacing: .padding8) {
+                        VStack(alignment: .leading, spacing: .padding4) {
                             hText(answer.title)
                                 .accessibilityAddTraits(.isHeader)
                             SummaryAnswerValueView(value: answer.value)
@@ -132,7 +135,9 @@ struct SubmitClaimSummaryAnswersView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
+                .padding(.top, .padding16)
             }
+            .sectionContainerStyle(.transparent)
         }
         .hFormContentPosition(.top)
     }
@@ -146,17 +151,11 @@ private struct SummaryAnswerValueView: View {
         case let .text(text):
             hText(text)
                 .frame(maxWidth: .infinity, alignment: .leading)
-        case let .audio(url, transcript):
-            VStack(alignment: .leading, spacing: .padding8) {
-                hSection {
-                    TrackPlayerView(audioPlayer: AudioPlayer(url: url))
-                }
-                .hWithoutHorizontalPadding([.section])
-                if let transcript, !transcript.isEmpty {
-                    hText(transcript)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+        case let .audio(url, _):
+            hSection {
+                TrackPlayerView(audioPlayer: AudioPlayer(url: url))
             }
+            .hWithoutHorizontalPadding([.section])
         case let .files(files):
             SummaryAnswerFilesView(files: files)
         }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -42,7 +42,9 @@ struct SubmitClaimSummaryView: View {
             presented: $showAllAnswers,
             presentationStyle: .detent(style: [.large])
         ) {
-            SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers)
+            SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers) {
+                showAllAnswers = false
+            }
         }
     }
 
@@ -117,6 +119,7 @@ struct SubmitClaimSummaryView: View {
 
 struct SubmitClaimSummaryAnswersView: View {
     let answers: [ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryAnswer]
+    let onClose: () -> Void
 
     var body: some View {
         hForm {
@@ -135,11 +138,21 @@ struct SubmitClaimSummaryAnswersView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
-                .padding(.top, .padding16)
+                .padding(.top, .padding32)
             }
             .sectionContainerStyle(.transparent)
         }
         .hFormContentPosition(.top)
+        .hFormAttachToBottom {
+            hSection {
+                hButton(
+                    .large,
+                    .secondary,
+                    content: .init(title: L10n.generalCloseButton)
+                ) { onClose() }
+            }
+            .sectionContainerStyle(.transparent)
+        }
     }
 }
 

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -5,6 +5,13 @@ import hCoreUI
 
 struct SubmitClaimSummaryView: View {
     @ObservedObject var viewModel: SubmitClaimSummaryStep
+    @State private var showAllAnswers = false
+
+    private var claimDetails: [ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryItem] {
+        viewModel.summaryModel.keyDetails.isEmpty
+            ? viewModel.summaryModel.items
+            : viewModel.summaryModel.keyDetails
+    }
 
     var body: some View {
         hSection {
@@ -13,9 +20,9 @@ struct SubmitClaimSummaryView: View {
                     alignment: .leading,
                     spacing: .padding24
                 ) {
-                    itemView
+                    claimDetailsView
+                    showAllAnswersView
                     audioRecordingView
-                    freeTextsView
                     uploadedFilesView
                 }
             }
@@ -29,16 +36,22 @@ struct SubmitClaimSummaryView: View {
                 .inset(by: 0.5)
                 .stroke(hBorderColor.primary, lineWidth: 1)
         }
+        .detent(
+            presented: $showAllAnswers,
+            presentationStyle: .detent(style: [.large])
+        ) {
+            SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers)
+        }
     }
 
     @ViewBuilder
-    var itemView: some View {
-        if viewModel.summaryModel.items.count != 0 {
+    var claimDetailsView: some View {
+        if !claimDetails.isEmpty {
             VStack(alignment: .leading, spacing: .padding8) {
                 hText(L10n.ClaimStatus.ClaimDetails.title)
                     .accessibilityAddTraits(.isHeader)
                 VStack {
-                    ForEach(viewModel.summaryModel.items, id: \.title) { item in
+                    ForEach(claimDetails, id: \.title) { item in
                         HStack(alignment: .top) {
                             hText(item.title)
                                 .multilineTextAlignment(.leading)
@@ -52,6 +65,20 @@ struct SubmitClaimSummaryView: View {
                     }
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    var showAllAnswersView: some View {
+        if !viewModel.summaryModel.answers.isEmpty {
+            hButton(
+                .medium,
+                .secondary,
+                content: .init(title: L10n.claimChatShowAllAnswersButton)
+            ) {
+                showAllAnswers = true
+            }
+            .hButtonTakeFullWidth(true)
         }
     }
 
@@ -83,25 +110,82 @@ struct SubmitClaimSummaryView: View {
             }
         }
     }
+}
 
-    @ViewBuilder
-    var freeTextsView: some View {
-        if !viewModel.summaryModel.freeTexts.isEmpty {
-            VStack(alignment: .leading, spacing: .padding8) {
-                hText(L10n.claimChatOtherTitle)
-                    .accessibilityAddTraits(.isHeader)
-                ForEach(viewModel.summaryModel.freeTexts, id: \.self) { freeText in
-                    HStack {
-                        hText(freeText)
-                        Spacer()
+struct SubmitClaimSummaryAnswersView: View {
+    let answers: [ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryAnswer]
+
+    var body: some View {
+        hForm {
+            hSection {
+                VStack(alignment: .leading, spacing: .padding24) {
+                    hText(L10n.ClaimStatus.ClaimDetails.title, style: .heading2)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .accessibilityAddTraits(.isHeader)
+                    ForEach(answers) { answer in
+                        VStack(alignment: .leading, spacing: .padding8) {
+                            hText(answer.title)
+                                .accessibilityAddTraits(.isHeader)
+                            SummaryAnswerValueView(value: answer.value)
+                                .foregroundColor(hTextColor.Opaque.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .hPillStyle(color: .grey, colorLevel: .two, withBorder: false)
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel(freeText)
                 }
-                .foregroundColor(hTextColor.Opaque.secondary)
             }
         }
+        .hFormContentPosition(.top)
+    }
+}
+
+private struct SummaryAnswerValueView: View {
+    let value: ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryAnswer.Value
+
+    var body: some View {
+        switch value {
+        case let .text(text):
+            hText(text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case let .audio(url, transcript):
+            VStack(alignment: .leading, spacing: .padding8) {
+                hSection {
+                    TrackPlayerView(audioPlayer: AudioPlayer(url: url))
+                }
+                .hWithoutHorizontalPadding([.section])
+                if let transcript, !transcript.isEmpty {
+                    hText(transcript)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        case let .files(files):
+            SummaryAnswerFilesView(files: files)
+        }
+    }
+}
+
+private struct SummaryAnswerFilesView: View {
+    @StateObject private var vm: FileGridViewModel
+
+    init(files: [ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryFileUpload]) {
+        _vm = StateObject(
+            wrappedValue: FileGridViewModel(
+                files: files.map {
+                    .init(
+                        id: $0.url.absoluteString,
+                        size: 0,
+                        mimeType: $0.contentType,
+                        name: $0.fileName,
+                        source: .url(url: $0.url, mimeType: $0.contentType)
+                    )
+                },
+                options: []
+            )
+        )
+    }
+
+    var body: some View {
+        FilesGridView(vm: vm)
+            .hFileGridAlignment(alignment: .leading)
     }
 }
 
@@ -135,20 +219,32 @@ struct SubmitClaimSummaryBottomView: View {
                             .init(title: "Date", value: "2025-11-25"),
                             .init(title: "Location", value: "At home"),
                             .init(title: "Type", value: "Phone"),
-                            .init(title: "Brand", value: "iPhone"),
-                            .init(title: "Model", value: "iPhone 14 Pro"),
-                            .init(title: "Purchase date", value: "2023-11-26"),
                         ],
-                        freeTexts: [
-                            """
-                            It is a long 
-                            text
-                            that goes in more lines
-                            and should take full width
-                            """,
-                            """
-                            One long text that should be shown nicely in the view and take full width of the screen
-                            """,
+                        freeTexts: [],
+                        keyDetails: [
+                            .init(title: "Type of claim", value: "Theft"),
+                            .init(title: "Date", value: "2025-11-25"),
+                            .init(title: "Location", value: "Stockholm"),
+                        ],
+                        answers: [
+                            .init(title: "Was the bike locked?", value: .text("No")),
+                            .init(
+                                title: "Describe what happened",
+                                value: .audio(
+                                    url: URL(string: "https://hedvig.com")!,
+                                    transcript: "I parked my bike and when I came back it was gone."
+                                )
+                            ),
+                            .init(
+                                title: "Any receipts?",
+                                value: .files([
+                                    .init(
+                                        url: URL(string: "https://hedvig.com/receipt.pdf")!,
+                                        contentType: .PDF,
+                                        fileName: "receipt.pdf"
+                                    )
+                                ])
+                            ),
                         ]
                     )
                 ),

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -76,7 +76,7 @@ struct SubmitClaimSummaryView: View {
             hButton(
                 .medium,
                 .ghost,
-                content: .init(title: L10n.claimChatShowAllAnswersButton)
+                content: .init(title: L10n.ClaimStatus.showAllAnswers)
             ) {
                 showAllAnswers = true
             }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -40,7 +40,7 @@ struct SubmitClaimSummaryView: View {
         }
         .detent(
             presented: $showAllAnswers,
-            presentationStyle: .detent(style: [.large])
+            presentationStyle: .detent(style: [.height])
         ) {
             SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers) {
                 showAllAnswers = false
@@ -139,6 +139,7 @@ struct SubmitClaimSummaryAnswersView: View {
                     }
                 }
                 .padding(.top, .padding32)
+                .padding(.bottom, .padding32)
             }
             .sectionContainerStyle(.transparent)
         }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -42,9 +42,9 @@ struct SubmitClaimSummaryView: View {
             presented: $showAllAnswers,
             presentationStyle: .detent(style: [.height])
         ) {
-            SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers) {
-                showAllAnswers = false
-            }
+            SubmitClaimSummaryAnswersView(answers: viewModel.summaryModel.answers)
+                .navigationTitle(L10n.ClaimStatus.ClaimDetails.title)
+                .embededInNavigation(tracking: String(describing: SubmitClaimSummaryAnswersView.self))
         }
     }
 
@@ -118,16 +118,13 @@ struct SubmitClaimSummaryView: View {
 }
 
 struct SubmitClaimSummaryAnswersView: View {
+    @Environment(\.dismiss) private var dismiss
     let answers: [ClaimIntentStepContentSummary.ClaimIntentStepContentSummaryAnswer]
-    let onClose: () -> Void
 
     var body: some View {
         hForm {
             hSection {
                 VStack(alignment: .leading, spacing: .padding24) {
-                    hText(L10n.ClaimStatus.ClaimDetails.title)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .accessibilityAddTraits(.isHeader)
                     ForEach(answers) { answer in
                         VStack(alignment: .leading, spacing: .padding4) {
                             hText(answer.title)
@@ -138,19 +135,18 @@ struct SubmitClaimSummaryAnswersView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
-                .padding(.top, .padding32)
                 .padding(.bottom, .padding32)
             }
             .sectionContainerStyle(.transparent)
         }
-        .hFormContentPosition(.top)
+        .hFormContentPosition(.compact)
         .hFormAttachToBottom {
             hSection {
                 hButton(
                     .large,
                     .secondary,
                     content: .init(title: L10n.generalCloseButton)
-                ) { onClose() }
+                ) { dismiss() }
             }
             .sectionContainerStyle(.transparent)
         }
@@ -217,7 +213,7 @@ struct SubmitClaimSummaryBottomView: View {
     }
 }
 
-#Preview {
+#Preview{
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
     let vm = SubmitClaimSummaryStep(
         claimIntent: .init(

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimSummaryView.swift
@@ -213,7 +213,7 @@ struct SubmitClaimSummaryBottomView: View {
     }
 }
 
-#Preview{
+#Preview {
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
     let vm = SubmitClaimSummaryStep(
         claimIntent: .init(

--- a/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
+++ b/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
@@ -139,7 +139,7 @@ final class SubmitClaimSummaryViewSnapshotTests: XCTestCase {
     func testShowAllAnswersContent() throws {
         registerDependencies()
         let url = try render(
-            SubmitClaimSummaryAnswersView(answers: summaryModel.answers),
+            SubmitClaimSummaryAnswersView(answers: summaryModel.answers, onClose: {}),
             name: "show_all_answers_content",
             height: 720
         )

--- a/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
+++ b/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
@@ -102,16 +102,17 @@ final class SubmitClaimSummaryViewSnapshotTests: XCTestCase {
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = 2
-        let image = UIGraphicsImageRenderer(bounds: bounds, format: format).image { _ in
-            hostingController.view.drawHierarchy(in: bounds, afterScreenUpdates: true)
-        }
+        let image = UIGraphicsImageRenderer(bounds: bounds, format: format)
+            .image { _ in
+                hostingController.view.drawHierarchy(in: bounds, afterScreenUpdates: true)
+            }
         let data = try XCTUnwrap(image.pngData(), "PNG encoding failed for \(name)")
 
         let dir =
             ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"]
             .map { URL(fileURLWithPath: $0) }
             ?? URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingPathComponent("SubmitClaimSummarySnapshots", isDirectory: true)
+            .appendingPathComponent("SubmitClaimSummarySnapshots", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent("\(name).png")
         try data.write(to: url)

--- a/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
+++ b/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import XCTest
+import hCore
+import hCoreUI
+
+@testable import SubmitClaimChat
+
+/// Renders the redesigned claim summary surfaces to PNGs so the collapsed
+/// "Claim details" card, a text answer and an inline audio player can be
+/// visually verified.
+///
+/// NOTE: the repo's `SnapshotTesting`/`assertSnapshot` helpers are vended by the
+/// `HedvigShared` (umbrella) package. In the current binary-umbrella
+/// configuration that module is not importable from a `.tests` target (the
+/// existing `*/Testing` snapshot folders are not wired into any Tuist target),
+/// so this uses SwiftUI `ImageRenderer` directly instead.
+final class SubmitClaimSummaryViewSnapshotTests: XCTestCase {
+    @MainActor
+    private func registerDependencies() {
+        Dependencies.shared.add(module: Module { () -> DateService in DateService() })
+    }
+
+    private var summaryModel: ClaimIntentStepContentSummary {
+        .init(
+            audioRecordings: [
+                .init(url: URL(string: "https://hedvig.com/recording.m4a")!)
+            ],
+            fileUploads: [],
+            items: [
+                .init(title: "Date", value: "2025-11-25"),
+                .init(title: "Location", value: "At home"),
+            ],
+            freeTexts: [],
+            keyDetails: [
+                .init(title: "Type of claim", value: "Theft"),
+                .init(title: "Date", value: "2025-11-25"),
+                .init(title: "Location", value: "Stockholm"),
+            ],
+            answers: [
+                .init(title: "Was the bike locked?", value: .text("No")),
+                .init(
+                    title: "Where did it happen?",
+                    value: .text("Outside the central station in Stockholm")
+                ),
+                .init(
+                    title: "Describe what happened",
+                    value: .audio(
+                        url: URL(string: "https://hedvig.com/recording.m4a")!,
+                        transcript: "I parked my bike and when I came back it was gone."
+                    )
+                ),
+                .init(
+                    title: "Any receipts?",
+                    value: .files([
+                        .init(
+                            url: URL(string: "https://hedvig.com/receipt.pdf")!,
+                            contentType: .PDF,
+                            fileName: "receipt.pdf"
+                        )
+                    ])
+                ),
+            ]
+        )
+    }
+
+    @MainActor
+    private func makeStep() -> SubmitClaimSummaryStep {
+        SubmitClaimSummaryStep(
+            claimIntent: .init(
+                currentStep: .init(
+                    content: .summary(model: summaryModel),
+                    id: "id1",
+                    text: "text"
+                ),
+                id: "claimIntentId",
+                isSkippable: false,
+                isRegrettable: false,
+                progress: 0
+            ),
+            service: .init(),
+            mainHandler: { _ in }
+        )
+    }
+
+    @MainActor
+    private func render<V: View>(_ view: V, name: String, height: CGFloat) throws -> URL {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: height)
+        let hostingController = UIHostingController(
+            rootView:
+                view
+                .frame(width: bounds.width, height: bounds.height, alignment: .top)
+                .background(Color.white)
+                .environment(\.colorScheme, .light)
+        )
+        let window = UIWindow(frame: bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        hostingController.view.frame = bounds
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 2
+        let image = UIGraphicsImageRenderer(bounds: bounds, format: format).image { _ in
+            hostingController.view.drawHierarchy(in: bounds, afterScreenUpdates: true)
+        }
+        let data = try XCTUnwrap(image.pngData(), "PNG encoding failed for \(name)")
+
+        let dir =
+            ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"]
+            .map { URL(fileURLWithPath: $0) }
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("SubmitClaimSummarySnapshots", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("\(name).png")
+        try data.write(to: url)
+        print("SNAPSHOT_PNG \(name) -> \(url.path)")
+        return url
+    }
+
+    @MainActor
+    func testCollapsedClaimDetailsCard() throws {
+        registerDependencies()
+        let step = makeStep()
+        let url = try render(
+            hForm {
+                hSection {
+                    SubmitClaimSummaryView(viewModel: step)
+                }
+            },
+            name: "collapsed_claim_details_card",
+            height: 640
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    func testShowAllAnswersContent() throws {
+        registerDependencies()
+        let url = try render(
+            SubmitClaimSummaryAnswersView(answers: summaryModel.answers),
+            name: "show_all_answers_content",
+            height: 720
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
+++ b/Projects/SubmitClaimChat/Tests/SubmitClaimSummaryViewSnapshotTests.swift
@@ -140,7 +140,9 @@ final class SubmitClaimSummaryViewSnapshotTests: XCTestCase {
     func testShowAllAnswersContent() throws {
         registerDependencies()
         let url = try render(
-            SubmitClaimSummaryAnswersView(answers: summaryModel.answers, onClose: {}),
+            SubmitClaimSummaryAnswersView(answers: summaryModel.answers)
+                .navigationTitle(L10n.ClaimStatus.ClaimDetails.title)
+                .embededInNavigation(tracking: String(describing: SubmitClaimSummaryAnswersView.self)),
             name: "show_all_answers_content",
             height: 720
         )

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -267,6 +267,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_PHONE_NUMBER_MISSING" = "Please provide phone number in the case we need to contact you";
 "CLAIM_CHAT_PHONE_NUMBER_UPDATE" = "Make sure we have right phone number in the case we need to contact you";
 "CLAIM_CHAT_RECORDING_TITLE" = "Recording";
+"CLAIM_CHAT_SHOW_ALL_ANSWERS_BUTTON" = "Show all answers";
 "CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT" = "If you don't remember the purchase date, you don't need to fill in anything.";
 "CLAIM_CHAT_SKIPPED_STEP" = "Skipped";
 "CLAIM_CHAT_SKIP_STEP" = "Skip";

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -267,7 +267,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_PHONE_NUMBER_MISSING" = "Please provide phone number in the case we need to contact you";
 "CLAIM_CHAT_PHONE_NUMBER_UPDATE" = "Make sure we have right phone number in the case we need to contact you";
 "CLAIM_CHAT_RECORDING_TITLE" = "Recording";
-"CLAIM_CHAT_SHOW_ALL_ANSWERS_BUTTON" = "Show all answers";
+"claim_status.show_all_answers" = "Show all answers";
 "CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT" = "If you don't remember the purchase date, you don't need to fill in anything.";
 "CLAIM_CHAT_SKIPPED_STEP" = "Skipped";
 "CLAIM_CHAT_SKIP_STEP" = "Skip";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -267,6 +267,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_PHONE_NUMBER_MISSING" = "Vänligen ange telefonnummer ifall vi behöver kontakta dig";
 "CLAIM_CHAT_PHONE_NUMBER_UPDATE" = "Se till att vi har rätt telefonnummer ifall vi behöver kontakta dig";
 "CLAIM_CHAT_RECORDING_TITLE" = "Inspelning";
+"CLAIM_CHAT_SHOW_ALL_ANSWERS_BUTTON" = "Visa alla svar";
 "CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT" = "Om du inte minns inköpsdatum behöver du inte fylla i något.";
 "CLAIM_CHAT_SKIPPED_STEP" = "Saknas";
 "CLAIM_CHAT_SKIP_STEP" = "Hoppa över";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -267,7 +267,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_PHONE_NUMBER_MISSING" = "Vänligen ange telefonnummer ifall vi behöver kontakta dig";
 "CLAIM_CHAT_PHONE_NUMBER_UPDATE" = "Se till att vi har rätt telefonnummer ifall vi behöver kontakta dig";
 "CLAIM_CHAT_RECORDING_TITLE" = "Inspelning";
-"CLAIM_CHAT_SHOW_ALL_ANSWERS_BUTTON" = "Visa alla svar";
+"claim_status.show_all_answers" = "Visa alla svar";
 "CLAIM_CHAT_SINGLE_ITEM_DETAILS_HINT" = "Om du inte minns inköpsdatum behöver du inte fylla i något.";
 "CLAIM_CHAT_SKIPPED_STEP" = "Saknas";
 "CLAIM_CHAT_SKIP_STEP" = "Hoppa över";

--- a/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
@@ -79,6 +79,29 @@ fragment ClaimIntentStepContentFragment on ClaimIntentStepContent {
             contentType
             fileName
         }
+        keyDetails {
+            title
+            value
+        }
+        answers {
+            title
+            value {
+                ... on ClaimIntentStepContentSummaryAnswerText {
+                    text
+                }
+                ... on ClaimIntentStepContentSummaryAnswerAudio {
+                    url
+                    transcript
+                }
+                ... on ClaimIntentStepContentSummaryAnswerFiles {
+                    files {
+                        url
+                        contentType
+                        fileName
+                    }
+                }
+            }
+        }
     }
     ... on ClaimIntentStepContentSelect {
         options {


### PR DESCRIPTION
## Why

The claims-service summary step now exposes `keyDetails` (facts for a collapsed
"Claim details" card) and `answers` (ordered question/answer pairs whose value is
a Text / Audio / Files union), for the new "claims-flow-new" summary UI. The iOS
summary previously rendered one flat, always-expanded card, so it couldn't show the
collapsed card + per-question answers with inline audio playback. This mirrors the
backend and Android work.

## What

- `SummaryFragment` (ClaimIntent.graphql) selects the new `keyDetails` and `answers`
  fields; `ClaimIntentStepContentSummary` gains `keyDetails` + `answers` (with an
  `Answer.Value` = text/audio/files enum), mapped in `ClaimIntentClientOctopus`
  (non-throwing on an unknown future value; malformed file URLs skipped).
- `SubmitClaimSummaryView` renders a collapsed "Claim details" card from `keyDetails`
  (falling back to `items` when empty) with an outlined "Show all answers" button —
  shown only when `answers` is non-empty — that opens a detent sheet listing each
  question with its answer inline (text, a `TrackPlayerView` for recorded answers, or
  files). The existing Recording and Uploaded-files sections are unchanged.
- Adds the `CLAIM_CHAT_SHOW_ALL_ANSWERS_BUTTON` string; UI aligned with Android
  (spacing, title size, transparent answers-sheet background).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
