### PR TITLE
feat: Onboarding - Connect payment step (GEN-5511)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -27,8 +27,7 @@ public class OnboardingClientOctopus: OnboardingClient {
             contactInfo: ContactInfo(phone: memberDetails.phone ?? ""),
             // Non-blocking: a failed referral fetch must not sink onboarding — the invite
             // step just renders without amount and share button.
-            foreverData: try? foreverData,
-            isConnectPaymentEnabled: Dependencies.featureFlags().isConnectPaymentEnabled
+            foreverData: try? foreverData
         )
     }
 

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,13 +1,16 @@
+import AppStateContainer
 import Contracts
 import Forever
 import Foundation
 import Onboarding
+import Payment
 import Profile
 import hCore
 
 @MainActor
 public class OnboardingClientOctopus: OnboardingClient {
     @Inject private var contractsClient: FetchContractsClient
+    @Inject private var paymentClient: hPaymentClient
     @Inject private var profileClient: ProfileClient
     @Inject private var foreverClient: ForeverClient
 
@@ -15,18 +18,30 @@ public class OnboardingClientOctopus: OnboardingClient {
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         async let contractsStack = contractsClient.getContracts()
+        async let paymentStatus = paymentClient.getPaymentStatusData()
         async let foreverData = foreverClient.getMemberReferralInformation()
         let memberDetails = try await profileClient.getMemberDetails()
         return try await OnboardingStepList.compute(
             contracts: contractsStack.activeContracts + contractsStack.pendingContracts,
+            isPaymentConnected: paymentStatus.status != .needsSetup,
             contactInfo: ContactInfo(phone: memberDetails.phone ?? ""),
             // Non-blocking: a failed referral fetch must not sink onboarding — the invite
             // step just renders without amount and share button.
-            foreverData: try? foreverData
+            foreverData: try? foreverData,
+            isConnectPaymentEnabled: Dependencies.featureFlags().isConnectPaymentEnabled
         )
     }
 
     public func updateContactInfo(phone: String) async throws {
         try await profileClient.update(phone: phone)
+    }
+
+    public func getIsPaymentConnected() async throws -> Bool {
+        let paymentStore: PaymentStore = globalAppStateContainer.get()
+        await paymentStore.fetchPaymentStatus()
+        if let paymentStatusData = paymentStore.paymentStatusData {
+            return paymentStatusData.status != .needsSetup
+        }
+        return false
     }
 }

