### PR TITLE
feat: Onboarding - Invite friend step (GEN-5511)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,4 +1,5 @@
 import Contracts
+import Forever
 import Foundation
 import Onboarding
 import Profile
@@ -8,15 +9,20 @@ import hCore
 public class OnboardingClientOctopus: OnboardingClient {
     @Inject private var contractsClient: FetchContractsClient
     @Inject private var profileClient: ProfileClient
+    @Inject private var foreverClient: ForeverClient
 
     public init() {}
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         async let contractsStack = contractsClient.getContracts()
+        async let foreverData = foreverClient.getMemberReferralInformation()
         let memberDetails = try await profileClient.getMemberDetails()
         return try await OnboardingStepList.compute(
             contracts: contractsStack.activeContracts + contractsStack.pendingContracts,
-            contactInfo: ContactInfo(phone: memberDetails.phone ?? "")
+            contactInfo: ContactInfo(phone: memberDetails.phone ?? ""),
+            // Non-blocking: a failed referral fetch must not sink onboarding — the invite
+            // step just renders without amount and share button.
+            foreverData: try? foreverData
         )
     }
 

--- a/Projects/Forever/Sources/Models/ForeverModel.swift
+++ b/Projects/Forever/Sources/Models/ForeverModel.swift
@@ -81,10 +81,10 @@ public struct ForeverData: Codable, Equatable, Sendable {
     let netAmount: MonetaryAmount
     let monthlyDiscount: MonetaryAmount
     let otherDiscounts: MonetaryAmount?
-    var discountCode: String
+    public internal(set) var discountCode: String
     let referrals: [Referral]
     let referredBy: Referral?
-    let monthlyDiscountPerReferral: MonetaryAmount
+    public let monthlyDiscountPerReferral: MonetaryAmount
 
     public mutating func updateDiscountCode(_ newValue: String) { discountCode = newValue }
 }

--- a/Projects/Forever/Sources/Service/Protocols/ForeverClient.swift
+++ b/Projects/Forever/Sources/Service/Protocols/ForeverClient.swift
@@ -1,5 +1,5 @@
 @MainActor
