### PR TITLE
feat: Onboarding - Bundle discount step (GEN-5511)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/OnboardingClientOctopus.swift
@@ -1,5 +1,6 @@
 import AppStateContainer
 import Contracts
+import CrossSell
 import Forever
 import Foundation
 import Onboarding
@@ -11,6 +12,7 @@ import hCore
 public class OnboardingClientOctopus: OnboardingClient {
     @Inject private var contractsClient: FetchContractsClient
     @Inject private var paymentClient: hPaymentClient
+    @Inject private var crossSellClient: CrossSellClient
     @Inject private var profileClient: ProfileClient
     @Inject private var foreverClient: ForeverClient
 
@@ -19,11 +21,13 @@ public class OnboardingClientOctopus: OnboardingClient {
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         async let contractsStack = contractsClient.getContracts()
         async let paymentStatus = paymentClient.getPaymentStatusData()
+        async let crossSells = crossSellClient.getCrossSell(source: .insurances, contractId: nil)
         async let foreverData = foreverClient.getMemberReferralInformation()
         let memberDetails = try await profileClient.getMemberDetails()
         return try await OnboardingStepList.compute(
             contracts: contractsStack.activeContracts + contractsStack.pendingContracts,
             isPaymentConnected: paymentStatus.status != .needsSetup,
+            crossSells: crossSells.others,
             contactInfo: ContactInfo(phone: memberDetails.phone ?? ""),
             // Non-blocking: a failed referral fetch must not sink onboarding — the invite
             // step just renders without amount and share button.
@@ -33,6 +37,10 @@ public class OnboardingClientOctopus: OnboardingClient {
 
     public func updateContactInfo(phone: String) async throws {
         try await profileClient.update(phone: phone)
+    }
+
+    public func getCrossSells() async throws -> [CrossSell] {
+        try await crossSellClient.getCrossSell(source: .insurances, contractId: nil).others
     }
 
     public func getIsPaymentConnected() async throws -> Bool {

--- a/Projects/CrossSell/Sources/Models/CrossSellModels.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellModels.swift
@@ -80,10 +80,10 @@ public struct AddonCrossSell: Codable, Equatable, Hashable, Sendable {
 
 public struct CrossSell: Codable, Equatable, Hashable, Sendable, Identifiable {
     public let id: String
-    let title: String
-    let description: String
+    public let title: String
+    public let description: String
     let buttonTitle: String
-    let webActionURL: String?
+    public let webActionURL: String?
     public let imageUrl: URL?
     let bannerText: String?
     let buttonText: String?

--- a/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import hCore
 import hCoreUI
 
-struct CrossSellStackComponent: View {
+public struct CrossSellStackComponent: View {
     let crossSells: [CrossSell]
     let withHeader: Bool
     let headerTitle: String
     let discountAvailable: Bool
-    init(crossSells: [CrossSell], discountAvailable: Bool, withHeader: Bool) {
+    public init(crossSells: [CrossSell], discountAvailable: Bool, withHeader: Bool) {
         self.crossSells = crossSells
         self.withHeader = withHeader
         self.discountAvailable = discountAvailable
@@ -19,7 +19,7 @@ struct CrossSellStackComponent: View {
             }
         }()
     }
-    var body: some View {
+    public var body: some View {
         let content = hSection {
             VStack(spacing: .padding4) {
                 ForEach(crossSells, id: \.title) { crossSell in

--- a/Projects/Onboarding/Sources/Models/OnboardingStep.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStep.swift
@@ -1,4 +1,5 @@
 import Contracts
+import CrossSell
 import Foundation
 import hCoreUI
 
@@ -12,6 +13,7 @@ public enum OnboardingStep: Hashable, Sendable {
     case petChipIds(contracts: [OnboardingContract])
     case inviteFriend(discountCode: String, monthlyDiscountPerReferral: String)
     case connectPayment(isConnected: Bool)
+    case crossSell(_ crossSells: [CrossSell])
 }
 
 @MainActor
@@ -35,6 +37,7 @@ extension OnboardingStep: TrackingViewNameProtocol {
         case .petChipIds: "OnboardingPetChipIds"
         case .inviteFriend: "OnboardingInviteFriend"
         case .connectPayment: "OnboardingConnectPayment"
+        case .crossSell: "OnboardingCrossSell"
         }
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,4 +1,5 @@
 import Contracts
+import CrossSell
 import Forever
 import Foundation
 import hCore
@@ -30,6 +31,7 @@ public enum OnboardingStepList {
     public static func compute(
         contracts: [Contracts.Contract],
         isPaymentConnected: Bool,
+        crossSells: [CrossSell],
         contactInfo: ContactInfo = .init(phone: ""),
         foreverData: ForeverData? = nil
     ) -> [OnboardingStep] {
@@ -61,6 +63,9 @@ public enum OnboardingStepList {
         }
         if !isPaymentConnected {
             steps.append(.connectPayment(isConnected: false))
+        }
+        if !crossSells.isEmpty {
+            steps.append(.crossSell(crossSells))
         }
         return steps
     }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -50,6 +50,7 @@ struct OnboardingNavigation: View {
                     monthlyDiscountPerReferral: monthlyDiscountPerReferral
                 )
             case .connectPayment: OnboardingConnectPaymentScreen()
+            case .crossSell: OnboardingCrossSellScreen()
             }
         }
         .withDismissButton {

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigationViewModel.swift
@@ -1,5 +1,6 @@
 import AppStateContainer
 import Contracts
+import CrossSell
 import EditStakeholders
 import Payment
 import SwiftUI
@@ -101,6 +102,28 @@ extension OnboardingNavigationViewModel {
         steps = steps.map { step in
             guard case let .petChipIds(contracts) = step else { return step }
             return .petChipIds(contracts: contracts.markingAdded(contractId: contractId))
+        }
+    }
+}
+
+// MARK: - Cross-sell step
+extension OnboardingNavigationViewModel {
+    /// The cross-sells carried by the `.crossSell` step, if present.
+    var crossSells: [CrossSell] {
+        for step in steps {
+            if case let .crossSell(crossSells) = step { return crossSells }
+        }
+        return []
+    }
+
+    /// Refresh the cross-sells on the `.crossSell` step — they may have changed since the
+    /// step list was computed. Keeps the existing cross-sells on failure or an empty result,
+    /// so the screen never goes blank mid-view.
+    func fetchCrossSells() async {
+        guard let crossSells = try? await onboardingService.getCrossSells(), !crossSells.isEmpty else { return }
+        steps = steps.map { step in
+            guard case .crossSell = step else { return step }
+            return .crossSell(crossSells)
         }
     }
 }

--- a/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
@@ -1,0 +1,100 @@
+import CrossSell
+import Kingfisher
+import SwiftUI
+import hCore
+import hCoreUI
+
+struct OnboardingCrossSellScreen: View {
+    @EnvironmentObject var vm: OnboardingNavigationViewModel
+    var body: some View {
+        hForm {
+            CrossSellStackComponent(crossSells: vm.crossSells, discountAvailable: false, withHeader: false)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .hFormTitle(
+            title: .init(.small, .body1, "Get bundle discount", alignment: .leading),
+            subTitle: .init(
+                .small,
+                .body1,
+                "You get a 15% bundle discount when you have two or more insurances with us",
+                alignment: .leading
+            )
+        )
+        .hFormContentPosition(.center)
+        .hFormAttachToBottom {
+            hSection {
+                hButton(.large, .primary, content: .init(title: "Continue to app")) {  // TODO: L10n
+                    vm.advance(after: .crossSell(vm.crossSells))
+                }
+                .accessibilityLabel("Continue to app")  // TODO: L10n
+            }
+            .sectionContainerStyle(.transparent)
+        }
+        .task {
+            await vm.fetchCrossSells()
+        }
+    }
+}
+
+private struct OnboardingCrossSellRow: View {
+    let crossSell: CrossSell
+
+    var body: some View {
+        HStack(spacing: .padding16) {
+            KFImage(crossSell.imageUrl)
+                .placeholder {
+                    hCoreUIAssets.bigPillowHome.view
+                        .resizable()
+                        .frame(width: 48, height: 48)
+                }
+                .fade(duration: 0.25)
+                .resizable()
+                .frame(width: 48, height: 48)
+                .aspectRatio(contentMode: .fill)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: .padding2) {
+                hText(crossSell.title, style: .body1)
+                hText(crossSell.description, style: .label)
+                    .foregroundColor(hTextColor.Opaque.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    let viewModel = OnboardingNavigationViewModel()
+    viewModel.steps = [
+        .crossSell(
+            [
+                .init(
+                    id: "1",
+                    title: "title",
+                    description: "desc",
+                    buttonTitle: "See price",
+                    imageUrl: URL(
+                        string:
+                            "https://www.hedvig.com/_next/image?url=https%3A%2F%2Fassets.hedvig.com%2Ff%2F165473%2F832x832%2Ff8c6668c24%2Frental-pillow-832x832px.png&w=640&q=75"
+                    ),
+                    buttonDescription: "desc"
+                ),
+                .init(
+                    id: "2",
+                    title: "title 2",
+                    description: "desc 2",
+                    buttonTitle: "See price",
+                    imageUrl: URL(
+                        string:
+                            "https://www.hedvig.com/_next/image?url=https%3A%2F%2Fassets.hedvig.com%2Ff%2F165473%2F832x832%2Ff8c6668c24%2Frental-pillow-832x832px.png&w=640&q=75"
+                    ),
+                    buttonDescription: "desc"
+                ),
+            ]
+        )
+    ]
+    return OnboardingCrossSellScreen()
+        .environmentObject(viewModel)
+}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -1,4 +1,5 @@
 import Contracts
+import CrossSell
 import Foundation
 import hCore
 
@@ -16,6 +17,20 @@ public class OnboardingClientDemo: OnboardingClient {
     public func getIsPaymentConnected() async throws -> Bool {
         await delay(1)
         return false
+    }
+
+    public func getCrossSells() async throws -> [CrossSell] {
+        await delay(1)
+        return [
+            .init(
+                id: "accident",
+                title: "Accident insurance",
+                description: "From 49 kr/mo",
+                buttonTitle: "See price",
+                imageUrl: nil,
+                buttonDescription: ""
+            )
+        ]
     }
 
     static func getSteps() -> [OnboardingStep] {
@@ -46,6 +61,7 @@ public class OnboardingClientDemo: OnboardingClient {
                 )
             ],
             isPaymentConnected: false,
+            crossSells: [],
             contactInfo: .init(phone: "0735328847")
         )
     }

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -1,4 +1,5 @@
 import AutomaticLog
+import CrossSell
 import Foundation
 import hCore
 
@@ -16,6 +17,11 @@ public class OnboardingService {
     @Log
     public func updateContactInfo(phone: String) async throws {
         try await client.updateContactInfo(phone: phone)
+    }
+
+    @Log
+    public func getCrossSells() async throws -> [CrossSell] {
+        try await client.getCrossSells()
     }
 
     @Log

--- a/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
+++ b/Projects/Onboarding/Sources/Service/Protocols/OnboardingClient.swift
@@ -1,8 +1,10 @@
+import CrossSell
 import Foundation
 
 @MainActor
 public protocol OnboardingClient {
     func getOnboardingSteps() async throws -> [OnboardingStep]
     func updateContactInfo(phone: String) async throws
+    func getCrossSells() async throws -> [CrossSell]
     func getIsPaymentConnected() async throws -> Bool
 }

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -1,4 +1,5 @@
 import Contracts
+import CrossSell
 import EditStakeholders
 import XCTest
 import hCore
@@ -10,7 +11,8 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testStaticStepsAlwaysPresent() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertEqual(
             steps,
@@ -27,6 +29,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let steps = OnboardingStepList.compute(
             contracts: [],
             isPaymentConnected: true,
+            crossSells: [],
             contactInfo: .init(phone: "0735328847")
         )
         XCTAssertTrue(steps.contains(.phoneNumber(phoneNumber: "0735328847")))
@@ -36,6 +39,7 @@ final class OnboardingStepComputationTests: XCTestCase {
         let steps = OnboardingStepList.compute(
             contracts: [],
             isPaymentConnected: true,
+            crossSells: [],
             foreverData: .init(
                 grossAmount: .init(amount: "100", currency: "SEK"),
                 netAmount: .init(amount: "90", currency: "SEK"),
@@ -53,7 +57,8 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testInviteFriendStepHiddenWithoutForeverData() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertFalse(steps.contains { $0.matches(.inviteFriend(discountCode: "", monthlyDiscountPerReferral: "")) })
     }
@@ -61,16 +66,27 @@ final class OnboardingStepComputationTests: XCTestCase {
     func testPaymentStepShownWhenNotConnected() {
         let steps = OnboardingStepList.compute(
             contracts: [],
-            isPaymentConnected: false
+            isPaymentConnected: false,
+            crossSells: []
         )
         XCTAssertTrue(steps.contains(.connectPayment(isConnected: false)))
+    }
+
+    func testCrossSellStepShownWhenCrossSellsExist() {
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: true,
+            crossSells: [.mock]
+        )
+        XCTAssertEqual(steps.last, .crossSell([.mock]))
     }
 
     func testCoInsuredStepShownWhenContractHasMissingCoInsured() {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: true)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertTrue(steps.contains(.coInsured(contracts: [.init(contract: contract)])))
     }
@@ -79,7 +95,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coInsured: [.init(needsMissingInfo: false)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertFalse(steps.contains { $0.matches(.coInsured(contracts: [])) })
     }
@@ -88,7 +105,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: true)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertTrue(steps.contains(.coOwners(contracts: [.init(contract: contract)])))
     }
@@ -97,7 +115,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(coOwners: [.init(needsMissingInfo: false)])
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertFalse(steps.contains { $0.matches(.coOwners(contracts: [])) })
     }
@@ -106,7 +125,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(missingPetChipId: true)
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertTrue(steps.contains(.petChipIds(contracts: [.init(contract: contract)])))
     }
@@ -115,7 +135,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         let contract = Self.makeContract(missingPetChipId: false)
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: true
+            isPaymentConnected: true,
+            crossSells: []
         )
         XCTAssertFalse(steps.contains { $0.matches(.petChipIds(contracts: [])) })
     }
@@ -128,7 +149,8 @@ final class OnboardingStepComputationTests: XCTestCase {
         )
         let steps = OnboardingStepList.compute(
             contracts: [contract],
-            isPaymentConnected: false
+            isPaymentConnected: false,
+            crossSells: [.mock]
         )
         XCTAssertEqual(
             steps,
@@ -141,6 +163,7 @@ final class OnboardingStepComputationTests: XCTestCase {
                 .coOwners(contracts: [.init(contract: contract)]),
                 .petChipIds(contracts: [.init(contract: contract)]),
                 .connectPayment(isConnected: false),
+                .crossSell([.mock]),
             ]
         )
     }
@@ -177,6 +200,19 @@ extension OnboardingStepComputationTests {
             coInsured: coInsured,
             coOwners: coOwners,
             missingPetChipId: missingPetChipId
+        )
+    }
+}
+
+extension CrossSell {
+    fileprivate static var mock: CrossSell {
+        .init(
+            id: "cross-sell-id",
+            title: "title",
+            description: "description",
+            buttonTitle: "buttonTitle",
+            imageUrl: nil,
+            buttonDescription: "buttonDescription"
         )
     }
 }


### PR DESCRIPTION
## What is happening here?

This PR adds the **bundle discount** step to the onboarding flow.

If the member could save money by bundling more insurances, we show them a screen with the relevant cross-sell offers and the discount they would get. The screen reuses the existing CrossSell components and only appears when there is actually something to offer.