--- a/Projects/Home/Tests/MockFeatureFlagsClient.swift
+++ b/Projects/Home/Tests/MockFeatureFlagsClient.swift
@@ -22,7 +22,6 @@ extension FeatureData {
     static func allOff(isNewConversationFromInboxEnabled: Bool = false) -> FeatureData {
         FeatureData(
             isUpdateNecessary: false,
-            isConnectPaymentEnabled: false,
             isSubmitClaimEnabled: false,
             osVersionTooLow: false,
             emailPreferencesEnabled: false,

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -11,6 +11,7 @@ public enum OnboardingStep: Hashable, Sendable {
     case coOwners(contracts: [OnboardingContract])
     case petChipIds(contracts: [OnboardingContract])
     case inviteFriend(discountCode: String, monthlyDiscountPerReferral: String)
+    case connectPayment(isConnected: Bool)
 }
 
 @MainActor
@@ -33,6 +34,7 @@ extension OnboardingStep: TrackingViewNameProtocol {
         case .coOwners: "OnboardingCoOwners"
         case .petChipIds: "OnboardingPetChipIds"
         case .inviteFriend: "OnboardingInviteFriend"
+        case .connectPayment: "OnboardingConnectPayment"
         }
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -31,8 +31,7 @@ public enum OnboardingStepList {
         contracts: [Contracts.Contract],
         isPaymentConnected: Bool,
         contactInfo: ContactInfo = .init(phone: ""),
-        foreverData: ForeverData? = nil,
-        isConnectPaymentEnabled: Bool
+        foreverData: ForeverData? = nil
     ) -> [OnboardingStep] {
         var steps: [OnboardingStep] = [
             .welcome,
@@ -60,7 +59,7 @@ public enum OnboardingStepList {
                 )
             )
         }
-        if !isPaymentConnected, isConnectPaymentEnabled {
+        if !isPaymentConnected {
             steps.append(.connectPayment(isConnected: false))
         }
         return steps

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -29,8 +29,10 @@ public struct OnboardingContract: Hashable, Identifiable, Sendable {
 public enum OnboardingStepList {
     public static func compute(
         contracts: [Contracts.Contract],
+        isPaymentConnected: Bool,
         contactInfo: ContactInfo = .init(phone: ""),
-        foreverData: ForeverData? = nil
+        foreverData: ForeverData? = nil,
+        isConnectPaymentEnabled: Bool
     ) -> [OnboardingStep] {
         var steps: [OnboardingStep] = [
             .welcome,
@@ -57,6 +59,9 @@ public enum OnboardingStepList {
                     monthlyDiscountPerReferral: foreverData.monthlyDiscountPerReferral.formattedAmount
                 )
             )
+        }
+        if !isPaymentConnected, isConnectPaymentEnabled {
+            steps.append(.connectPayment(isConnected: false))
         }
         return steps
     }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -1,5 +1,6 @@
 import Contracts
 import EditStakeholders
+import Payment
 import SwiftUI
 import hCore
 import hCoreUI
@@ -27,6 +28,7 @@ struct OnboardingNavigation: View {
         }
         .environmentObject(vm)
         .handleEditStakeholders(with: vm.editStakeholdersVm)
+        .handleConnectPayment(with: vm.connectPaymentVm)
         .handleMissingChipIds(input: $vm.missingPetChipIdInput)
     }
 
@@ -47,6 +49,7 @@ struct OnboardingNavigation: View {
                     discountCode: discountCode,
                     monthlyDiscountPerReferral: monthlyDiscountPerReferral
                 )
+            case .connectPayment: OnboardingConnectPaymentScreen()
             }
         }
         .withDismissButton {

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
@@ -1,6 +1,7 @@
 import AppStateContainer
 import Contracts
 import EditStakeholders
+import Payment
 import SwiftUI
 import hCore
 import hCoreUI
@@ -19,6 +20,7 @@ class OnboardingNavigationViewModel: ObservableObject {
     let router = NavigationRouter()
     let onboardingService = OnboardingService()
     let editStakeholdersVm: EditStakeholdersViewModel
+    let connectPaymentVm = ConnectPaymentViewModel()
     @Published var steps: [OnboardingStep] = [
         .welcome
     ]
@@ -66,6 +68,26 @@ extension OnboardingNavigationViewModel {
             default:
                 return step
             }
+        }
+    }
+}
+
+// MARK: - Connect-payment step
+extension OnboardingNavigationViewModel {
+    /// Refresh the `.connectPayment` step's connected flag — the member may have connected
+    /// payment since the step list was computed. Only ever flips to connected: a stale
+    /// backend read must not revert a connection made during the flow.
+    func fetchPaymentStatus() async {
+        guard let isConnected = try? await onboardingService.getIsPaymentConnected(), isConnected else { return }
+        markPaymentConnected()
+    }
+
+    /// Payment was connected — flip the `connectPayment` step's `isConnected` flag so the
+    /// step's state reflects reality.
+    func markPaymentConnected() {
+        steps = steps.map { step in
+            guard case .connectPayment = step else { return step }
+            return .connectPayment(isConnected: true)
         }
     }
 }

--- a/Projects/Onboarding/Sources/Screens/OnboardingConnectPaymentScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingConnectPaymentScreen.swift
@@ -1,0 +1,128 @@
+import Payment
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingConnectPaymentScreen: View {
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+    @State private var bankSide: CGFloat = 0
+
+    private var isPaymentConnected: Bool {
+        vm.steps.contains { step in
+            if case let .connectPayment(isConnected) = step { return isConnected }
+            return false
+        }
+    }
+
+    var body: some View {
+        hForm {
+            graphic
+        }
+        .hFormTitle(
+            title: .init(.small, .body1, "Connect payment", alignment: .leading),
+            subTitle: .init(
+                .small,
+                .body1,
+                "Add a payment method to activate your insurance",
+                alignment: .leading
+            )
+        )
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                VStack(spacing: .padding8) {
+                    hText("Adding a payment method is required to keep your insurance active", style: .finePrint)
+                        .foregroundColor(hTextColor.Translucent.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                    if isPaymentConnected {
+                        hContinueButton { [weak vm] in
+                            vm?.advance(after: .connectPayment(isConnected: true))
+                        }
+                    } else {
+                        hButton(.large, .primary, content: .init(title: "Connect payment")) { [weak vm] in
+                            vm?.connectPaymentVm
+                                .set(onSuccess: { [weak vm] in
+                                    vm?.markPaymentConnected()
+                                }) { [weak vm] in
+                                    await vm?.fetchPaymentStatus()
+                                }
+                        }
+                    }
+                }
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .task {
+            await vm.fetchPaymentStatus()
+        }
+    }
+    private var graphic: some View {
+        HStack(spacing: .padding16) {
+            hText("Bank")
+                .padding(.padding24)
+                .hShadow(type: .custom(opacity: 0.05, radius: 5, xOffset: 0, yOffset: 4), show: true)
+                .hShadow(type: .custom(opacity: 0.1, radius: 1, xOffset: 0, yOffset: 2), show: true)
+                .background(
+                    GeometryReader { proxy in
+                        let side = max(proxy.size.width, proxy.size.height)
+                        RoundedRectangle(cornerRadius: .padding24)
+                            .inset(by: 0.5)
+                            .stroke(hBorderColor.secondary, lineWidth: 1)
+                            .frame(width: side, height: side)
+                            .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                            .preference(key: SquareSideKey.self, value: side)
+                    }
+                )
+            Group {
+                if isPaymentConnected {
+                    DotsActivityIndicator(.standard, animated: false)
+                        .transition(.opacity.animation(.bouncy))
+                } else {
+                    DotsActivityIndicator(.standard)
+                        .transition(.opacity.animation(.bouncy))
+                }
+            }
+            .useDarkColor
+
+            hCoreUIAssets.bigPillowBlack.view
+                .resizable()
+                .frame(width: bankSide, height: bankSide)
+                .overlay(alignment: .topTrailing) {
+                    hCoreUIAssets.checkmarkFilled.view
+                        .resizable()
+                        .frame(width: bankSide / 2.5, height: bankSide / 2.5)
+                        .foregroundColor(hSignalColor.Green.element)
+
+                        .background {
+                            Circle()
+                                .fill(hSurfaceColor.Opaque.primary)
+                                .frame(width: bankSide / 4, height: bankSide / 4)
+                        }
+                        .scaleEffect(isPaymentConnected ? 1 : 0, anchor: .center)
+                        .animation(.bouncy, value: isPaymentConnected)
+                        .offset(x: bankSide / 12, y: -bankSide / 12)
+                }
+        }
+        .onPreferenceChange(SquareSideKey.self) { bankSide = $0 }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct SquareSideKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+#Preview {
+    let model = OnboardingNavigationViewModel()
+    model.steps = [.connectPayment(isConnected: false)]
+    return OnboardingConnectPaymentScreen()
+        .environmentObject(model)
+        .task {
+            await delay(1)
+            model.markPaymentConnected()
+        }
+}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -13,6 +13,11 @@ public class OnboardingClientDemo: OnboardingClient {
 
     public func updateContactInfo(phone: String) async throws {}
 
+    public func getIsPaymentConnected() async throws -> Bool {
+        await delay(1)
+        return false
+    }
+
     static func getSteps() -> [OnboardingStep] {
         OnboardingStepList.compute(
             contracts: [
@@ -40,7 +45,9 @@ public class OnboardingClientDemo: OnboardingClient {
                     missingPetChipId: true
                 )
             ],
-            contactInfo: .init(phone: "0735328847")
+            isPaymentConnected: false,
+            contactInfo: .init(phone: "0735328847"),
+            isConnectPaymentEnabled: true
         )
     }
 }

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -46,8 +46,7 @@ public class OnboardingClientDemo: OnboardingClient {
                 )
             ],
             isPaymentConnected: false,
-            contactInfo: .init(phone: "0735328847"),
-            isConnectPaymentEnabled: true
+            contactInfo: .init(phone: "0735328847")
         )
     }
 }

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -17,4 +17,9 @@ public class OnboardingService {
     public func updateContactInfo(phone: String) async throws {
         try await client.updateContactInfo(phone: phone)
     }
+
+    @Log
+    public func getIsPaymentConnected() async throws -> Bool {
+        try await client.getIsPaymentConnected()
+    }
 }