-public protocol ForeverClient {
+public protocol ForeverClient: Sendable {
     func getMemberReferralInformation() async throws -> ForeverData
     func changeCode(code: String) async throws
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -10,6 +10,7 @@ public enum OnboardingStep: Hashable, Sendable {
     case coInsured(contracts: [OnboardingContract])
     case coOwners(contracts: [OnboardingContract])
     case petChipIds(contracts: [OnboardingContract])
+    case inviteFriend(discountCode: String, monthlyDiscountPerReferral: String)
 }
 
 @MainActor
@@ -31,6 +32,7 @@ extension OnboardingStep: TrackingViewNameProtocol {
         case .coInsured: "OnboardingCoInsured"
         case .coOwners: "OnboardingCoOwners"
         case .petChipIds: "OnboardingPetChipIds"
+        case .inviteFriend: "OnboardingInviteFriend"
         }
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,4 +1,5 @@
 import Contracts
+import Forever
 import Foundation
 import hCore
 
@@ -28,7 +29,8 @@ public struct OnboardingContract: Hashable, Identifiable, Sendable {
 public enum OnboardingStepList {
     public static func compute(
         contracts: [Contracts.Contract],
-        contactInfo: ContactInfo = .init(phone: "")
+        contactInfo: ContactInfo = .init(phone: ""),
+        foreverData: ForeverData? = nil
     ) -> [OnboardingStep] {
         var steps: [OnboardingStep] = [
             .welcome,
@@ -47,6 +49,14 @@ public enum OnboardingStepList {
         let contractsMissingPetChipId = contracts.filter(\.missingPetChipId).map(OnboardingContract.init)
         if !contractsMissingPetChipId.isEmpty {
             steps.append(.petChipIds(contracts: contractsMissingPetChipId))
+        }
+        if let foreverData {
+            steps.append(
+                .inviteFriend(
+                    discountCode: foreverData.discountCode,
+                    monthlyDiscountPerReferral: foreverData.monthlyDiscountPerReferral.formattedAmount
+                )
+            )
         }
         return steps
     }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -42,6 +42,11 @@ struct OnboardingNavigation: View {
             case .coInsured: OnboardingMissingInfoScreen(type: .coInsured)
             case .coOwners: OnboardingMissingInfoScreen(type: .coOwner)
             case .petChipIds: OnboardingMissingInfoScreen(type: .petChipIds)
+            case let .inviteFriend(discountCode, monthlyDiscountPerReferral):
+                OnboardingInviteScreen(
+                    discountCode: discountCode,
+                    monthlyDiscountPerReferral: monthlyDiscountPerReferral
+                )
             }
         }
         .withDismissButton {

--- a/Projects/Onboarding/Sources/Screens/OnboardingInviteScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingInviteScreen.swift
@@ -1,0 +1,124 @@
+import Environment
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingInviteScreen: View {
+    let discountCode: String
+    let monthlyDiscountPerReferral: String
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+    @State private var modalPresentationSourceWrapperViewModel = ModalPresentationSourceWrapperViewModel()
+    @State private var namesToDisplay: [String] = []
+    private var subtitle: String {
+        if !monthlyDiscountPerReferral.isEmpty {
+            // TODO: L10n
+            return "With Hedvig Forever, you get \(monthlyDiscountPerReferral) off for every friend you invite."
+        }
+        return "With Hedvig Forever, you get a discount off for every friend you invite."  // TODO: L10n
+    }
+
+    var body: some View {
+        hForm {
+            centerContent
+        }
+        .hFormTitle(
+            title: .init(.small, .body1, "Invite a friend", alignment: .leading),
+            subTitle: .init(
+                .small,
+                .body1,
+                subtitle,
+                alignment: .leading
+            )
+        )
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                VStack(spacing: .padding8) {
+                    if !discountCode.isEmpty {
+                        ModalPresentationSourceWrapper(
+                            content: {
+                                hButton(
+                                    .large,
+                                    .secondary,
+                                    content: .init(title: "Invite a friend")  // TODO: L10n
+                                ) {
+                                    shareCode(code: discountCode)
+                                }
+                            },
+                            vm: modalPresentationSourceWrapperViewModel
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+                    hContinueButton {
+                        vm.advance(
+                            after: .inviteFriend(
+                                discountCode: discountCode,
+                                monthlyDiscountPerReferral: monthlyDiscountPerReferral
+                            )
+                        )
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .task {
+            namesToDisplay = []
+            await delay(0.5)
+            for name in ["Elin", "Hampus", "Li", "Peter"] {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                    namesToDisplay.append(name)
+                }
+                await delay(1)
+            }
+        }
+    }
+
+    private var centerContent: some View {
+        hSection(namesToDisplay, id: \.self) { element in
+            hRow {
+                Circle()
+                    .foregroundColor(hSignalColor.Green.element)
+                    .frame(width: 14, height: 14)
+                hText(element)
+                Spacer()
+                hText("-10kr")
+            }
+
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+        .clipped()
+        .hWithoutHorizontalPadding(.row)
+        .sectionContainerStyle(.transparent)
+        .hRowContentAlignment(.center)
+        .background() {
+            RoundedRectangle(cornerRadius: .padding24)
+                .fill(hFillColor.Opaque.negative)
+                .hShadow(type: .custom(opacity: 0.05, radius: 5, xOffset: 0, yOffset: 4), show: true)
+                .hShadow(type: .custom(opacity: 0.1, radius: 1, xOffset: 0, yOffset: 2), show: true)
+                .overlay(
+                    RoundedRectangle(cornerRadius: .padding24)
+                        .inset(by: 0.5)
+                        .stroke(hBorderColor.secondary, lineWidth: 1)
+                )
+        }
+        .padding(.horizontal, 72)
+        .accessibilityHidden(true)
+    }
+
+    private func shareCode(code: String) {
+        let url =
+            "\(Environment.current.webBaseURL)/\(hCore.Localization.Locale.currentLocale.value.webPath)/forever/\(code)"
+        let message = L10n.referralSmsMessage(monthlyDiscountPerReferral, url)
+
+        let activityVC = UIActivityViewController(
+            activityItems: [message as Any],
+            applicationActivities: nil
+        )
+        modalPresentationSourceWrapperViewModel.present(activity: activityVC)
+    }
+}
+
+#Preview {
+    OnboardingInviteScreen(discountCode: "HEDVIG", monthlyDiscountPerReferral: "10 kr")
+        .environmentObject(OnboardingNavigationViewModel())
+}

--- a/Projects/Onboarding/Sources/Screens/OnboardingInviteScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingInviteScreen.swift
@@ -64,7 +64,7 @@ struct OnboardingInviteScreen: View {
         .task {
             namesToDisplay = []
             await delay(0.5)
-            for name in ["Elin", "Hampus", "Li", "Peter"] {
+            for name in ["Elin", "Hampus", "Li"] {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                     namesToDisplay.append(name)
                 }

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -28,6 +28,28 @@ final class OnboardingStepComputationTests: XCTestCase {
         XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
     }
 
+    func testInviteFriendStepShownWhenForeverDataExists() {
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            foreverData: .init(
+                grossAmount: .init(amount: "100", currency: "SEK"),
+                netAmount: .init(amount: "90", currency: "SEK"),
+                otherDiscounts: nil,
+                discountCode: "CODE",
+                monthlyDiscount: .init(amount: "10", currency: "SEK"),
+                referrals: [],
+                referredBy: nil,
+                monthlyDiscountPerReferral: .init(amount: "10", currency: "SEK")
+            )
+        )
+        XCTAssertTrue(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
+    }
+
+    func testInviteFriendStepHiddenWithoutForeverData() {
+        let steps = OnboardingStepList.compute(contracts: [])
+        XCTAssertFalse(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
+    }
+
     func testCoInsuredStepShownWhenContractHasMissingCoInsured() {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: true)])
         let steps = OnboardingStepList.compute(contracts: [contract])


### PR DESCRIPTION
## What is happening here?

This PR adds the **invite a friend** step to the onboarding flow.

We show the member their Forever referral code and let them share it, so they can invite friends and both get a discount. The screen reuses the existing Forever referral data through the `ForeverClient`.
