### PR TITLE
Use compact sheet for claim chat single-select questions with many options

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -17,7 +17,7 @@ struct SingleItemModel: Equatable, Identifiable {
             result.append(.singleSelect)
         }
 
-        if values.count > 5 {
+        if multiselect && values.count > 5 {
             result.append(.alwaysAttachToBottom)
         }
 


### PR DESCRIPTION
## Why

From the claims-automation test session 2026-07-15/16 ("Deterministic travel + stroller + bike"): in the delayed-luggage flow, the single-select "cause of delay" question opens a full-height bottom sheet while similar questions open compact ones.

The cause: `SingleItemModel.attributes` adds `.alwaysAttachToBottom` to any option picker with more than 5 options, and `SubmitClaimFormView` maps that attribute to the `.large` detent and bottom-attached content. That attribute exists to keep the multiselect save button pinned on long lists — but single-select pickers submit on tap (`returnValueOnSelection`) and have no save button, so they were getting the large sheet for nothing.

## What

- `SingleItemModel.attributes` only adds `.alwaysAttachToBottom` for multiselect pickers with more than 5 options.
- Single-select questions now always present with the compact `.height` detent (which still caps at max sheet height for very long lists); multiselect behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)