--- a/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
+++ b/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
@@ -4,4 +4,5 @@ import Foundation
 public protocol OnboardingClient {
     func getOnboardingSteps() async throws -> [OnboardingStep]
     func updateContactInfo(phone: String) async throws
+    func getIsPaymentConnected() async throws -> Bool
 }

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -10,8 +10,7 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testStaticStepsAlwaysPresent() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertEqual(
             steps,
@@ -28,8 +27,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let steps = OnboardingStepList.compute(
             contracts: [],
             isPaymentConnected: true,
-            contactInfo: .init(phone: "0735328847"),
-            isConnectPaymentEnabled: true
+            contactInfo: .init(phone: "0735328847")
         )
         XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
     }
@@ -47,8 +45,7 @@ final class OnboardingStepComputationTests: XCTestCase {
                 referrals: [],
                 referredBy: nil,
                 monthlyDiscountPerReferral: .init(amount: "10", currency: "SEK")
-            ),
-            isConnectPaymentEnabled: true
+            )
         )
         XCTAssertTrue(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
     }
@@ -56,8 +53,7 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testInviteFriendStepHiddenWithoutForeverData() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertFalse(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
     }
@@ -65,27 +61,16 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testPaymentStepShownWhenNotConnected() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: false,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: false
         )
         XCTAssertTrue(steps.contains(.connectPayment(isConnected: false)))
