### PR TITLE
feat: Onboarding - Missing info steps: co-insured, co-owners, pet chip IDs (GEN-5511)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,3 +1,4 @@
+import Contracts
 import Foundation
 import Onboarding
 import Profile
@@ -5,13 +6,16 @@ import hCore
 
 @MainActor
 public class OnboardingClientOctopus: OnboardingClient {
+    @Inject private var contractsClient: FetchContractsClient
     @Inject private var profileClient: ProfileClient
 
     public init() {}
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
+        async let contractsStack = contractsClient.getContracts()
         let memberDetails = try await profileClient.getMemberDetails()
-        return OnboardingStepList.compute(
+        return try await OnboardingStepList.compute(
+            contracts: contractsStack.activeContracts + contractsStack.pendingContracts,
             contactInfo: ContactInfo(phone: memberDetails.phone ?? "")
         )
     }

--- a/Projects/Contracts/Sources/Models/ContractModels.swift
+++ b/Projects/Contracts/Sources/Models/ContractModels.swift
@@ -80,30 +80,6 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
         firstName + " " + lastName
     }
 
-    public var nbOfMissingCoInsured: Int {
-        coInsured.filter(\.hasMissingInfo).count
-    }
-
-    public var nbOfMissingCoOwners: Int {
-        coOwners.filter(\.hasMissingInfo).count
-    }
-
-    public var nbOfMissingCoInsuredWithoutTermination: Int {
-        coInsured.filter { $0.hasMissingInfo && $0.terminatesOn == nil }.count
-    }
-
-    public var nbOfMissingCoOwnersWithoutTermination: Int {
-        coOwners.filter { $0.hasMissingInfo && $0.terminatesOn == nil }.count
-    }
-
-    public var showEditCoInsuredInfo: Bool {
-        supportsCoInsured && terminationDate == nil
-    }
-
-    public var showEditCoOwnersInfo: Bool {
-        supportsCoOwners && terminationDate == nil
-    }
-
     @MainActor
     public var showEditInfo: Bool {
         EditType.getTypes(for: self).count > 0 && terminationDate == nil
@@ -204,6 +180,40 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
             }
         }
         return typeOfContract.pillowType
+    }
+}
+//MARK: coInsured + coOwners
+extension Contract {
+    public var nbOfMissingCoInsured: Int {
+        coInsured.filter(\.hasMissingInfo).count
+    }
+
+    public var nbOfMissingCoOwners: Int {
+        coOwners.filter(\.hasMissingInfo).count
+    }
+
+    public var hasMissingCoInsured: Bool {
+        coInsured.filter(\.hasMissingInfo).count > 0
+    }
+
+    public var hasMissingCoOwners: Bool {
+        coOwners.filter(\.hasMissingInfo).count > 0
+    }
+
+    public var nbOfMissingCoInsuredWithoutTermination: Int {
+        coInsured.filter { $0.hasMissingInfo && $0.terminatesOn == nil }.count
+    }
+
+    public var nbOfMissingCoOwnersWithoutTermination: Int {
+        coOwners.filter { $0.hasMissingInfo && $0.terminatesOn == nil }.count
+    }
+
+    public var showEditCoInsuredInfo: Bool {
+        supportsCoInsured && terminationDate == nil
+    }
+
+    public var showEditCoOwnersInfo: Bool {
+        supportsCoOwners && terminationDate == nil
     }
 }
 

--- a/Projects/Contracts/Sources/Service/Protocols/ContractsClient.swift
+++ b/Projects/Contracts/Sources/Service/Protocols/ContractsClient.swift
@@ -2,7 +2,7 @@ import Addons
 import Foundation
 
 @MainActor
