### PR TITLE
feat: Onboarding - Phone number step (GEN-5511)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,12 +1,22 @@
 import Foundation
 import Onboarding
+import Profile
 import hCore
 
 @MainActor
 public class OnboardingClientOctopus: OnboardingClient {
+    @Inject private var profileClient: ProfileClient
+
     public init() {}
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
-        OnboardingStepList.compute()
+        let memberDetails = try await profileClient.getMemberDetails()
+        return OnboardingStepList.compute(
+            contactInfo: ContactInfo(phone: memberDetails.phone ?? "")
+        )
+    }
+
+    public func updateContactInfo(phone: String) async throws {
+        _ = try await profileClient.update(email: "", phone: phone)
     }
 }

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -17,6 +17,6 @@ public class OnboardingClientOctopus: OnboardingClient {
     }
 
     public func updateContactInfo(phone: String) async throws {
-        _ = try await profileClient.update(email: "", phone: phone)
+        try await profileClient.update(phone: phone)
     }
 }

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/ProfileClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/ProfileClientOctopus.swift
@@ -83,6 +83,15 @@ class ProfileClientOctopus: ProfileClient {
         throw ProfileError.error(message: L10n.General.errorBody)
     }
 
+    func update(phone: String) async throws {
+        let input = OctopusGraphQL.MemberUpdatePhoneNumberInput(phoneNumber: phone)
+        let mutation = OctopusGraphQL.MemberUpdatePhoneNumberMutation(input: input)
+        let data = try await octopus.client.mutation(mutation: mutation)
+        if let errorMessage = data?.memberUpdatePhoneNumber.userError?.message {
+            throw ProfileError.error(message: errorMessage)
+        }
+    }
+
     func update(eurobonus: String) async throws -> PartnerData {
         let input = OctopusGraphQL.MemberUpdateEurobonusNumberInput(eurobonusNumber: eurobonus)
         let mutation = OctopusGraphQL.UpdateEurobonusNumberMutation(input: input)

--- a/Projects/Onboarding/Project.swift
+++ b/Projects/Onboarding/Project.swift
@@ -4,6 +4,6 @@ import ProjectDescriptionHelpers
 let project = Project.framework(
     name: "Onboarding",
     targets: Set([.framework, .example, .tests]),
-    projects: ["hCore", "hCoreUI", "Contracts", "EditStakeholders", "Payment", "Forever", "CrossSell"],
+    projects: ["hCore", "hCoreUI", "Contracts", "EditStakeholders", "Payment", "Forever", "CrossSell", "Profile"],
     sdks: []
 )

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -4,6 +4,7 @@ import hCoreUI
 public enum OnboardingStep: Hashable, Sendable {
     case welcome
     case analyticsConsent
+    case phoneNumber(phoneNumber: String)
 }
 
 @MainActor
@@ -20,6 +21,7 @@ extension OnboardingStep: TrackingViewNameProtocol {
         switch self {
         case .welcome: "OnboardingWelcome"
         case .analyticsConsent: "OnboardingAnalyticsConsent"
+        case .phoneNumber: "OnboardingPhoneNumber"
         }
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,11 +1,22 @@
 import Foundation
 import hCore
 
+public struct ContactInfo: Equatable, Hashable, Sendable {
+    public let phone: String
+
+    public init(phone: String) {
+        self.phone = phone
+    }
+}
+
 public enum OnboardingStepList {
-    public static func compute() -> [OnboardingStep] {
+    public static func compute(
+        contactInfo: ContactInfo = .init(phone: "")
+    ) -> [OnboardingStep] {
         [
             .welcome,
             .analyticsConsent,
+            .phoneNumber(phoneNumber: contactInfo.phone),
         ]
     }
 }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -32,6 +32,8 @@ struct OnboardingNavigation: View {
             switch step {
             case .welcome: OnboardingWelcomeScreen()
             case .analyticsConsent: OnboardingAnalyticsScreen()
+            case let .phoneNumber(phoneNumber):
+                OnboardingPhoneScreen(phoneNumber: phoneNumber)
             }
         }
         .withDismissButton {

--- a/Projects/Onboarding/Sources/Screens/OnboardingPhoneScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingPhoneScreen.swift
@@ -1,0 +1,147 @@
+import Profile
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingPhoneScreen: View {
+    let phoneNumber: String
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+    @StateObject private var phoneVm = OnboardingPhoneViewModel()
+    let digits = [["1", "2", "3"], ["4", "5", "6"], ["7", "8", "9"], ["*", "0", "#"]]
+    @State private var animateDigits: [String] = []
+    var body: some View {
+        hForm {
+            hSection {
+                VStack(spacing: .padding8) {
+                    ForEach(digits, id: \.self) { row in
+                        HStack(spacing: .padding10) {
+                            ForEach(row, id: \.self) { digit in
+                                hText(digit)
+                                    .frame(width: 36, height: 36)
+                                    .background(getColor(for: digit))
+                                    .cornerRadius(.padding12)
+                                    .scaleEffect(animateDigits.contains(digit) ? 1.2 : 1)
+                                    .animation(.defaultSpring, value: animateDigits.contains(digit))
+                                    .onTapGesture {
+                                        if Int(digit) != nil {
+                                            phoneVm.phone.append(digit)
+                                        }
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .hFormTitle(
+            title: .init(.small, .body1, "Phone number", alignment: .leading),
+            subTitle: .init(
+                .small,
+                .body1,
+                "Add your phone number so we can reach you if something happens",
+                alignment: .leading
+            )
+        )
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                VStack(spacing: .padding8) {
+                    hFloatingTextField(
+                        masking: phoneVm.masking,
+                        value: $phoneVm.phone,
+                        equals: $phoneVm.focus,
+                        focusValue: .phone,
+                        placeholder: L10n.phoneNumberRowTitle,
+                        error: $phoneVm.error
+                    )
+
+                    hSaveButton(.primary) {
+                        if await phoneVm.save() {
+                            UIApplication.dismissKeyboard()
+                            vm.advance(after: .phoneNumber(phoneNumber: phoneNumber))
+                        }
+                    }
+                    .hButtonIsLoading(phoneVm.isLoading)
+                    hButton(.large, .ghost, content: .init(title: "Do this later")) {  // TODO: L10n
+                        UIApplication.dismissKeyboard()
+                        vm.advance(after: .phoneNumber(phoneNumber: phoneNumber))
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .disabled(phoneVm.isLoading)
+        .onAppear { phoneVm.prefill(phone: phoneNumber) }
+        .onChange(of: phoneVm.phone) { value in
+            if value.count < phoneVm.previousValue.count {
+            } else {
+                if let last = value.last {
+                    animateDigits.append(String(last))
+                }
+                Task {
+                    await delay(0.4)
+                    animateDigits.removeFirst()
+                }
+            }
+            phoneVm.previousValue = value
+        }
+    }
+
+    @hColorBuilder
+    private func getColor(for digit: String) -> some hColor {
+        if animateDigits.contains(digit) {
+            hSignalColor.Green.fill
+        } else {
+            hSurfaceColor.Translucent.secondary
+        }
+    }
+}
+
+private enum OnboardingPhoneField: hTextFieldFocusStateCompliant {
+    case phone
+    static let last: OnboardingPhoneField = .phone
+    var next: OnboardingPhoneField? { nil }
+}
+
+@MainActor
+class OnboardingPhoneViewModel: ObservableObject {
+    private let service = OnboardingService()
+    @Published var phone = ""
+    var previousValue = ""
+    @Published var isLoading = false
+    @Published var error: String?
+    let masking = Masking(type: .phoneNumber)
+    @Published fileprivate var focus: OnboardingPhoneField?
+
+    // NOTE: contact info arrives via the `.phoneNumber` step's payload (fetched once in
+    // getOnboardingSteps); updateContactInfo takes phone and the screen passes
+    func prefill(phone: String) {
+        if self.phone.isEmpty { self.phone = phone }
+    }
+
+    func save() async -> Bool {
+        withAnimation {
+            isLoading = true; error = nil
+        }
+        defer { withAnimation { isLoading = false } }
+        do {
+            if phone == "" {
+                throw MyInfoSaveError.phoneNumberEmpty
+            }
+            if !Masking(type: .phoneNumber).isValid(text: phone) {
+                throw MyInfoSaveError.phoneNumberMalformed
+            }
+            try await service.updateContactInfo(phone: phone)
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+}
+
+#Preview {
+    OnboardingPhoneScreen(phoneNumber: "0735328847")
+        .environmentObject(OnboardingNavigationViewModel())
+}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -10,7 +10,11 @@ public class OnboardingClientDemo: OnboardingClient {
         return OnboardingClientDemo.getSteps()
     }
 
+    public func updateContactInfo(phone: String) async throws {}
+
     static func getSteps() -> [OnboardingStep] {
-        OnboardingStepList.compute()
+        OnboardingStepList.compute(
+            contactInfo: .init(phone: "0735328847")
+        )
     }
 }

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -12,4 +12,9 @@ public class OnboardingService {
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         try await client.getOnboardingSteps()
     }
+
+    @Log
+    public func updateContactInfo(phone: String) async throws {
+        try await client.updateContactInfo(phone: phone)
+    }
 }

--- a/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
+++ b/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
@@ -3,4 +3,5 @@ import Foundation
 @MainActor
 public protocol OnboardingClient {
     func getOnboardingSteps() async throws -> [OnboardingStep]
+    func updateContactInfo(phone: String) async throws
 }

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -11,7 +11,15 @@ final class OnboardingStepComputationTests: XCTestCase {
             [
                 .welcome,
                 .analyticsConsent,
+                .phoneNumber(phoneNumber: ""),
             ]
         )
+    }
+
+    func testPhoneNumberStepCarriesContactInfo() {
+        let steps = OnboardingStepList.compute(
+            contactInfo: .init(phone: "0735328847")
+        )
+        XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
     }
 }

--- a/Projects/Profile/Sources/Service/DemoImplementation/ProfileClientDemo.swift
+++ b/Projects/Profile/Sources/Service/DemoImplementation/ProfileClientDemo.swift
@@ -45,5 +45,7 @@ public class ProfileClientDemo: ProfileClient {
         (email, phone)
     }
 
+    public func update(phone: String) async throws {}
+
     public func updateSubscriptionPreference(to _: Bool) async throws {}
 }

--- a/Projects/Profile/Sources/Service/Protocols/ProfileClient.swift
+++ b/Projects/Profile/Sources/Service/Protocols/ProfileClient.swift
@@ -10,6 +10,7 @@ public protocol ProfileClient {
     func updateLanguage() async throws
     func postDeleteRequest() async throws
     func update(email: String, phone: String) async throws -> (email: String, phone: String)
+    func update(phone: String) async throws
     func update(eurobonus: String) async throws -> PartnerData
     func updateSubscriptionPreference(to subscribed: Bool) async throws
 }

--- a/Projects/Profile/Sources/Views/Screens/MyInfo/MyInfoSaveError.swift
+++ b/Projects/Profile/Sources/Views/Screens/MyInfo/MyInfoSaveError.swift
@@ -1,7 +1,7 @@
 import Foundation
 import hCore
 
-enum MyInfoSaveError {
+public enum MyInfoSaveError {
     case emailEmpty
     case emailMalformed
     case phoneNumberEmpty
@@ -10,7 +10,7 @@ enum MyInfoSaveError {
 }
 
 extension MyInfoSaveError: LocalizedError {
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .phoneNumberEmpty: return L10n.myInfoPhoneNumberEmptyError
         case .phoneNumberMalformed: return L10n.myInfoPhoneNumberMalformedError

--- a/Projects/Profile/Tests/MockData.swift
+++ b/Projects/Profile/Tests/MockData.swift
@@ -36,6 +36,7 @@ struct MockData {
         memberUpdate: @escaping MemberUpdate = { email, phone in
             (email, phone)
         },
+        phoneUpdate: @escaping PhoneUpdate = { _ in },
         eurobonusUpdate: @escaping EurobonusUpdate = { eurobonus in
             let partnerData: PartnerData = .init(sas: .init(eligible: true, eurobonusNumber: eurobonus))
             return partnerData
@@ -48,6 +49,7 @@ struct MockData {
             languageUpdate: languageUpdate,
             deleteRequest: deleteRequest,
             memberUpdate: memberUpdate,
+            phoneUpdate: phoneUpdate,
             eurobonusUpdate: eurobonusUpdate,
             subscriptionPreferenceUpdate: subscriptionPreferenceUpdate
         )
@@ -63,6 +65,7 @@ typealias FetchMemberDetails = () async throws -> MemberDetails
 typealias LanguageUpdate = () async throws -> Void
 typealias DeleteRequest = () async throws -> Void
 typealias MemberUpdate = (String, String) async throws -> (email: String, phone: String)
+typealias PhoneUpdate = (String) async throws -> Void
 typealias EurobonusUpdate = (String) async throws -> PartnerData
 typealias SubscriptionPreferenceUpdate = (Bool) async throws -> Void
 
@@ -74,6 +77,7 @@ class MockProfileService: ProfileClient {
     var languageUpdate: LanguageUpdate
     var deleteRequest: DeleteRequest
     var memberUpdate: MemberUpdate
+    var phoneUpdate: PhoneUpdate
     var eurobonusUpdate: EurobonusUpdate
     var subscriptionPreferenceUpdate: SubscriptionPreferenceUpdate
 
@@ -83,6 +87,7 @@ class MockProfileService: ProfileClient {
         case updateLanguage
         case postDeleteRequest
         case memberUpdate
+        case updatePhone
         case updateEurobonus
         case updateSubscriptionPreference
     }
@@ -93,6 +98,7 @@ class MockProfileService: ProfileClient {
         languageUpdate: @escaping LanguageUpdate,
         deleteRequest: @escaping DeleteRequest,
         memberUpdate: @escaping MemberUpdate,
+        phoneUpdate: @escaping PhoneUpdate,
         eurobonusUpdate: @escaping EurobonusUpdate,
         subscriptionPreferenceUpdate: @escaping SubscriptionPreferenceUpdate
     ) {
@@ -101,6 +107,7 @@ class MockProfileService: ProfileClient {
         self.languageUpdate = languageUpdate
         self.deleteRequest = deleteRequest
         self.memberUpdate = memberUpdate
+        self.phoneUpdate = phoneUpdate
         self.eurobonusUpdate = eurobonusUpdate
         self.subscriptionPreferenceUpdate = subscriptionPreferenceUpdate
     }
@@ -134,6 +141,11 @@ class MockProfileService: ProfileClient {
         events.append(.memberUpdate)
         let data = try await memberUpdate(email, phone)
         return data
+    }
+
+    func update(phone: String) async throws {
+        events.append(.updatePhone)
+        try await phoneUpdate(phone)
     }
 
     func update(eurobonus: String) async throws -> Profile.PartnerData {

--- a/Projects/hGraphQL/GraphQL/Octopus/Profile/MemberUpdateContactInfo.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/Profile/MemberUpdateContactInfo.graphql
@@ -9,3 +9,11 @@ mutation MemberUpdateContactInfo($input: MemberUpdateContactInfoInput!) {
     }
   }
 }
+
+mutation MemberUpdatePhoneNumber($input: MemberUpdatePhoneNumberInput!) {
+  memberUpdatePhoneNumber(input: $input) {
+    userError {
+      message
+    }
+  }
+}


### PR DESCRIPTION
## What is happening here?

This PR adds the **phone number** step to the onboarding flow.

We ask the member to enter (or confirm) their phone number so we can reach them. The screen validates the input and saves the number to the backend through a new `OnboardingClient` method, with demo and Octopus implementations included.