-    }
-
-    func testPaymentStepHiddenWhenFlagDisabled() {
-        let steps = OnboardingStepList.compute(
-            contracts: [],
-            isPaymentConnected: false,
-            isConnectPaymentEnabled: false
-        )
-        XCTAssertFalse(steps.contains(.connectPayment(isConnected: false)))
     }
 
     func testCoInsuredStepShownWhenContractHasMissingCoInsured() {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: true)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertTrue(steps.contains(.coInsured(contracts: [.init(contract: contract)])))
     }
@@ -94,8 +79,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: false)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertFalse(steps.contains { $0.matches(.coInsured(contracts: [])) })
     }
@@ -104,8 +88,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: true)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertTrue(steps.contains(.coOwners(contracts: [.init(contract: contract)])))
     }
@@ -114,8 +97,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: false)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertFalse(steps.contains { $0.matches(.coOwners(contracts: [])) })
     }
@@ -124,8 +106,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(missingPetChipId: true)
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertTrue(steps.contains(.petChipIds(contracts: [.init(contract: contract)])))
     }
@@ -134,8 +115,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(missingPetChipId: false)
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: true
         )
         XCTAssertFalse(steps.contains { $0.matches(.petChipIds(contracts: [])) })
     }
@@ -148,8 +128,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         )
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: false,
-            isConnectPaymentEnabled: true
+            isPaymentConnected: false
         )
         XCTAssertEqual(
             steps,

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -8,7 +8,11 @@ import hCore
 @MainActor
 final class OnboardingStepComputationTests: XCTestCase {
     func testStaticStepsAlwaysPresent() {
-        let steps = OnboardingStepList.compute(contracts: [])
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertEqual(
             steps,
             [
@@ -23,7 +27,9 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testPhoneNumberStepCarriesContactInfo() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            contactInfo: .init(phone: "0735328847")
+            isPaymentConnected: true,
+            contactInfo: .init(phone: "0735328847"),
+            isConnectPaymentEnabled: true
         )
         XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
     }
@@ -31,6 +37,7 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testInviteFriendStepShownWhenForeverDataExists() {
         let steps = OnboardingStepList.compute(
             contracts: [],
+            isPaymentConnected: true,
             foreverData: .init(
                 grossAmount: .init(amount: "100", currency: "SEK"),
                 netAmount: .init(amount: "90", currency: "SEK"),
@@ -40,49 +47,96 @@ final class OnboardingStepComputationTests: XCTestCase {
                 referrals: [],
                 referredBy: nil,
                 monthlyDiscountPerReferral: .init(amount: "10", currency: "SEK")
-            )
+            ),
+            isConnectPaymentEnabled: true
         )
         XCTAssertTrue(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
     }
 
     func testInviteFriendStepHiddenWithoutForeverData() {
-        let steps = OnboardingStepList.compute(contracts: [])
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertFalse(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
+    }
+
+    func testPaymentStepShownWhenNotConnected() {
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: false,
+            isConnectPaymentEnabled: true
+        )
+        XCTAssertTrue(steps.contains(.connectPayment(isConnected: false)))
+    }
+
+    func testPaymentStepHiddenWhenFlagDisabled() {
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: false,
+            isConnectPaymentEnabled: false
+        )
+        XCTAssertFalse(steps.contains(.connectPayment(isConnected: false)))
     }
 
     func testCoInsuredStepShownWhenContractHasMissingCoInsured() {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: true)])
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertTrue(steps.contains(.coInsured(contracts: [.init(contract: contract)])))
     }
 
     func testCoInsuredStepHiddenWhenNoCoInsuredIsMissingInfo() {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: false)])
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertFalse(steps.contains { $0.matches(.coInsured(contracts: [])) })
     }
 
     func testCoOwnersStepShownWhenContractHasMissingCoOwners() {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: true)])
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertTrue(steps.contains(.coOwners(contracts: [.init(contract: contract)])))
     }
 
     func testCoOwnersStepHiddenWhenNoCoOwnerIsMissingInfo() {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: false)])
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertFalse(steps.contains { $0.matches(.coOwners(contracts: [])) })
     }
 
     func testPetChipIdsStepShownWithContractsWhenContractIsMissingPetChipId() {
         let contract = Self.makeContract(missingPetChipId: true)
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertTrue(steps.contains(.petChipIds(contracts: [.init(contract: contract)])))
     }
 
     func testPetChipIdsStepHiddenWhenNoContractIsMissingPetChipId() {
         let contract = Self.makeContract(missingPetChipId: false)
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: true,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertFalse(steps.contains { $0.matches(.petChipIds(contracts: [])) })
     }
 