-public protocol FetchContractsClient {
+public protocol FetchContractsClient: Sendable {
     func getContracts() async throws -> ContractsStack
     func getAddonBanners(source: AddonSource) async throws -> [AddonBanner]
 }

--- a/Projects/Contracts/Sources/View/MissingPetChipId/MissingPetChipIdsCoordinator.swift
+++ b/Projects/Contracts/Sources/View/MissingPetChipId/MissingPetChipIdsCoordinator.swift
@@ -157,7 +157,7 @@ class AddMissingPetChipIdViewModel: ObservableObject {
                     for: contract.id
                 )
                 await contractStore.fetchContracts()
-                NotificationCenter.default.post(name: .petChipIdAdded, object: nil)
+                NotificationCenter.default.post(name: .petChipIdAdded, object: contract.id)
                 Toasts.success()
                 dismiss()
             } catch let error as PetChipIdError {

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -1,3 +1,4 @@
+import Contracts
 import Foundation
 import hCoreUI
 
@@ -6,6 +7,9 @@ public enum OnboardingStep: Hashable, Sendable {
     case analyticsConsent
     case phoneNumber(phoneNumber: String)
     case theme
+    case coInsured(contracts: [OnboardingContract])
+    case coOwners(contracts: [OnboardingContract])
+    case petChipIds(contracts: [OnboardingContract])
 }
 
 @MainActor
@@ -24,6 +28,9 @@ extension OnboardingStep: TrackingViewNameProtocol {
         case .analyticsConsent: "OnboardingAnalyticsConsent"
         case .phoneNumber: "OnboardingPhoneNumber"
         case .theme: "OnboardingTheme"
+        case .coInsured: "OnboardingCoInsured"
+        case .coOwners: "OnboardingCoOwners"
+        case .petChipIds: "OnboardingPetChipIds"
         }
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,3 +1,4 @@
+import Contracts
 import Foundation
 import hCore
 
@@ -9,15 +10,44 @@ public struct ContactInfo: Equatable, Hashable, Sendable {
     }
 }
 
+/// A contract surfaced in an onboarding step, plus onboarding-local added-state.
+/// `missingData` is always true on init — cleared via the ViewModel's mark helpers once
+/// the member adds the missing info during onboarding.
+public struct OnboardingContract: Hashable, Identifiable, Sendable {
+    public let contract: Contracts.Contract
+    public var missingData: Bool
+
+    public var id: String { contract.id }
+
+    public init(contract: Contracts.Contract) {
+        self.contract = contract
+        self.missingData = true
+    }
+}
+
 public enum OnboardingStepList {
     public static func compute(
+        contracts: [Contracts.Contract],
         contactInfo: ContactInfo = .init(phone: "")
     ) -> [OnboardingStep] {
-        [
+        var steps: [OnboardingStep] = [
             .welcome,
             .analyticsConsent,
             .phoneNumber(phoneNumber: contactInfo.phone),
             .theme,
         ]
+        let coInsuredContracts = contracts.filter(\.hasMissingCoInsured).map(OnboardingContract.init)
+        if !coInsuredContracts.isEmpty {
+            steps.append(.coInsured(contracts: coInsuredContracts))
+        }
+        let coOwnerContracts = contracts.filter(\.hasMissingCoOwners).map(OnboardingContract.init)
+        if !coOwnerContracts.isEmpty {
+            steps.append(.coOwners(contracts: coOwnerContracts))
+        }
+        let contractsMissingPetChipId = contracts.filter(\.missingPetChipId).map(OnboardingContract.init)
+        if !contractsMissingPetChipId.isEmpty {
+            steps.append(.petChipIds(contracts: contractsMissingPetChipId))
+        }
+        return steps
     }
 }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -1,3 +1,5 @@
+import Contracts
+import EditStakeholders
 import SwiftUI
 import hCore
 import hCoreUI
@@ -24,6 +26,8 @@ struct OnboardingNavigation: View {
                 .addStepProgressBar(with: $vm.progress)
         }
         .environmentObject(vm)
+        .handleEditStakeholders(with: vm.editStakeholdersVm)
+        .handleMissingChipIds(input: $vm.missingPetChipIdInput)
     }
 
     @ViewBuilder
