### PR TITLE
Clamp claim chat date picker preset to the allowed date range

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -217,6 +217,19 @@ public struct ClaimIntentStepContentForm: Sendable {
             self.title = title
             self.type = type
         }
+
+        /// The date the picker opens with: the saved value if present, otherwise today, clamped to min/max
+        @MainActor
+        func initialPickerDate(selectedValue: String?) -> Date {
+            let date = selectedValue?.localDateToDate ?? Date()
+            if let maxDate = maxValue?.localDateToDate, date > maxDate {
+                return maxDate
+            }
+            if let minDate = minValue?.localDateToDate, date < minDate {
+                return minDate
+            }
+            return date
+        }
     }
 
     public struct SearchData: Sendable {

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
@@ -189,7 +189,7 @@ struct FormFieldView: View {
         ) { [weak viewModel] in
             guard let viewModel else { return }
             if viewModel.state.isEnabled == true {
-                viewModel.dateForPicker = fieldViewModel.values.first?.localDateToDate ?? Date()
+                viewModel.dateForPicker = field.initialPickerDate(selectedValue: fieldViewModel.values.first)
                 viewModel.isDatePickerPresented = .init(
                     id: field.id,
                     continueAction: { [weak viewModel] in


### PR DESCRIPTION
## Why

From the claims-automation test session 2026-07-15/16 ("Deterministic travel + stroller + bike"): in the travel flow, the "travel start date?" picker opens preset to today, but today is outside the allowed range when the date of occurrence is in the past (the field's `maxValue` from the backend step model). The out-of-range preset date can't be confirmed, so the user is forced to manually navigate to a valid date before proceeding.

The preset is client-side: `SubmitClaimFormView.dateField` falls back to `Date()` when the field has no saved value, ignoring the backend-provided `minValue`/`maxValue` constraints that the picker itself enforces.

## What

- Added `ClaimIntentStepContentFormField.initialPickerDate(selectedValue:)`, which resolves the saved value (or today) and clamps it to the field's min/max dates.
- `SubmitClaimFormView.dateField` uses it to preset the picker, so the picker opens on the nearest allowed date (e.g. the date of occurrence) instead of a disabled today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)