### PR TITLE
bug: item picker detent size

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -17,10 +17,6 @@ struct SingleItemModel: Equatable, Identifiable {
             result.append(.singleSelect)
         }
 
-        if values.count > 5 {
-            result.append(.alwaysAttachToBottom)
-        }
-
         return result
     }
 }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFormView.swift
@@ -34,8 +34,7 @@ struct SubmitClaimFormView: View {
         .detent(
             item: $viewModel.isSelectItemPresented,
             presentationStyle: .detent(
-                style: viewModel.isSelectItemPresented?.attributes.contains(.alwaysAttachToBottom) == true
-                    ? [.large] : [.height]
+                style: [.height]
             )
         ) { [weak viewModel] model in
             ItemPickerScreen<SingleSelectValue>(
@@ -72,7 +71,7 @@ struct SubmitClaimFormView: View {
             .hItemPickerAttributes(model.attributes)
             .navigationTitle(model.title)
             .embededInNavigation(options: .largeNavigationBar, tracking: SubmitClaimModalType.itemPicker)
-            .hFormContentPosition(model.attributes.contains(.alwaysAttachToBottom) ? .bottom : .compact)
+            .hFormContentPosition(.compact)
         }
         .detent(
             item: $viewModel.searchFieldPresentation,

--- a/Projects/hCoreUI/Sources/ItemPickerScreen.swift
+++ b/Projects/hCoreUI/Sources/ItemPickerScreen.swift
@@ -100,11 +100,20 @@ public struct ItemPickerScreen<T>: View where T: Equatable & Hashable {
                     }
             } else {
                 Group {
-                    hForm {
-                        content(with: proxy)
-                    }
-                    .hFormAttachToBottom {
-                        bottomContent
+                    if attributes.contains(.alwaysAttachToBottom) {
+                        hForm {
+                            content(with: proxy)
+                        }
+                        .hFormAlwaysAttachToBottom {
+                            bottomContent
+                        }
+                    } else {
+                        hForm {
+                            content(with: proxy)
+                        }
+                        .hFormAttachToBottom {
+                            bottomContent
+                        }
                     }
                 }
             }
@@ -400,6 +409,7 @@ public enum ItemPickerAttribute {
     case singleSelect
     case disableIfNoneSelected
     case attachToBottom
+    case alwaysAttachToBottom
 }
 
 extension EnvironmentValues {

--- a/Projects/hCoreUI/Sources/ItemPickerScreen.swift
+++ b/Projects/hCoreUI/Sources/ItemPickerScreen.swift
@@ -100,20 +100,11 @@ public struct ItemPickerScreen<T>: View where T: Equatable & Hashable {
                     }
             } else {
                 Group {
-                    if attributes.contains(.alwaysAttachToBottom) {
-                        hForm {
-                            content(with: proxy)
-                        }
-                        .hFormAlwaysAttachToBottom {
-                            bottomContent
-                        }
-                    } else {
-                        hForm {
-                            content(with: proxy)
-                        }
-                        .hFormAttachToBottom {
-                            bottomContent
-                        }
+                    hForm {
+                        content(with: proxy)
+                    }
+                    .hFormAttachToBottom {
+                        bottomContent
                     }
                 }
             }
@@ -409,7 +400,6 @@ public enum ItemPickerAttribute {
     case singleSelect
     case disableIfNoneSelected
     case attachToBottom
-    case alwaysAttachToBottom
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
- We had logic to always show item picker at full height if there are more than 5 items in the list, now it is removed and will be always shown with height wrapped

## Blockers

- Blocker

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