@@ -35,6 +39,9 @@ struct OnboardingNavigation: View {
             case let .phoneNumber(phoneNumber):
                 OnboardingPhoneScreen(phoneNumber: phoneNumber)
             case .theme: OnboardingThemeScreen()
+            case .coInsured: OnboardingMissingInfoScreen(type: .coInsured)
+            case .coOwners: OnboardingMissingInfoScreen(type: .coOwner)
+            case .petChipIds: OnboardingMissingInfoScreen(type: .petChipIds)
             }
         }
         .withDismissButton {

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
@@ -1,3 +1,6 @@
+import AppStateContainer
+import Contracts
+import EditStakeholders
 import SwiftUI
 import hCore
 import hCoreUI
@@ -15,6 +18,7 @@ class OnboardingNavigationViewModel: ObservableObject {
 
     let router = NavigationRouter()
     let onboardingService = OnboardingService()
+    let editStakeholdersVm: EditStakeholdersViewModel
     @Published var steps: [OnboardingStep] = [
         .welcome
     ]
@@ -24,6 +28,13 @@ class OnboardingNavigationViewModel: ObservableObject {
         }
     }
     @Published var progress = StepProgressModel(currentStep: 0, totalSteps: 0)
+
+    @Published var missingPetChipIdInput: MissingPetChipIdInput?
+
+    init() {
+        let contractStore: ContractStore = globalAppStateContainer.get()
+        editStakeholdersVm = .init(existingStakeholders: contractStore)
+    }
 
     func advance(after step: OnboardingStep) {
         guard let index = steps.firstIndex(where: { $0.matches(step) }), index + 1 < steps.count else {
@@ -37,5 +48,47 @@ class OnboardingNavigationViewModel: ObservableObject {
     func updateProgress() {
         let index = router.routeTypes.count
         withAnimation { progress = .init(currentStep: index + 1, totalSteps: steps.count) }
+    }
+}
+
+// MARK: - Co-insured & co-owner steps
+extension OnboardingNavigationViewModel {
+    /// A stakeholder was added for `contractId` — clear `missingData` on that contract in
+    /// the matching step, so the screen (which reads its contracts from `steps`) shows the
+    /// added checkmark.
+    func markStakeholderAdded(contractId: String, type: StakeholderType) {
+        steps = steps.map { step in
+            switch (type, step) {
+            case let (.coInsured, .coInsured(contracts)):
+                return .coInsured(contracts: contracts.markingAdded(contractId: contractId))
+            case let (.coOwner, .coOwners(contracts)):
+                return .coOwners(contracts: contracts.markingAdded(contractId: contractId))
+            default:
+                return step
+            }
+        }
+    }
+}
+
+// MARK: - Pet chip id step
+extension OnboardingNavigationViewModel {
+    /// A pet chip id was added for `contractId` — clear `missingData` on that contract
+    /// in the step, so the screen (which reads its contracts from `steps`) shows the
+    /// added checkmark.
+    func markPetChipIdAdded(contractId: String) {
+        steps = steps.map { step in
+            guard case let .petChipIds(contracts) = step else { return step }
+            return .petChipIds(contracts: contracts.markingAdded(contractId: contractId))
+        }
+    }
+}
+
+extension [OnboardingContract] {
+    fileprivate func markingAdded(contractId: String) -> [OnboardingContract] {
+        map { contract in
+            var contract = contract
+            if contract.id == contractId { contract.missingData = false }
+            return contract
+        }
     }
 }

--- a/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
@@ -1,0 +1,253 @@
+import Contracts
+import EditStakeholders
+import SwiftUI
+import hCore
+import hCoreUI
+
+enum OnboardingMissingInfoType {
+    case coInsured
+    case coOwner
+    case petChipIds
+
+    /// The stakeholder edit flow this type maps to, if any.
+    var stakeholderType: StakeholderType? {
+        switch self {
+        case .coInsured: .coInsured
+        case .coOwner: .coOwner
+        case .petChipIds: nil
+        }
+    }
+}
+
+struct OnboardingMissingInfoScreen: View {
+    let type: OnboardingMissingInfoType
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+
+    private var step: OnboardingStep {
+        switch type {
+        case .coInsured: .coInsured(contracts: contracts)
+        case .coOwner: .coOwners(contracts: contracts)
+        case .petChipIds: .petChipIds(contracts: contracts)
+        }
+    }
+
+    /// Read from `vm.steps` rather than the pushed payload, so contracts marked as added
+    /// (`missingData` cleared) re-render with the checkmark.
+    private var contracts: [OnboardingContract] {
+        for step in vm.steps {
+            if case let .coInsured(contracts) = step, type == .coInsured { return contracts }
+            if case let .coOwners(contracts) = step, type == .coOwner { return contracts }
+            if case let .petChipIds(contracts) = step, type == .petChipIds { return contracts }
+        }
+        return []
+    }
+
+    private var headerTitle: String {
+        switch type {
+        case .coInsured: "Add co-insured"  // TODO: L10n
+        case .coOwner: "Add co-owners"  // TODO: L10n
+        case .petChipIds: "Add your pets ID numbers"  // TODO: L10n
+        }
+    }
+
+    private var subtitle: String {
+        switch type {
+        case .coInsured, .coOwner: "So we know who's covered by your insurance"  // TODO: L10n
+        case .petChipIds: "This makes it easier to help you if something happens"  // TODO: L10n
+        }
+    }
+
+    var body: some View {
+        hForm {
+            hSection(contracts) { onboardingContract in
+                hRow {
+                    ContractInformation(
+                        title: onboardingContract.contract.currentAgreement?.productVariant.displayName,
+                        subtitle: onboardingContract.contract.exposureDisplayNameShort,
+                        pillowImage: onboardingContract.contract.pillowType?.bgImage
+                    )
+                }
+                .withCustomAccessory {
+                    if !onboardingContract.missingData {
+                        hCoreUIAssets.checkmark.view
+                            .foregroundColor(hSignalColor.Green.element)
+                            // TODO: L10n
+                            .accessibilityLabel(
+                                "Added" + ", " + onboardingContract.contract.exposureDisplayNameShort
+                            )
+                    } else {
+                        hButton(.small, .secondary, content: .init(title: L10n.generalAddButton)) {
+                            add(onboardingContract)
+                        }
+                        .accessibilityLabel(
+                            L10n.generalAddButton + ", " + onboardingContract.contract.exposureDisplayNameShort
+                        )
+                    }
+                }
+            }
+        }
+        .hFormTitle(
+            title: .init(.small, .body1, headerTitle, alignment: .leading),
+            subTitle: .init(
+                .small,
+                .body1,
+                subtitle,
+                alignment: .leading
+            )
+        )
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                VStack(spacing: .padding16) {
+                    hText("You can add this information later", style: .label)  // TODO: L10n
+                        .foregroundColor(hTextColor.Opaque.secondary)
+                    VStack(spacing: .padding8) {
+                        hContinueButton { vm.advance(after: step) }
+                        hButton(.large, .secondary, content: .init(title: "Do this later")) {  // TODO: L10n
+                            vm.advance(after: step)
+                        }
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .onReceive(EditStakeholdersViewModel.updatedStakeholderForContractId) { contractId in
+            guard let contractId, let stakeholderType = type.stakeholderType else { return }
+            vm.markStakeholderAdded(contractId: contractId, type: stakeholderType)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .petChipIdAdded)) { notification in
+            guard type == .petChipIds, let contractId = notification.object as? String else { return }
+            vm.markPetChipIdAdded(contractId: contractId)
+        }
+    }
+
+    private func add(_ onboardingContract: OnboardingContract) {
+        switch type {
+        case .coInsured, .coOwner:
+            guard let stakeholderType = type.stakeholderType else { return }
+            let contract: StakeholdersConfig = .init(
+                contract: onboardingContract.contract,
+                stakeholderType: stakeholderType,
+                fromInfoCard: true
+            )
+            vm.editStakeholdersVm.start(fromContract: contract)
+        case .petChipIds:
+            vm.missingPetChipIdInput = .init(contracts: [onboardingContract.contract])
+        }
+    }
+}
+
+#Preview("Co insured") {
+    OnboardingMissingInfoScreen(type: .coInsured)
+        .environmentObject(
+            {
+                let vm = OnboardingNavigationViewModel()
+                vm.steps = [
+                    .coInsured(contracts: [
+                        .init(contract: .mock(id: "id1", exposureName: "Bellmansgatan 19")),
+                        .init(contract: .mock(id: "id2", exposureName: "Bellmansgatan 19 2")),
+                    ])
+                ]
+                return vm
+            }()
+        )
+        .task {
+            await delay(1)
+            EditStakeholdersViewModel.updatedStakeholderForContractId.send("id1")
+            await delay(2)
+            EditStakeholdersViewModel.updatedStakeholderForContractId.send("id2")
+        }
+}
+
+#Preview("Co Owners") {
+    OnboardingMissingInfoScreen(type: .coOwner)
+        .environmentObject(
+            {
+                let vm = OnboardingNavigationViewModel()
+                vm.steps = [
+                    .coOwners(contracts: [
+                        .init(contract: .mock(id: "id1", exposureName: "Bellmansgatan 19")),
+                        .init(contract: .mock(id: "id2", exposureName: "Bellmansgatan 19 2")),
+                    ])
+                ]
+                return vm
+            }()
+        )
+        .task {
+            await delay(1)
+            EditStakeholdersViewModel.updatedStakeholderForContractId.send("id1")
+            await delay(2)
+            EditStakeholdersViewModel.updatedStakeholderForContractId.send("id2")
+        }
+}
+
+#Preview("Pet chip ids") {
+    OnboardingMissingInfoScreen(type: .petChipIds)
+        .environmentObject(
+            {
+                let vm = OnboardingNavigationViewModel()
+                vm.steps = [
+                    .petChipIds(contracts: [
+                        .init(contract: .mock(id: "id1", exposureName: "Fido", typeOfContract: .seDogStandard)),
+                        .init(contract: .mock(id: "id2", exposureName: "Rex", typeOfContract: .seDogBasic)),
+                    ])
+                ]
+                return vm
+            }()
+        )
+        .task {
+            await delay(1)
+            NotificationCenter.default.post(name: .petChipIdAdded, object: "id1")
+            await delay(2)
+            NotificationCenter.default.post(name: .petChipIdAdded, object: "id2")
+        }
+}
+
+@MainActor
+extension Contracts.Contract {
+    fileprivate static func mock(
+        id: String,
+        exposureName: String,
+        typeOfContract: TypeOfContract = .seHouse
+    ) -> Contracts.Contract {
+        .init(
+            id: id,
+            currentAgreement: .init(
+                id: id,
+                basePremium: .sek(100),
+                itemCost: nil,
+                displayItems: [],
+                productVariant: .init(
+                    termsVersion: "",
+                    typeOfContract: typeOfContract.rawValue,
+                    perils: [],
+                    insurableLimits: [],
+                    documents: [],
+                    displayName: "display name",
+                    displayNameTier: "display name tier",
+                    tierDescription: "tier description"
+                ),
+                addonVariant: []
+            ),
+            exposureDisplayName: exposureName,
+            exposureDisplayNameShort: exposureName,
+            masterInceptionDate: nil,
+            terminationDate: nil,
+            supportsAddressChange: true,
+            supportsCoInsured: true,
+            supportsCoOwners: true,
+            supportsTravelCertificate: true,
+            supportsChangeTier: true,
+            supportsTermination: true,
+            upcomingChangedAgreement: nil,
+            upcomingRenewal: nil,
+            firstName: "first name",
+            lastName: "last name",
+            ssn: "ssn",
+            typeOfContract: typeOfContract,
+            coInsured: [.init(needsMissingInfo: true)],
+            coOwners: [.init(needsMissingInfo: true)],
+            missingPetChipId: true
+        )
+    }
+}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -1,3 +1,4 @@
+import Contracts
 import Foundation
 import hCore
 
@@ -14,6 +15,31 @@ public class OnboardingClientDemo: OnboardingClient {
 
     static func getSteps() -> [OnboardingStep] {
         OnboardingStepList.compute(
+            contracts: [
+                .init(
+                    id: "id1",
+                    currentAgreement: nil,
+                    exposureDisplayName: "exposure 1",
+                    exposureDisplayNameShort: "exsposure 1 short",
+                    masterInceptionDate: nil,
+                    terminationDate: nil,
+                    supportsAddressChange: true,
+                    supportsCoInsured: true,
+                    supportsCoOwners: true,
+                    supportsTravelCertificate: true,
+                    supportsChangeTier: true,
+                    supportsTermination: true,
+                    upcomingChangedAgreement: nil,
+                    upcomingRenewal: nil,
+                    firstName: "first name",
+                    lastName: "last name",
+                    ssn: "ssn",
+                    typeOfContract: .seHouse,
+                    coInsured: [.init(needsMissingInfo: true)],
+                    coOwners: [.init(needsMissingInfo: true)],
+                    missingPetChipId: true
+                )
+            ],
             contactInfo: .init(phone: "0735328847")
         )
     }

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -1,11 +1,14 @@
+import Contracts
+import EditStakeholders
 import XCTest
 import hCore
 
 @testable import Onboarding
 
+@MainActor
 final class OnboardingStepComputationTests: XCTestCase {
     func testStaticStepsAlwaysPresent() {
-        let steps = OnboardingStepList.compute()
+        let steps = OnboardingStepList.compute(contracts: [])
         XCTAssertEqual(
             steps,
             [
@@ -19,8 +22,101 @@ final class OnboardingStepComputationTests: XCTestCase {
 
     func testPhoneNumberStepCarriesContactInfo() {
         let steps = OnboardingStepList.compute(
+            contracts: [],
             contactInfo: .init(phone: "0735328847")
         )
         XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
+    }
+
+    func testCoInsuredStepShownWhenContractHasMissingCoInsured() {
+        let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: true)])
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertTrue(steps.contains(.coInsured(contracts: [.init(contract: contract)])))
+    }
+
+    func testCoInsuredStepHiddenWhenNoCoInsuredIsMissingInfo() {
+        let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: false)])
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertFalse(steps.contains { $0.matches(.coInsured(contracts: [])) })
+    }
+
+    func testCoOwnersStepShownWhenContractHasMissingCoOwners() {
+        let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: true)])
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertTrue(steps.contains(.coOwners(contracts: [.init(contract: contract)])))
+    }
+
+    func testCoOwnersStepHiddenWhenNoCoOwnerIsMissingInfo() {
+        let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: false)])
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertFalse(steps.contains { $0.matches(.coOwners(contracts: [])) })
+    }
+
+    func testPetChipIdsStepShownWithContractsWhenContractIsMissingPetChipId() {
+        let contract = Self.makeContract(missingPetChipId: true)
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertTrue(steps.contains(.petChipIds(contracts: [.init(contract: contract)])))
+    }
+
+    func testPetChipIdsStepHiddenWhenNoContractIsMissingPetChipId() {
+        let contract = Self.makeContract(missingPetChipId: false)
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertFalse(steps.contains { $0.matches(.petChipIds(contracts: [])) })
+    }
+
+    func testAllStepsShownInOrderWhenEveryConditionApplies() {
+        let contract = Self.makeContract(
+            coInsured: [.init(needsMissingInfo: true)],
+            coOwners: [.init(needsMissingInfo: true)],
+            missingPetChipId: true
+        )
+        let steps = OnboardingStepList.compute(contracts: [contract])
+        XCTAssertEqual(
+            steps,
+            [
+                .welcome,
+                .analyticsConsent,
+                .phoneNumber(phoneNumber: ""),
+                .theme,
+                .coInsured(contracts: [.init(contract: contract)]),
+                .coOwners(contracts: [.init(contract: contract)]),
+                .petChipIds(contracts: [.init(contract: contract)]),
+            ]
+        )
+    }
+}
+
+extension OnboardingStepComputationTests {
+    /// `Contract`'s memberwise init has 22 parameters; this factory supplies sensible
+    /// defaults so gating tests only need to spell out the fields they exercise.
+    fileprivate static func makeContract(
+        coInsured: [Stakeholder] = [],
+        coOwners: [Stakeholder] = [],
+        missingPetChipId: Bool = false,
+        terminationDate: String? = nil
+    ) -> Contracts.Contract {
+        .init(
+            id: "contractId",
+            currentAgreement: nil,
+            exposureDisplayName: "Home",
+            exposureDisplayNameShort: "Home",
+            masterInceptionDate: nil,
+            terminationDate: terminationDate,
+            supportsAddressChange: false,
+            supportsCoInsured: true,
+            supportsCoOwners: true,
+            supportsTravelCertificate: false,
+            supportsChangeTier: false,
+            supportsTermination: false,
+            upcomingChangedAgreement: nil,
+            upcomingRenewal: nil,
+            firstName: "First",
+            lastName: "Last",
+            ssn: nil,
+            typeOfContract: .seApartmentRent,
+            coInsured: coInsured,
+            coOwners: coOwners,
+            missingPetChipId: missingPetChipId
+        )
     }
 }


### PR DESCRIPTION
## What is happening here?

This PR adds the **missing info** steps to the onboarding flow.

Some members have gaps in their insurance data — co-insured people without full details, missing co-owners of the home, or pets without a chip ID. During onboarding we now detect these gaps from the member's contracts and show a step for each one, sending the member into the existing edit flows to fill them in. The step only appears if the member actually has something missing.
