### PR TITLE
feat: Onboarding - Module with welcome step (GEN-5511)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -112,6 +112,7 @@ let appDependencies: [TargetDependency] = [
         .project(target: "ChangeTier", path: .relativeToRoot("Projects/ChangeTier")),
         .project(target: "Addons", path: .relativeToRoot("Projects/Addons")),
         .project(target: "CrossSell", path: .relativeToRoot("Projects/CrossSell")),
+        .project(target: "Onboarding", path: .relativeToRoot("Projects/Onboarding")),
         .project(target: "CampaignCore", path: .relativeToRoot("Projects/CampaignCore")),
         .project(target: "CampaignUI", path: .relativeToRoot("Projects/CampaignUI")),
         .project(target: "CoreDependencies", path: .relativeToRoot("Dependencies/CoreDependencies")),

--- a/Projects/App/Sources/AppDelegate+DI.swift
+++ b/Projects/App/Sources/AppDelegate+DI.swift
@@ -15,6 +15,7 @@ import Foundation
 import Home
 import InsuranceEvidence
 import MoveFlow
+import Onboarding
 import Payment
 import Profile
 import SubmitClaimChat
@@ -55,6 +56,7 @@ enum DI {
             let campaignClient = hCampaignClientDemo()
             let insuranceEvidenceClient = InsuranceEvidenceClientDemo()
             let petChipIdClient = PetChipIdClientDemo()
+            let onboardingClient = OnboardingClientDemo()
 
             Dependencies.shared.add(module: Module { () -> FeatureFlagsClient in featureFlagsClient })
             Dependencies.shared.add(module: Module { () -> hPaymentClient in hPaymentService })
@@ -75,6 +77,7 @@ enum DI {
             Dependencies.shared.add(module: Module { () -> hCampaignClient in campaignClient })
             Dependencies.shared.add(module: Module { () -> InsuranceEvidenceClient in insuranceEvidenceClient })
             Dependencies.shared.add(module: Module { () -> PetChipIdClient in petChipIdClient })
+            Dependencies.shared.add(module: Module { () -> OnboardingClient in onboardingClient })
         } else {
             let paymentService = hPaymentClientOctopus()
             let hCampaignsService = hCampaignsClientOctopus()
@@ -105,6 +108,7 @@ enum DI {
             let insuranceEvidenceClient = InsuranceEvidenceClientOctopus()
             let claimIntentClient = ClaimIntentClientOctopus()
             let petChipIdClient = PetChipIdClientOctopus()
+            let onboardingClient = OnboardingClientOctopus()
             switch Environment.current {
             case .staging:
                 Dependencies.shared.add(module: Module { () -> FeatureFlagsClient in featureFlagsClientUnleash })
@@ -134,6 +138,7 @@ enum DI {
                 Dependencies.shared.add(module: Module { () -> hSubmitClaimFileUploadClient in networkClient })
                 Dependencies.shared.add(module: Module { () -> AuthorizationCodeClient in networkClient })
                 Dependencies.shared.add(module: Module { () -> PetChipIdClient in petChipIdClient })
+                Dependencies.shared.add(module: Module { () -> OnboardingClient in onboardingClient })
             case .production, .custom:
                 Dependencies.shared.add(module: Module { () -> FeatureFlagsClient in featureFlagsClientUnleash })
                 Dependencies.shared.add(module: Module { () -> TravelInsuranceClient in travelInsuranceService })
@@ -162,6 +167,7 @@ enum DI {
                 Dependencies.shared.add(module: Module { () -> hSubmitClaimFileUploadClient in networkClient })
                 Dependencies.shared.add(module: Module { () -> AuthorizationCodeClient in networkClient })
                 Dependencies.shared.add(module: Module { () -> PetChipIdClient in petChipIdClient })
+                Dependencies.shared.add(module: Module { () -> OnboardingClient in onboardingClient })
             }
         }
     }

--- a/Projects/App/Sources/Navigation/LoggedInNavigation+Presentations.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation+Presentations.swift
@@ -9,6 +9,7 @@ import Foundation
 import Home
 import InsuranceEvidence
 import MoveFlow
+import Onboarding
 import Profile
 import SwiftUI
 import TerminateContracts
@@ -48,6 +49,7 @@ struct LoggedInPresentations: ViewModifier {
             ) {
                 InsuranceEvidenceNavigation()
             }
+
             .modally(
                 presented: $vm.isMoveContractPresented,
                 options: .constant(.alwaysOpenOnTop)
@@ -63,6 +65,7 @@ struct LoggedInPresentations: ViewModifier {
             }
             .handleAddons(input: $vm.isAddonPresented)
             .handleMissingChipIds(input: $vm.missingPetChipIdInput)
+            .handleOnboarding()
             .handleTerminateInsurance(vm: vm.terminateInsuranceVm) {
                 dismissType in
                 switch dismissType {

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -14,6 +14,7 @@ import Home
 import InsuranceEvidence
 import Market
 import MoveFlow
+import Onboarding
 import Payment
 import Profile
 import SafariServices

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Onboarding
+import hCore
+
+@MainActor
+public class OnboardingClientOctopus: OnboardingClient {
+    public init() {}
+
+    public func getOnboardingSteps() async throws -> [OnboardingStep] {
+        OnboardingStepList.compute()
+    }
+}

--- a/Projects/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct OnboardingExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Onboarding Example")
+        }
+    }
+}

--- a/Projects/Onboarding/Project.swift
+++ b/Projects/Onboarding/Project.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.framework(
+    name: "Onboarding",
+    targets: Set([.framework, .example, .tests]),
+    projects: ["hCore", "hCoreUI", "Contracts", "EditStakeholders", "Payment", "Forever", "CrossSell"],
+    sdks: []
+)

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -1,0 +1,23 @@
+import Foundation
+import hCoreUI
+
+public enum OnboardingStep: Hashable, Sendable {
+    case welcome
+}
+
+@MainActor
+extension OnboardingStep {
+    /// Case identity, ignoring associated values — each case appears at most once per flow,
+    /// so screens can advance with a step rebuilt from the payload they were handed.
+    func matches(_ other: OnboardingStep) -> Bool {
+        nameForTracking == other.nameForTracking
+    }
+}
+
+extension OnboardingStep: TrackingViewNameProtocol {
+    public var nameForTracking: String {
+        switch self {
+        case .welcome: "OnboardingWelcome"
+        }
+    }
+}

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,0 +1,10 @@
+import Foundation
+import hCore
+
+public enum OnboardingStepList {
+    public static func compute() -> [OnboardingStep] {
+        [
+            .welcome
+        ]
+    }
+}

--- a/Projects/Onboarding/Sources/Navigation/OnboardingFlowLauncher.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingFlowLauncher.swift
@@ -1,0 +1,41 @@
+import AppStateContainer
+import Combine
+import Contracts
+import CrossSell
+import EditStakeholders
+import Payment
+import SwiftUI
+import hCore
+import hCoreUI
+
+extension View {
+    public func handleOnboarding() -> some View {
+        self.modifier(OnboardingFlowLauncher())
+    }
+}
+
+private struct OnboardingFlowLauncher: ViewModifier {
+    @State var onboardingStepsWrapper: OnboardingStepsWrapper?
+
+    public func body(content: Content) -> some View {
+        content
+            .modally(
+                item: $onboardingStepsWrapper,
+                options: .constant(.alwaysOpenOnTop)
+            ) { stepsWrapper in
+                OnboardingNavigation(steps: stepsWrapper.steps)
+            }
+            .task {
+                guard !OnboardingNavigationViewModel.hasSeenOnboarding else { return }
+                let service = OnboardingService()
+                if let steps = try? await service.getOnboardingSteps() {
+                    onboardingStepsWrapper = .init(id: UUID().uuidString, steps: steps)
+                }
+            }
+    }
+}
+
+private struct OnboardingStepsWrapper: Equatable, Identifiable {
+    let id: String
+    let steps: [OnboardingStep]
+}

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingNavigation: View {
+    @StateObject private var vm = OnboardingNavigationViewModel()
+
+    init(steps: [OnboardingStep]) {
+        let vm = OnboardingNavigationViewModel()
+        vm.steps = steps
+        _vm = StateObject(wrappedValue: vm)
+    }
+
+    var body: some View {
+        hNavigationStack(
+            router: vm.router,
+            options: [],
+            tracking: OnboardingStep.welcome
+        ) {
+            stepDestination(for: .welcome)
+                .routerDestination(for: OnboardingStep.self) { step in
+                    stepDestination(for: step)
+                }
+                .addStepProgressBar(with: $vm.progress)
+        }
+        .environmentObject(vm)
+    }
+
+    @ViewBuilder
+    private func stepDestination(for step: OnboardingStep) -> some View {
+        Group {
+            switch step {
+            case .welcome: OnboardingWelcomeScreen()
+            }
+        }
+        .withDismissButton {
+            OnboardingNavigationViewModel.setOnboardingToSeen()
+        }
+    }
+}
+
+#Preview {
+    Dependencies.shared.add(module: Module { () -> OnboardingClient in OnboardingClientDemo() })
+    let steps = OnboardingClientDemo.getSteps()
+    return OnboardingNavigation(steps: steps)
+}

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+@MainActor
+class OnboardingNavigationViewModel: ObservableObject {
+    private static let hasBeenPresentedKey = "onboarding_has_been_presented"
+    public static var hasSeenOnboarding: Bool {
+        UserDefaults.standard.bool(forKey: hasBeenPresentedKey) == true
+    }
+
+    static func setOnboardingToSeen() {
+        UserDefaults.standard.set(true, forKey: OnboardingNavigationViewModel.hasBeenPresentedKey)
+    }
+
+    let router = NavigationRouter()
+    let onboardingService = OnboardingService()
+    @Published var steps: [OnboardingStep] = [
+        .welcome
+    ]
+    {
+        didSet {
+            progress = .init(currentStep: progress.currentStep, totalSteps: steps.count)
+        }
+    }
+    @Published var progress = StepProgressModel(currentStep: 0, totalSteps: 0)
+
+    func advance(after step: OnboardingStep) {
+        guard let index = steps.firstIndex(where: { $0.matches(step) }), index + 1 < steps.count else {
+            router.dismiss()
+            OnboardingNavigationViewModel.setOnboardingToSeen()
+            return
+        }
+        router.push(steps[index + 1])
+    }
+
+    func updateProgress() {
+        let index = router.routeTypes.count
+        withAnimation { progress = .init(currentStep: index + 1, totalSteps: steps.count) }
+    }
+}

--- a/Projects/Onboarding/Sources/Screens/OnboardingWelcomeScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingWelcomeScreen.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingWelcomeScreen: View {
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+    @State private var showBadge = false
+    var body: some View {
+        hForm {
+            hSection {
+                VStack(spacing: .padding16) {
+                    logo
+                    VStack(spacing: .padding4) {
+                        hText("Welcome to Hedvig", style: .body1)  // TODO: L10n
+                            .accessibilityAddTraits(.isHeader)
+                        hText("Follow the steps to get started with your insurance", style: .body1)  // TODO: L10n
+                            .foregroundColor(hTextColor.Opaque.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                hButton(.large, .primary, content: .init(title: "Get started")) {  // TODO: L10n
+                    vm.advance(after: .welcome)
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .task {
+            await delay(2)
+            showBadge = true
+        }
+    }
+
+    private var logo: some View {
+        ZStack(alignment: .topTrailing) {
+            hCoreUIAssets.bigPillowBlack.view
+                .resizable()
+                .frame(width: 128, height: 128)
+            if showBadge {
+                Circle()
+                    .fill(hSignalColor.Red.element)
+                    .frame(width: 38, height: 38)
+                    .overlay {
+                        hText("1", style: .heading1)
+                            .foregroundColor(hTextColor.Opaque.white)
+                    }
+                    .offset(x: .padding6, y: -.padding6)
+                    .transition(.scale.animation(.bouncy))
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    OnboardingWelcomeScreen()
+        .environmentObject(OnboardingNavigationViewModel())
+}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -1,0 +1,16 @@
+import Foundation
+import hCore
+
+@MainActor
+public class OnboardingClientDemo: OnboardingClient {
+    public init() {}
+
+    public func getOnboardingSteps() async throws -> [OnboardingStep] {
+        await delay(1)
+        return OnboardingClientDemo.getSteps()
+    }
+
+    static func getSteps() -> [OnboardingStep] {
+        OnboardingStepList.compute()
+    }
+}

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -1,0 +1,15 @@
+import AutomaticLog
+import Foundation
+import hCore
+
+@MainActor
+public class OnboardingService {
+    @Inject var client: OnboardingClient
+
+    public init() {}
+
+    @Log
+    public func getOnboardingSteps() async throws -> [OnboardingStep] {
+        try await client.getOnboardingSteps()
+    }
+}

--- a/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
+++ b/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@MainActor
+public protocol OnboardingClient {
+    func getOnboardingSteps() async throws -> [OnboardingStep]
+}

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import hCore
+
+@testable import Onboarding
+
+final class OnboardingStepComputationTests: XCTestCase {
+    func testStaticStepsAlwaysPresent() {
+        let steps = OnboardingStepList.compute()
+        XCTAssertEqual(
+            steps,
+            [
+                .welcome
+            ]
+        )
+    }
+}

--- a/Projects/hCoreUI/Sources/Progress/ProgressBar.swift
+++ b/Projects/hCoreUI/Sources/Progress/ProgressBar.swift
@@ -78,3 +78,120 @@ struct ProgressBarView: ViewModifier {
         self.progressView = progress
     }
 }
+
+extension View {
+    public func addStepProgressBar(with progress: Binding<StepProgressModel>) -> some View {
+        self.modifier(StepProgressBarView(progress: progress))
+    }
+}
+
+public struct StepProgressModel: Equatable {
+    public let currentStep: Int
+    public let totalSteps: Int
+    public init(currentStep: Int, totalSteps: Int) {
+        self.currentStep = currentStep
+        self.totalSteps = totalSteps
+    }
+}
+
+struct StepProgressBarView: ViewModifier {
+    @Binding var progress: StepProgressModel
+    @State private var stackView: UIStackView?
+
+    init(
+        progress: Binding<StepProgressModel>
+    ) {
+        _progress = progress
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .introspect(.viewController, on: .iOS(.v13...)) { viewController in
+                let navigationController =
+                    (viewController as? UINavigationController)
+                    ?? viewController.navigationController
+                if let navigationController, stackView == nil {
+                    setupProgressView(for: navigationController)
+                    handleStackView(with: progress)
+                }
+            }
+            .onChange(of: progress) { newProgress in
+                handleStackView(with: newProgress)
+            }
+    }
+
+    private func handleStackView(with progress: StepProgressModel) {
+        if let stackView {
+            if stackView.subviews.count < progress.totalSteps && progress.totalSteps > 1 {
+                for i in 1...progress.totalSteps - stackView.subviews.count {
+                    let viewToAdd = UIView()
+                    viewToAdd.backgroundColor = .clear
+                    viewToAdd.layer.cornerRadius = 2
+                    stackView.addArrangedSubview(viewToAdd)
+                    if #available(iOS 18.0, *) {
+                        viewToAdd.anchorPoint = .init(x: 0.5, y: 0.5)
+                        Task { @MainActor in
+                            await delay(TimeInterval(i) * 0.2 + 0.1)
+                            UIView.animate(.bouncy) {
+                                viewToAdd.transform = .init(scaleX: 1.1, y: 1.8)
+                            }
+                            await delay(0.4)
+                            UIView.animate(.bouncy) {
+                                viewToAdd.transform = .identity
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stackView?.arrangedSubviews.enumerated()
+            .forEach { (index, element) in
+                UIView.animate(withDuration: 0.2) {
+                    if index + 1 == progress.currentStep {
+                        element.backgroundColor = UIColor(
+                            light: hFillColor.Opaque.primary.colorFor(.light, .base).color.uiColor(),
+                            dark: hFillColor.Opaque.primary.colorFor(.dark, .base).color.uiColor()
+                        )
+                    } else {
+                        element.backgroundColor = UIColor(
+                            light: hSurfaceColor.Opaque.secondary.colorFor(.light, .base).color.uiColor(),
+                            dark: hSurfaceColor.Opaque.secondary.colorFor(.dark, .base).color.uiColor()
+                        )
+                    }
+                }
+            }
+    }
+
+    private func setupProgressView(for navigationController: UINavigationController) {
+        let navBar = navigationController.navigationBar
+
+        let stackView = UIStackView()
+        stackView.spacing = 10
+        stackView.distribution = .fillEqually
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .regular)
+        DefaultStyling.applyCommonNavigationBarStyling(appearance)
+        appearance.shadowColor = UIColor(
+            light: hBorderColor.primary.colorFor(.light, .base).color.uiColor(),
+            dark: hBorderColor.primary.colorFor(.dark, .base).color.uiColor()
+        )
+
+        navBar.standardAppearance = appearance
+        navBar.scrollEdgeAppearance = appearance
+        stackView.isAccessibilityElement = true
+        stackView.accessibilityElementsHidden = true
+        navBar.addSubview(stackView)
+        let layoutGuide = navBar.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 80),
+            stackView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -80),
+            stackView.centerYAnchor.constraint(equalTo: layoutGuide.centerYAnchor),
+            stackView.heightAnchor.constraint(equalToConstant: 3),
+        ])
+        stackView.backgroundColor = .clear
+        self.stackView = stackView
+    }
+}

--- a/Projects/hCoreUI/Sources/View+dismissButton.swift
+++ b/Projects/hCoreUI/Sources/View+dismissButton.swift
@@ -4,13 +4,13 @@ import SwiftUI
 import hCore
 
 extension View {
-    public func withDismissButton() -> some View {
+    public func withDismissButton(action: (() -> Void)? = nil) -> some View {
         modifier(
-            DismissButton()
+            DismissButton(action: action)
         )
     }
 
-    public func withDismissButton(reducedTopSpacing: Int = 0) -> some View {
+    public func withDismissButton(reducedTopSpacing: Int) -> some View {
         modifier(DismissButton(reducedTopSpacing: reducedTopSpacing))
     }
 
@@ -50,6 +50,7 @@ private struct DismissButton: ViewModifier {
     let message: String?
     let confirmButtonTitle: String?
     let cancelButtonTitle: String?
+    let action: (() -> Void)?
     @EnvironmentObject var router: NavigationRouter
     @State var isAlertPresented = false
 
@@ -60,6 +61,7 @@ private struct DismissButton: ViewModifier {
         confirmButtonTitle: String? = nil,
         cancelButtonTitle: String? = nil,
         reducedTopSpacing: Int = 0,
+        action: (() -> Void)? = nil
     ) {
         self.reducedTopSpacing = reducedTopSpacing
         self.withAlert = withAlert
@@ -67,18 +69,21 @@ private struct DismissButton: ViewModifier {
         self.message = message
         self.confirmButtonTitle = confirmButtonTitle
         self.cancelButtonTitle = cancelButtonTitle
+        self.action = action
     }
 
     func body(content: Content) -> some View {
         content
             .toolbar {
                 ToolbarItem(
+                    id: "closeButton",
                     placement: .topBarTrailing
                 ) {
                     Button {
                         if withAlert {
                             isAlertPresented = true
                         } else {
+                            action?()
                             router.dismiss()
                         }
                     } label: {
@@ -99,7 +104,8 @@ private struct DismissButton: ViewModifier {
                         message: message,
                         confirmButton: confirmButtonTitle,
                         cancelButton: cancelButtonTitle,
-                        isPresented: $isAlertPresented
+                        isPresented: $isAlertPresented,
+                        action: action
                     )
                     .foregroundColor(hTextColor.Opaque.primary)
                     .accessibilityLabel(L10n.a11YClose)
@@ -115,7 +121,8 @@ extension View {
         message: String? = nil,
         confirmButton: String? = nil,
         cancelButton: String? = nil,
-        isPresented: Binding<Bool>
+        isPresented: Binding<Bool>,
+        action: (() -> Void)? = nil
     ) -> some View {
         modifier(
             DismissAlertPopup(
@@ -134,7 +141,7 @@ private struct DismissAlertPopup: ViewModifier {
     let message: String
     let confirmButton: String
     let cancelButton: String
-
+    let action: (() -> Void)?
     @Binding var isPresented: Bool
     @EnvironmentObject var router: NavigationRouter
 
@@ -143,13 +150,15 @@ private struct DismissAlertPopup: ViewModifier {
         message: String? = L10n.General.progressWillBeLostAlert,
         confirmButton: String = L10n.General.yes,
         cancelButton: String = L10n.General.no,
-        isPresented: Binding<Bool>
+        isPresented: Binding<Bool>,
+        action: (() -> Void)? = nil
     ) {
         self.title = title
         self.message = message ?? L10n.General.progressWillBeLostAlert
         self.confirmButton = confirmButton
         self.cancelButton = cancelButton
         self._isPresented = isPresented
+        self.action = action
     }
     func body(content: Content) -> some View {
         content
@@ -160,6 +169,7 @@ private struct DismissAlertPopup: ViewModifier {
                     }
                     Button(confirmButton, role: .destructive) {
                         router.dismiss()
+                        action?()
                     }
                 }
             } message: {


### PR DESCRIPTION
## What is happening here?

This PR creates the brand new **Onboarding** module and the first screen of the flow: a welcome screen for new members.

When a new member logs in for the first time, we want to guide them through a few setup steps. This PR lays the foundation for that — it adds the module itself, the step model (`OnboardingStep` / `OnboardingStepList`), navigation, the service layer (protocol + demo + Octopus implementations), DI registration, an example app, and the welcome screen that greets the member. After this PR the flow has exactly one step; the following PRs in the stack add one step each.