@@ -92,7 +146,11 @@ final class OnboardingStepComputationTests: XCTestCase {
             coOwners: [.init(needsMissingInfo: true)],
             missingPetChipId: true
         )
-        let steps = OnboardingStepList.compute(contracts: [contract])
+        let steps = OnboardingStepList.compute(
+            contracts: [contract],
+            isPaymentConnected: false,
+            isConnectPaymentEnabled: true
+        )
         XCTAssertEqual(
             steps,
             [
@@ -103,6 +161,7 @@ final class OnboardingStepComputationTests: XCTestCase {
                 .coInsured(contracts: [.init(contract: contract)]),
                 .coOwners(contracts: [.init(contract: contract)]),
                 .petChipIds(contracts: [.init(contract: contract)]),
+                .connectPayment(isConnected: false),
             ]
         )
     }

--- a/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPayment+modifier.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/ConnectPayment+modifier.swift
@@ -20,33 +20,41 @@ struct ConnectPayment: ViewModifier {
                 DirectDebitSetup(
                     onSuccess: model.onSuccess
                 )
+                .onDeinit {
+                    Task {
+                        await model.onDeinit?()
+                    }
+                }
             }
     }
 }
 
 @MainActor
 public class ConnectPaymentViewModel: ObservableObject {
-    @Published var setupTypeNavigationModel: SetupTypeNavigationModel?
+    @Published public internal(set) var setupTypeNavigationModel: SetupTypeNavigationModel?
     public init() {}
 
     public func set(
-        onSuccess: (() -> Void)? = nil
+        onSuccess: (() -> Void)? = nil,
+        onDeinit: (() async -> Void)? = nil
     ) {
         Task { @MainActor [weak self] in
             self?.setupTypeNavigationModel = .init(
-                onSuccess: onSuccess
+                onSuccess: onSuccess,
+                onDeinit: onDeinit
             )
         }
     }
 }
 
