### PR TITLE
fix: self-dismissing confirm sheet on iOS 16

### DIFF
--- a/Projects/Addons/Sources/Views/ChangeAddonSummaryScreen.swift
+++ b/Projects/Addons/Sources/Views/ChangeAddonSummaryScreen.swift
@@ -3,35 +3,35 @@ import hCore
 import hCoreUI
 
 struct ChangeAddonSummaryScreen: View {
-    let quoteSummaryVm: QuoteSummaryViewModel
+    let changeAddonNavigationVm: ChangeAddonNavigationViewModel
 
     init(_ changeAddonNavigationVm: ChangeAddonNavigationViewModel) {
-        self.quoteSummaryVm = changeAddonNavigationVm.changeAddonVm!
-            .asQuoteSummaryViewModel(changeAddonNavigationVm: changeAddonNavigationVm)
+        self.changeAddonNavigationVm = changeAddonNavigationVm
     }
 
     var body: some View {
-        QuoteSummaryScreen(vm: quoteSummaryVm)
+        QuoteSummaryScreen(
+            quoteSummary: changeAddonNavigationVm.changeAddonVm!.asQuoteSummary(),
+            onDocumentTap: { [weak changeAddonNavigationVm] in changeAddonNavigationVm?.document = $0 }
+        ) { [weak changeAddonNavigationVm] in
+            changeAddonNavigationVm?.isAddonProcessingPresented = true
+            Task { await changeAddonNavigationVm?.changeAddonVm?.submitAddons() }
+        }
     }
 }
 
 extension ChangeAddonViewModel {
-    func asQuoteSummaryViewModel(changeAddonNavigationVm: ChangeAddonNavigationViewModel) -> QuoteSummaryViewModel {
+    func asQuoteSummary() -> QuoteSummary {
         let documents = offer.quote.productVariant.documents
 
         let typeOfContract = TypeOfContract(rawValue: offer.quote.productVariant.typeOfContract)
 
-        let contractInfo: QuoteSummaryViewModel.ContractInfo = .init(
+        let contractInfo: QuoteSummary.ContractInfo = .init(
             id: offer.contractInfo.contractId,
             title: offer.contractInfo.displayName,
             subtitle: offer.contractInfo.exposureName,
             premium: getPremium(),
-            documentSection: .init(
-                documents: documents,
-                onTap: { [weak changeAddonNavigationVm] document in
-                    changeAddonNavigationVm?.document = document
-                }
-            ),
+            documents: documents,
             displayItems: selectedAddons.flatMap(\.displayItems).map { $0.asQuoteDisplayItem() },
             insuranceLimits: [],
             typeOfContract: typeOfContract,
@@ -39,17 +39,12 @@ extension ChangeAddonViewModel {
         )
 
         let increase = getAddonPriceChange() ?? .zeroSek
-        let vm = QuoteSummaryViewModel(
-            contract: [contractInfo],
+        return QuoteSummary(
+            contracts: [contractInfo],
             activationDate: offer.quote.activationDate,
             noticeInfo: offer.infoMessage,
             totalPrice: .change(amount: increase.net)
-        ) { [weak self, weak changeAddonNavigationVm] in
-            changeAddonNavigationVm?.isAddonProcessingPresented = true
-            Task { await self?.submitAddons() }
-        }
-
-        return vm
+        )
     }
 }
 

--- a/Projects/Addons/Sources/Views/RemoveAddonSummaryScreen.swift
+++ b/Projects/Addons/Sources/Views/RemoveAddonSummaryScreen.swift
@@ -3,51 +3,46 @@ import hCore
 import hCoreUI
 
 struct RemoveAddonSummaryScreen: View {
-    let quoteSummaryVm: QuoteSummaryViewModel
+    let removeAddonNavigationVm: RemoveAddonNavigationViewModel
 
     init(_ removeAddonNavigationVm: RemoveAddonNavigationViewModel) {
-        self.quoteSummaryVm = removeAddonNavigationVm.removeAddonVm
-            .asQuoteSummaryViewModel(navigationVm: removeAddonNavigationVm)
+        self.removeAddonNavigationVm = removeAddonNavigationVm
     }
 
     var body: some View {
-        QuoteSummaryScreen(vm: quoteSummaryVm)
+        QuoteSummaryScreen(
+            quoteSummary: removeAddonNavigationVm.removeAddonVm.asQuoteSummary(),
+            onDocumentTap: { [weak removeAddonNavigationVm] in removeAddonNavigationVm?.document = $0 }
+        ) { [weak removeAddonNavigationVm] in
+            removeAddonNavigationVm?.isProcessingPresented = true
+            Task { await removeAddonNavigationVm?.removeAddonVm.confirmRemoval() }
+        }
     }
 }
 
 extension RemoveAddonViewModel {
-    func asQuoteSummaryViewModel(navigationVm: RemoveAddonNavigationViewModel) -> QuoteSummaryViewModel {
+    func asQuoteSummary() -> QuoteSummary {
         let documents = removeOffer.productVariant.documents
 
         let typeOfContract: TypeOfContract? = TypeOfContract(rawValue: removeOffer.productVariant.typeOfContract)
 
-        let contractInfo: QuoteSummaryViewModel.ContractInfo = .init(
+        let contractInfo: QuoteSummary.ContractInfo = .init(
             id: removeOffer.contractInfo.contractId,
             title: removeOffer.contractInfo.displayName,
             subtitle: removeOffer.contractInfo.exposureName,
             premium: getPremium(),
-            documentSection: .init(
-                documents: documents,
-                onTap: { [weak navigationVm] document in
-                    navigationVm?.document = document
-                }
-            ),
+            documents: documents,
             displayItems: [],
             insuranceLimits: [],
             typeOfContract: typeOfContract,
             priceBreakdownItems: getBreakdownDisplayItems()
         )
 
-        let vm = QuoteSummaryViewModel(
-            contract: [contractInfo],
+        return QuoteSummary(
+            contracts: [contractInfo],
             activationDate: removeOffer.activationDate,
             totalPrice: .none
-        ) { [weak self, weak navigationVm] in
-            navigationVm?.isProcessingPresented = true
-            Task { await self?.confirmRemoval() }
-        }
-
-        return vm
+        )
     }
 }
 

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -293,11 +293,8 @@ public struct ChangeTierNavigation: View {
                 if let changeTierNavigationVm {
                     switch action {
                     case .summary:
-                        ChangeTierSummaryScreen(
-                            changeTierVm: changeTierNavigationVm.vm,
-                            changeTierNavigationVm: changeTierNavigationVm
-                        )
-                        .navigationTitle(L10n.offerUpdateSummaryTitle)
+                        ChangeTierSummaryScreen(changeTierNavigationVm: changeTierNavigationVm)
+                            .navigationTitle(L10n.offerUpdateSummaryTitle)
                     }
                 } else {
                     EmptyView()

--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -13,9 +13,9 @@ struct ChangeTierSummaryScreen: View {
         QuoteSummaryScreen(
             quoteSummary: changeTierNavigationVm.vm.asQuoteSummary(),
             onDocumentTap: { [weak changeTierNavigationVm] in changeTierNavigationVm?.document = $0 }
-        ) { [weak changeTierNavigationVm] in
-            changeTierNavigationVm?.vm.commitTier()
+        ) { @MainActor [weak changeTierNavigationVm] in
             changeTierNavigationVm?.router.push(ChangeTierRouterActionsWithoutBackButton.commitTier)
+            changeTierNavigationVm?.vm.commitTier()
         }
     }
 }

--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -3,22 +3,25 @@ import hCore
 import hCoreUI
 
 struct ChangeTierSummaryScreen: View {
-    private let quoteSummaryVm: QuoteSummaryViewModel
+    private let changeTierNavigationVm: ChangeTierNavigationViewModel
 
-    init(
-        changeTierVm: ChangeTierViewModel,
-        changeTierNavigationVm: ChangeTierNavigationViewModel
-    ) {
-        quoteSummaryVm = changeTierVm.asQuoteSummaryViewModel(changeTierNavigationVm: changeTierNavigationVm)
+    init(changeTierNavigationVm: ChangeTierNavigationViewModel) {
+        self.changeTierNavigationVm = changeTierNavigationVm
     }
 
     var body: some View {
-        QuoteSummaryScreen(vm: quoteSummaryVm)
+        QuoteSummaryScreen(
+            quoteSummary: changeTierNavigationVm.vm.asQuoteSummary(),
+            onDocumentTap: { [weak changeTierNavigationVm] in changeTierNavigationVm?.document = $0 }
+        ) { [weak changeTierNavigationVm] in
+            changeTierNavigationVm?.vm.commitTier()
+            changeTierNavigationVm?.router.push(ChangeTierRouterActionsWithoutBackButton.commitTier)
+        }
     }
 }
 
 extension ChangeTierViewModel {
-    func asQuoteSummaryViewModel(changeTierNavigationVm: ChangeTierNavigationViewModel) -> QuoteSummaryViewModel {
+    func asQuoteSummary() -> QuoteSummary {
         let displayItems: [QuoteDisplayItem] =
             selectedQuote?.displayItems.map { .init(title: $0.title, value: $0.value) } ?? []
         let activationDate = L10n.changeAddressActivationDate(activationDate?.displayDateDDMMMYYYYFormat ?? "")
@@ -29,17 +32,12 @@ extension ChangeTierViewModel {
             + (selectedQuote?.addons.flatMap(\.addonVariant.documents) ?? [])
 
         let contracts = [
-            QuoteSummaryViewModel.ContractInfo(
+            QuoteSummary.ContractInfo(
                 id: currentTier?.id ?? "",
                 title: displayName ?? "",
                 subtitle: activationDate,
                 premium: newTotalCost,
-                documentSection: .init(
-                    documents: documents,
-                    onTap: { [weak changeTierNavigationVm] document in
-                        changeTierNavigationVm?.document = document
-                    },
-                ),
+                documents: documents,
                 displayItems: displayItems,
                 insuranceLimits: selectedQuote?.productVariant?.insurableLimits ?? [],
                 typeOfContract: typeOfContract,
@@ -50,17 +48,11 @@ extension ChangeTierViewModel {
 
         let totalPremium = contracts.compactMap(\.premium).sum()
 
-        let vm = QuoteSummaryViewModel(
-            contract: contracts,
+        return QuoteSummary(
+            contracts: contracts,
             activationDate: self.activationDate,
-            totalPrice: .comparison(old: totalPremium.gross, new: totalPremium.net),
-            onConfirmClick: { [weak changeTierNavigationVm] in
-                changeTierNavigationVm?.vm.commitTier()
-                changeTierNavigationVm?.router.push(ChangeTierRouterActionsWithoutBackButton.commitTier)
-            }
+            totalPrice: .comparison(old: totalPremium.gross, new: totalPremium.net)
         )
-
-        return vm
     }
 }
 @available(iOS 17.0, *)
@@ -77,7 +69,6 @@ extension ChangeTierViewModel {
     Dependencies.shared.add(module: Module { () -> ChangeTierClient in ChangeTierClientDemo() })
 
     return ChangeTierSummaryScreen(
-        changeTierVm: changeTierVm,
         changeTierNavigationVm: changeTierNavigationVm
     )
 }

--- a/Projects/MoveFlow/Sources/Navigation/MovingFlowNavigation.swift
+++ b/Projects/MoveFlow/Sources/Navigation/MovingFlowNavigation.swift
@@ -8,15 +8,12 @@ import hCoreUI
 
 @MainActor
 class MovingFlowQuoteManager {
-    weak var viewModel: MovingFlowNavigationViewModel?
-
-    func createSummaryViewModel(
-        router: NavigationRouter,
+    func createQuoteSummary(
         moveQuotesModel: MoveQuotesModel?,
         selectedHomeQuote: MovingFlowQuote?,
         totalPremium: Premium,
         removedAddonIds: [String]
-    ) -> QuoteSummaryViewModel {
+    ) -> QuoteSummary {
         let movingFlowQuotes = getQuotes(
             moveQuotesModel: moveQuotesModel,
             selectedHomeQuote: selectedHomeQuote
@@ -26,34 +23,18 @@ class MovingFlowQuoteManager {
             createContractInfo(for: quote, removedAddonIds: removedAddonIds)
         }
 
-        let vm = QuoteSummaryViewModel(
-            contract: contractInfos,
+        return QuoteSummary(
+            contracts: contractInfos,
             activationDate: movingFlowQuotes.first?.startDate,
             noticeInfo: contractInfos.count > 1 ? L10n.changeAddressOtherInsurancesInfoText : nil,
             totalPrice: .comparison(old: totalPremium.gross, new: totalPremium.net)
         )
-
-        vm.onConfirmClick = { [weak router, weak viewModel] in
-            Task { [weak viewModel] in
-                guard let viewModel = viewModel,
-                    let movingFlowConfirmViewModel = viewModel.movingFlowConfirmViewModel
-                else { return }
-                router?.push(MovingFlowRouterWithHiddenBackButtonActions.processing)
-                await movingFlowConfirmViewModel.confirmMoveIntent(
-                    intentId: viewModel.moveConfigurationModel?.id ?? "",
-                    currentHomeQuoteId: viewModel.selectedHomeQuote?.id ?? "",
-                    removedAddons: viewModel.removedAddonIds
-                )
-            }
-        }
-
-        return vm
     }
 
     private func createContractInfo(
         for quote: MovingFlowQuote,
         removedAddonIds: [String]
-    ) -> QuoteSummaryViewModel.ContractInfo {
+    ) -> QuoteSummary.ContractInfo {
         var documents: [hPDFDocument] = quote.documents.map {
             .init(displayName: $0.displayName, url: $0.url, type: .unknown)
         }
@@ -74,17 +55,12 @@ class MovingFlowQuoteManager {
             contentsOf: quote.priceBreakdownItems.map { .init(title: $0.displayTitle, value: $0.displayValue) }
         )
 
-        return QuoteSummaryViewModel.ContractInfo(
+        return QuoteSummary.ContractInfo(
             id: quote.id,
             title: quote.displayName,
             subtitle: quote.exposureName ?? "",
             premium: quote.totalPremium,
-            documentSection: .init(
-                documents: documents,
-                onTap: { [weak viewModel] document in
-                    viewModel?.document = document
-                }
-            ),
+            documents: documents,
             displayItems: quote.displayItems.map({ .init(title: $0.displayTitle, value: $0.displayValue) }),
             insuranceLimits: quote.insurableLimits,
             typeOfContract: quote.contractType,
@@ -152,15 +128,13 @@ public class MovingFlowNavigationViewModel: ObservableObject, ChangeTierQuoteDat
     @Published var houseInformationInputvm = HouseInformationInputModel()
     @Published var selectedHomeQuote: MovingFlowQuote?
     @Published var selectedHomeAddress: MoveAddress?
-    var totalPremium: Premium?
+    var totalPremium: Premium!
     var movingFlowConfirmViewModel: MovingFlowConfirmViewModel?
-    var quoteSummaryViewModel: QuoteSummaryViewModel?
     var removedAddonIds: [String] = []
 
     fileprivate var initialTrackingType: MovingFlowDetentType?
 
     init() {
-        quoteManager.viewModel = self
         initializeData()
     }
 
@@ -199,11 +173,8 @@ public class MovingFlowNavigationViewModel: ObservableObject, ChangeTierQuoteDat
         }
     }
 
-    func setMovingFlowSummaryViewModel(router: NavigationRouter) {
-        guard let totalPremium else { return }
-        movingFlowConfirmViewModel = .init()
-        quoteSummaryViewModel = quoteManager.createSummaryViewModel(
-            router: router,
+    func createQuoteSummary() -> QuoteSummary {
+        quoteManager.createQuoteSummary(
             moveQuotesModel: moveQuotesModel,
             selectedHomeQuote: selectedHomeQuote,
             totalPremium: totalPremium,
@@ -413,11 +384,7 @@ public struct MovingFlowNavigation: View {
     }
 
     func openConfirmScreen() -> some View {
-        movingFlowNavigationVm.setMovingFlowSummaryViewModel(
-            router: router
-        )
-        let model = movingFlowNavigationVm.quoteSummaryViewModel!
-        return MovingFlowConfirmScreen(quoteSummaryViewModel: model)
+        MovingFlowConfirmScreen(navigationVm: movingFlowNavigationVm, router: router)
             .navigationTitle(L10n.changeAddressSummaryTitle)
     }
 

--- a/Projects/MoveFlow/Sources/View/MovingFlowConfirmScreen.swift
+++ b/Projects/MoveFlow/Sources/View/MovingFlowConfirmScreen.swift
@@ -3,10 +3,30 @@ import hCore
 import hCoreUI
 
 struct MovingFlowConfirmScreen: View {
-    let quoteSummaryViewModel: QuoteSummaryViewModel
+    let navigationVm: MovingFlowNavigationViewModel
+    let router: NavigationRouter
 
     var body: some View {
-        QuoteSummaryScreen(vm: quoteSummaryViewModel)
+        QuoteSummaryScreen(
+            quoteSummary: navigationVm.createQuoteSummary(),
+            onDocumentTap: { [weak navigationVm] in navigationVm?.document = $0 }
+        ) { [weak navigationVm, weak router] in
+            guard let navigationVm else { return }
+            if navigationVm.movingFlowConfirmViewModel == nil {
+                navigationVm.movingFlowConfirmViewModel = .init()
+            }
+            Task { [weak navigationVm] in
+                guard let navigationVm,
+                    let movingFlowConfirmViewModel = navigationVm.movingFlowConfirmViewModel
+                else { return }
+                router?.push(MovingFlowRouterWithHiddenBackButtonActions.processing)
+                await movingFlowConfirmViewModel.confirmMoveIntent(
+                    intentId: navigationVm.moveConfigurationModel?.id ?? "",
+                    currentHomeQuoteId: navigationVm.selectedHomeQuote?.id ?? "",
+                    removedAddons: navigationVm.removedAddonIds
+                )
+            }
+        }
     }
 }
 
@@ -39,14 +59,14 @@ public class MovingFlowConfirmViewModel: ObservableObject {
 }
 
 #Preview {
-    let model = QuoteSummaryViewModel(
-        contract: [],
+    let quoteSummary = QuoteSummary(
+        contracts: [],
         activationDate: Date(),
         totalPrice: .comparison(
             old: .sek(399),
             new: .sek(399)
         )
-    ) {}
+    )
     Localization.Locale.currentLocale.send(.en_SE)
-    return MovingFlowConfirmScreen(quoteSummaryViewModel: model)
+    return QuoteSummaryScreen(quoteSummary: quoteSummary, onDocumentTap: { _ in }) {}
 }

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/ContractOverviewScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/ContractOverviewScreen.swift
@@ -2,7 +2,8 @@ import SwiftUI
 import hCore
 
 struct ContractOverviewScreen: View {
-    let contract: QuoteSummaryViewModel.ContractInfo
+    let contract: QuoteSummary.ContractInfo
+    let onDocumentTap: (hPDFDocument) -> Void
     @State private var router = NavigationRouter()
     var body: some View {
         hForm {
@@ -60,13 +61,13 @@ struct ContractOverviewScreen: View {
 
     @ViewBuilder
     private var documentSection: some View {
-        let documentItems = contract.documentSection.documents
+        let documentItems = contract.documents
         if !documentItems.isEmpty {
             hSection(documentItems) { document in
                 DocumentRowItemView(
                     document: document,
                     onTap: { document in
-                        contract.documentSection.onTap(document)
+                        onDocumentTap(document)
                     }
                 )
             }
@@ -93,14 +94,11 @@ extension ContractOverviewScreen: TrackingViewNameProtocol {
                     gross: .init(amount: 599, currency: "SEK"),
                     net: .init(amount: 999, currency: "SEK")
                 ),
-                documentSection: .init(
-                    documents: [
-                        .init(displayName: "Insurance terms", url: "url", type: .generalTerms),
-                        .init(displayName: "Pre sale information", url: "url", type: .generalTerms),
-                        .init(displayName: "Product facts", url: "url", type: .generalTerms),
-                    ],
-                    onTap: { document in }
-                ),
+                documents: [
+                    .init(displayName: "Insurance terms", url: "url", type: .generalTerms),
+                    .init(displayName: "Pre sale information", url: "url", type: .generalTerms),
+                    .init(displayName: "Product facts", url: "url", type: .generalTerms),
+                ],
                 displayItems: [
                     .init(title: "Limits", value: "mockLimits mockLimits long long long name"),
                     .init(title: "Documents", value: "documents"),
@@ -112,6 +110,7 @@ extension ContractOverviewScreen: TrackingViewNameProtocol {
                 ],
                 typeOfContract: .seApartmentBrf,
                 priceBreakdownItems: [.init(title: "15% bundle discount", value: "-30 kr/mo")]
-            )
+            ),
+        onDocumentTap: { _ in }
     )
 }

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummary.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummary.swift
@@ -1,24 +1,31 @@
 import SwiftUI
 import hCore
 
-@MainActor
-public class QuoteSummaryViewModel: ObservableObject, Identifiable {
-    @Published public var contracts: [ContractInfo]
-    @Published public var activationDate: Date?
-    @Published var isConfirmChangesPresented: Bool = false
-    @Published var isShowDetailsPresented: QuoteSummaryViewModel.ContractInfo? = nil
-
-    public var onConfirmClick: () -> Void
+public struct QuoteSummary: Equatable {
+    public let contracts: [ContractInfo]
+    public let activationDate: Date?
     let noticeInfo: String?
     let totalPrice: TotalPrice
 
+    public init(
+        contracts: [ContractInfo],
+        activationDate: Date?,
+        noticeInfo: String? = nil,
+        totalPrice: TotalPrice
+    ) {
+        self.contracts = contracts
+        self.activationDate = activationDate
+        self.noticeInfo = noticeInfo
+        self.totalPrice = totalPrice
+    }
+
     public struct ContractInfo: Identifiable, Equatable {
-        public var id: String
+        public let id: String
         let title: String
         let subtitle: String
         public let premium: Premium?
         let displayItems: [QuoteDisplayItem]
-        let documentSection: DocumentSection
+        let documents: [hPDFDocument]
         let insuranceLimits: [InsurableLimits]
         let typeOfContract: TypeOfContract?
         let shouldShowDetails: Bool
@@ -29,7 +36,7 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
             title: String,
             subtitle: String,
             premium: Premium?,
-            documentSection: DocumentSection,
+            documents: [hPDFDocument],
             displayItems: [QuoteDisplayItem],
             insuranceLimits: [InsurableLimits],
             typeOfContract: TypeOfContract?,
@@ -39,47 +46,16 @@ public class QuoteSummaryViewModel: ObservableObject, Identifiable {
             self.title = title
             self.subtitle = subtitle
             self.premium = premium
-            self.documentSection = documentSection
+            self.documents = documents
             self.displayItems = displayItems
             self.insuranceLimits = insuranceLimits
             self.typeOfContract = typeOfContract
-            self.shouldShowDetails =
-                !(documentSection.documents.isEmpty && displayItems.isEmpty
-                && insuranceLimits.isEmpty)
+            self.shouldShowDetails = !(documents.isEmpty && displayItems.isEmpty && insuranceLimits.isEmpty)
             self.priceBreakdownItems = priceBreakdownItems
         }
-
-        public static func == (lhs: QuoteSummaryViewModel.ContractInfo, rhs: QuoteSummaryViewModel.ContractInfo) -> Bool
-        {
-            lhs.id == rhs.id
-        }
-
-        public struct DocumentSection {
-            public let documents: [hPDFDocument]
-            public let onTap: (_ document: hPDFDocument) -> Void
-
-            public init(documents: [hPDFDocument], onTap: @escaping (_: hPDFDocument) -> Void) {
-                self.documents = documents
-                self.onTap = onTap
-            }
-        }
     }
 
-    public init(
-        contract: [ContractInfo],
-        activationDate: Date?,
-        noticeInfo: String? = nil,
-        totalPrice: TotalPrice,
-        onConfirmClick: (() -> Void)? = nil
-    ) {
-        self.contracts = contract
-        self.activationDate = activationDate
-        self.onConfirmClick = onConfirmClick ?? {}
-        self.noticeInfo = noticeInfo
-        self.totalPrice = totalPrice
-    }
-
-    public enum TotalPrice {
+    public enum TotalPrice: Equatable {
         case comparison(old: MonetaryAmount, new: MonetaryAmount)
         case change(amount: MonetaryAmount)
         case none

--- a/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummaryScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/QuoteSummaryScreen/QuoteSummaryScreen.swift
@@ -2,41 +2,56 @@ import SwiftUI
 import hCore
 
 public struct QuoteSummaryScreen: View {
-    @ObservedObject var vm: QuoteSummaryViewModel
-    @State var spacingCoverage: CGFloat = 0
-    @State var totalHeight: CGFloat = 0
+    let quoteSummary: QuoteSummary
+    let onDocumentTap: (hPDFDocument) -> Void
+    let onConfirm: () -> Void
+
+    @State private var isConfirmChangesPresented = false
+    @State private var showDetailsContract: QuoteSummary.ContractInfo? = nil
+    @State private var spacingCoverage: CGFloat = 0
+    @State private var totalHeight: CGFloat = 0
 
     public init(
-        vm: QuoteSummaryViewModel
+        quoteSummary: QuoteSummary,
+        onDocumentTap: @escaping (hPDFDocument) -> Void,
+        onConfirm: @escaping () -> Void
     ) {
-        self.vm = vm
+        self.quoteSummary = quoteSummary
+        self.onDocumentTap = onDocumentTap
+        self.onConfirm = onConfirm
     }
 
     public var body: some View {
         ScrollViewReader { proxy in
             hForm {
                 VStack(spacing: .padding16) {
-                    ContractCardView(vm: vm)
-                        .background(
-                            GeometryReader { proxy in
-                                Color.clear
-                                    .onAppear {
-                                        spacingCoverage = max(totalHeight - proxy.size.height, 0)
-                                    }
-                                    .onChange(of: proxy.size) { size in
-                                        spacingCoverage = max(totalHeight - size.height, 0)
-                                    }
-                            }
-                        )
+                    ContractCardView(
+                        contracts: quoteSummary.contracts,
+                        showDetailsContract: $showDetailsContract
+                    )
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear
+                                .onAppear {
+                                    spacingCoverage = max(totalHeight - proxy.size.height, 0)
+                                }
+                                .onChange(of: proxy.size) { size in
+                                    spacingCoverage = max(totalHeight - size.height, 0)
+                                }
+                        }
+                    )
                 }
             }
             .hButtonTakeFullWidth(true)
             .hFormAlwaysAttachToBottom {
                 VStack(spacing: .padding8) {
-                    if let noticeInfo = vm.noticeInfo {
+                    if let noticeInfo = quoteSummary.noticeInfo {
                         noticeComponent(info: noticeInfo)
                     }
-                    PriceSummarySection(vm: vm)
+                    PriceSummarySection(
+                        quoteSummary: quoteSummary,
+                        isConfirmChangesPresented: $isConfirmChangesPresented
+                    )
                 }
             }
         }
@@ -52,16 +67,16 @@ public struct QuoteSummaryScreen: View {
             }
         )
         .detent(
-            presented: $vm.isConfirmChangesPresented,
+            presented: $isConfirmChangesPresented,
             options: .constant([.alwaysOpenOnTop])
         ) {
             openConfirmChangesScreen
         }
         .detent(
-            item: $vm.isShowDetailsPresented,
+            item: $showDetailsContract,
             options: .constant([.alwaysOpenOnTop]),
         ) { contract in
-            ContractOverviewScreen(contract: contract)
+            ContractOverviewScreen(contract: contract, onDocumentTap: onDocumentTap)
         }
     }
 
@@ -70,15 +85,15 @@ public struct QuoteSummaryScreen: View {
             ConfirmChangesScreen(
                 title: L10n.confirmChangesTitle,
                 subTitle: L10n.confirmChangesSubtitle(
-                    vm.activationDate?.displayDateDDMMMYYYYFormat ?? Date().displayDateDDMMMYYYYFormat
+                    quoteSummary.activationDate?.displayDateDDMMMYYYYFormat ?? Date().displayDateDDMMMYYYYFormat
                 ),
                 buttons: .init(
-                    mainButton: .init(buttonAction: { [weak vm] in
-                        vm?.isConfirmChangesPresented = false
-                        vm?.onConfirmClick()
+                    mainButton: .init(buttonAction: {
+                        isConfirmChangesPresented = false
+                        onConfirm()
                     }),
-                    dismissButton: .init(buttonAction: { [weak vm] in
-                        vm?.isConfirmChangesPresented = false
+                    dismissButton: .init(buttonAction: {
+                        isConfirmChangesPresented = false
                     })
                 )
             )
@@ -102,11 +117,12 @@ public struct QuoteSummaryScreen: View {
 }
 
 private struct ContractCardView: View {
-    @ObservedObject var vm: QuoteSummaryViewModel
+    let contracts: [QuoteSummary.ContractInfo]
+    @Binding var showDetailsContract: QuoteSummary.ContractInfo?
 
     var body: some View {
         VStack(spacing: 0) {
-            ForEach(vm.contracts, id: \.id) { contract in
+            ForEach(contracts) { contract in
                 contractInfoView(for: contract)
                     .id(contract.id)
             }
@@ -114,13 +130,7 @@ private struct ContractCardView: View {
     }
 
     @ViewBuilder
-    private func contractInfoView(for contract: QuoteSummaryViewModel.ContractInfo) -> some View {
-        contractContent(for: contract)
-    }
-
-    func contractContent(
-        for contract: QuoteSummaryViewModel.ContractInfo
-    ) -> some View {
+    private func contractInfoView(for contract: QuoteSummary.ContractInfo) -> some View {
         hSection {
             StatusCard(
                 mainContent:
@@ -146,9 +156,7 @@ private struct ContractCardView: View {
     }
 
     @ViewBuilder
-    private func pricingSummary(
-        for contract: QuoteSummaryViewModel.ContractInfo
-    ) -> some View {
+    private func pricingSummary(for contract: QuoteSummary.ContractInfo) -> some View {
         VStack(spacing: .padding16) {
             if contract.shouldShowDetails {
                 showDetailsButton(contract)
@@ -182,7 +190,7 @@ private struct ContractCardView: View {
     }
 
     @ViewBuilder
-    private func showDetailsButton(_ contract: QuoteSummaryViewModel.ContractInfo) -> some View {
+    private func showDetailsButton(_ contract: QuoteSummary.ContractInfo) -> some View {
         hButton(
             .medium,
             .ghost,
@@ -190,7 +198,7 @@ private struct ContractCardView: View {
                 title: L10n.ClaimStatus.ClaimDetails.button
             )
         ) {
-            vm.isShowDetailsPresented = contract
+            showDetailsContract = contract
         }
         .hWithTransition(.scale)
         .hButtonWithBorder
@@ -198,13 +206,14 @@ private struct ContractCardView: View {
 }
 
 private struct PriceSummarySection: View {
-    @ObservedObject var vm: QuoteSummaryViewModel
+    let quoteSummary: QuoteSummary
+    @Binding var isConfirmChangesPresented: Bool
     @State private var isCancelAlertPresented = false
 
     var body: some View {
         hSection {
             VStack(spacing: .padding16) {
-                switch vm.totalPrice {
+                switch quoteSummary.totalPrice {
                 case .comparison(let currentPrice, let newPrice):
                     PriceField(
                         viewModel: .init(
@@ -212,7 +221,7 @@ private struct PriceSummarySection: View {
                             newValue: newPrice,
                             title: nil,
                             subTitle: L10n.summaryTotalPriceSubtitle(
-                                vm.activationDate?.displayDateDDMMMYYYYFormat ?? ""
+                                quoteSummary.activationDate?.displayDateDDMMMYYYYFormat ?? ""
                             )
                         )
                     )
@@ -241,7 +250,7 @@ private struct PriceSummarySection: View {
                         content: .init(
                             title: L10n.changeAddressAcceptOffer
                         )
-                    ) { [weak vm] in vm?.isConfirmChangesPresented = true }
+                    ) { isConfirmChangesPresented = true }
 
                     hCancelButton {
                         isCancelAlertPresented = true
@@ -263,8 +272,8 @@ private struct PriceSummarySection: View {
             .init(displayName: "document 1", url: "https//hedvig.com", type: .generalTerms),
             .init(displayName: "document 2", url: "https//hedvig.com", type: .preSaleInfo),
         ]
-        let vm = QuoteSummaryViewModel(
-            contract: [
+        let quoteSummary = QuoteSummary(
+            contracts: [
                 .init(
                     id: "id1",
                     title: "Homeowner",
@@ -273,10 +282,7 @@ private struct PriceSummarySection: View {
                         gross: .init(amount: 599, currency: "SEK"),
                         net: .init(amount: 999, currency: "SEK")
                     ),
-                    documentSection: .init(
-                        documents: [],
-                        onTap: { document in }
-                    ),
+                    documents: [],
                     displayItems: [
                         .init(title: "Limits", value: "mockLimits mockLimits long long long name"),
                         .init(title: "Documents", value: "documents"),
@@ -294,10 +300,7 @@ private struct PriceSummarySection: View {
                         gross: .init(amount: 599, currency: "SEK"),
                         net: .init(amount: 999, currency: "SEK")
                     ),
-                    documentSection: .init(
-                        documents: documents,
-                        onTap: { document in }
-                    ),
+                    documents: documents,
                     displayItems: [
                         .init(title: "Limits", value: "mockLimits"),
                         .init(title: "Documents", value: "documents"),
@@ -319,10 +322,7 @@ private struct PriceSummarySection: View {
                         gross: .init(amount: 599, currency: "SEK"),
                         net: .init(amount: 999, currency: "SEK")
                     ),
-                    documentSection: .init(
-                        documents: [],
-                        onTap: { document in }
-                    ),
+                    documents: [],
                     displayItems: [],
                     insuranceLimits: [
                         .init(label: "label", limit: "limit", description: "description"),
@@ -340,10 +340,7 @@ private struct PriceSummarySection: View {
                         gross: .init(amount: 599, currency: "SEK"),
                         net: .init(amount: 999, currency: "SEK")
                     ),
-                    documentSection: .init(
-                        documents: [],
-                        onTap: { document in }
-                    ),
+                    documents: [],
                     displayItems: [],
                     insuranceLimits: [],
                     typeOfContract: .seAccident,
@@ -360,10 +357,7 @@ private struct PriceSummarySection: View {
                         gross: .init(amount: 599, currency: "SEK"),
                         net: .init(amount: 999, currency: "SEK")
                     ),
-                    documentSection: .init(
-                        documents: [],
-                        onTap: { document in }
-                    ),
+                    documents: [],
                     displayItems: [],
                     insuranceLimits: [],
                     typeOfContract: .seDogStandard,
@@ -371,10 +365,9 @@ private struct PriceSummarySection: View {
                 ),
             ],
             activationDate: "2025-08-24".localDateToDate ?? Date(),
-            totalPrice: .comparison(old: .sek(599), new: .sek(999)),
-            onConfirmClick: {}
+            totalPrice: .comparison(old: .sek(599), new: .sek(999))
         )
 
-        return QuoteSummaryScreen(vm: vm)
+        return QuoteSummaryScreen(quoteSummary: quoteSummary, onDocumentTap: { _ in }) {}
     }
 )


### PR DESCRIPTION
## [RND-XXXX]

- Quote-summary confirm sheet self-dismissed on iOS 16 (ChangeTier, MoveFlow; latent in Addons).
  Root cause + investigation: https://hedviginsurance.slack.com/archives/CFDPC2FUL/p1783586423410319
- `QuoteSummaryViewModel` (class) → `QuoteSummary` (`Equatable` value); detent flags are now `@State`
  owned by `QuoteSummaryScreen`; actions lifted to `onDocumentTap`/`onConfirm` closures; feature
  mappers become pure functions.

## Blockers

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
- [ ] Confirm sheet on iOS 16.4 sim, all four flows