-struct SetupTypeNavigationModel: Identifiable {
-    let id: String = UUID().uuidString
-    let onSuccess: (() -> Void)?
+public struct SetupTypeNavigationModel: Identifiable {
+    public let id: String = UUID().uuidString
+    public let onSuccess: (() -> Void)?
+    public let onDeinit: (() async -> Void)?
 }
 
 extension SetupTypeNavigationModel: Equatable {
-    static func == (lhs: SetupTypeNavigationModel, rhs: SetupTypeNavigationModel) -> Bool {
+    public static func == (lhs: SetupTypeNavigationModel, rhs: SetupTypeNavigationModel) -> Bool {
         lhs.id == rhs.id
     }
 }

--- a/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
+++ b/Projects/Payment/Sources/Screens/ConnectPayments/DirectDebitSetup.swift
@@ -236,7 +236,6 @@ public struct DirectDebitSetup: View {
     }
 
     @State var activeAlert: AlertType?
-    @State var showNotSupported: Bool = false
 
     @StateObject private var ownedRouter = NavigationRouter()
     @ObservedObject private var externalRouter: NavigationRouter
@@ -259,7 +258,6 @@ public struct DirectDebitSetup: View {
                 .contains(store.paymentStatusData?.status ?? .active)
             return hasAlreadyConnected ? .replacement : .initial
         }()
-        showNotSupported = !Dependencies.featureFlags().isConnectPaymentEnabled
         self.setupType = finalSetupType
         self.onSuccess = onSuccess
         self.hasExternalRouter = router != nil
@@ -267,55 +265,22 @@ public struct DirectDebitSetup: View {
     }
 
     public var body: some View {
-        Group {
-            if showNotSupported {
-                GenericErrorView(
-                    title: L10n.moveintentGenericError,
-                    description: nil,
-                    formPosition: .center
-                )
-                .hStateViewButtonConfig(
-                    .init(
-                        actionButtonAttachedToBottom: .init(
-                            buttonTitle: L10n.openChat,
-                            buttonAction: { [weak router] in
-                                router?.dismiss()
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                                    NotificationCenter.default.post(
-                                        name: .openChat,
-                                        object: ChatType.newConversation
-                                    )
-                                }
-                            }
-                        ),
-                        dismissButton: .init(
-                            buttonAction: { [weak router] in
-                                router?.dismiss()
-                            }
-                        )
-                    )
-                )
-            } else {
-                DirectDebitSetupRepresentable(showErrorAlert: showErrorAlertBinding, router: router) { [onSuccess] in
-                    onSuccess?()
-                }
-                .alert(item: $activeAlert) { alertType in
-                    switch alertType {
-                    case .cancel:
-                        cancelAlert()
-                    case .error:
-                        errorAlert()
-                    }
-                }
+        DirectDebitSetupRepresentable(showErrorAlert: showErrorAlertBinding, router: router) { [onSuccess] in
+            onSuccess?()
+        }
+        .alert(item: $activeAlert) { alertType in
+            switch alertType {
+            case .cancel:
+                cancelAlert()
+            case .error:
+                errorAlert()
             }
         }
         .toolbar {
             ToolbarItem(
                 placement: .topBarLeading
             ) {
-                if !showNotSupported {
-                    dismissButton
-                }
+                dismissButton
             }
         }
         .navigationTitle(
@@ -339,12 +304,8 @@ public struct DirectDebitSetup: View {
         )
         .padding(.horizontal, .padding4)
         .fixedSize()
-        .onTapGesture { [weak router] in
-            if showNotSupported {
-                router?.dismiss()
-            } else {
-                activeAlert = .cancel
-            }
+        .onTapGesture {
+            activeAlert = .cancel
         }
         .accessibilityAddTraits(.isButton)
     }

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagUnleash.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagUnleash.swift
@@ -72,7 +72,6 @@ public class FeatureFlagsUnleash: FeatureFlagsClient {
         }
         let data = FeatureData(
             isUpdateNecessary: unleashClient.isEnabled(name: "update_necessary"),
-            isConnectPaymentEnabled: unleashClient.getVariant(name: "payment_type").name == "trustly",
             isSubmitClaimEnabled: true,
             osVersionTooLow: unleashClient.isEnabled(name: "update_os_version"),
             emailPreferencesEnabled: true,

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagsDemo.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagsDemo.swift
@@ -12,7 +12,6 @@ public class FeatureFlagsDemo: @unchecked Sendable, FeatureFlagsClient {
     public func setup(with _: [String: String]) async throws {
         let data = FeatureData(
             isUpdateNecessary: false,
-            isConnectPaymentEnabled: false,
             isSubmitClaimEnabled: false,
             osVersionTooLow: false,
             emailPreferencesEnabled: false,
@@ -28,7 +27,6 @@ public class FeatureFlagsDemo: @unchecked Sendable, FeatureFlagsClient {
     public func updateContext(context _: [String: String]) {
         let data = FeatureData(
             isUpdateNecessary: false,
-            isConnectPaymentEnabled: false,
             isSubmitClaimEnabled: false,
             osVersionTooLow: false,
             emailPreferencesEnabled: false,

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagsProtocol.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagsProtocol.swift
@@ -10,7 +10,6 @@ public protocol FeatureFlagsClient {
 
 public struct FeatureData: Codable, Equatable {
     public let isUpdateNecessary: Bool
-    public let isConnectPaymentEnabled: Bool
     public let isSubmitClaimEnabled: Bool
     public let osVersionTooLow: Bool
     public let emailPreferencesEnabled: Bool
@@ -22,7 +21,6 @@ public struct FeatureData: Codable, Equatable {
 
     public init(
         isUpdateNecessary: Bool,
-        isConnectPaymentEnabled: Bool,
         isSubmitClaimEnabled: Bool,
         osVersionTooLow: Bool,
         emailPreferencesEnabled: Bool,
@@ -33,7 +31,6 @@ public struct FeatureData: Codable, Equatable {
         isResumeClaimEnabled: Bool
     ) {
         self.isUpdateNecessary = isUpdateNecessary
-        self.isConnectPaymentEnabled = isConnectPaymentEnabled
         self.isSubmitClaimEnabled = isSubmitClaimEnabled
         self.osVersionTooLow = osVersionTooLow
         self.emailPreferencesEnabled = emailPreferencesEnabled
@@ -65,7 +62,6 @@ public class FeatureFlags: ObservableObject {
     private var featureDataCancellable: AnyCancellable?
     @Published public var data: FeatureData = .init(
         isUpdateNecessary: false,
-        isConnectPaymentEnabled: false,
         isSubmitClaimEnabled: false,
         osVersionTooLow: false,
         emailPreferencesEnabled: false,

--- a/Projects/hCoreUI/Sources/Activity/ActivityIndicator.swift
+++ b/Projects/hCoreUI/Sources/Activity/ActivityIndicator.swift
@@ -87,15 +87,18 @@ public struct WordmarkActivityIndicator: View {
 public struct DotsActivityIndicator: View {
     @State var animate: Bool = false
     var size: Size
+    var animated: Bool
     public enum Size {
         case standard
         case small
     }
 
     public init(
-        _ size: Size
+        _ size: Size,
+        animated: Bool = true
     ) {
         self.size = size
+        self.animated = animated
     }
 
     var dotSize: CGFloat {
@@ -109,11 +112,11 @@ public struct DotsActivityIndicator: View {
 
     public var body: some View {
         HStack(alignment: .center, spacing: 0) {
-            PulsingCircle(index: 0).frame(width: dotSize, height: dotSize)
+            PulsingCircle(index: 0, animated: animated).frame(width: dotSize, height: dotSize)
             Color.clear.frame(width: dotSize)
-            PulsingCircle(index: 1).frame(width: dotSize, height: dotSize)
+            PulsingCircle(index: 1, animated: animated).frame(width: dotSize, height: dotSize)
             Color.clear.frame(width: dotSize)
-            PulsingCircle(index: 2).frame(width: dotSize, height: dotSize)
+            PulsingCircle(index: 2, animated: animated).frame(width: dotSize, height: dotSize)
         }
         .onAppear {
             animate = true
@@ -129,6 +132,7 @@ private struct PulsingCircle: View {
     let totalNumber: CGFloat = 3
     let duration: CGFloat = 0.5
     let index: CGFloat
+    let animated: Bool
     @State var animate: Bool = false
 
     public var body: some View {
@@ -136,7 +140,9 @@ private struct PulsingCircle: View {
             .fill(getFillColor)
             .opacity(animate ? 0.4 : 1)
             .onAppear {
-                setAnimation()
+                if animated {
+                    setAnimation()
+                }
             }
     }
 


### PR DESCRIPTION
## What is happening here?

This PR adds the **connect payment** step to the onboarding flow.

For insurance to be paid, the member needs to connect a payment method (direct debit). This step checks whether payment is already connected and, if not, shows a screen that sends the member into the existing connect-payment flow. The step is skipped for members who already have payment set up.
