### PR TITLE
feat: Home Screen 3 — claim card restyle

### DIFF
--- a/Projects/Claims/Sources/ClaimStore.swift
+++ b/Projects/Claims/Sources/ClaimStore.swift
@@ -21,7 +21,7 @@ public final class ClaimsStore: AppStore {
             setAllActiveClaims()
         }
     }
-    @Published var allActiveClaims: [ActiveClaimType] = []
+    @Published public internal(set) var allActiveClaims: [ActiveClaimType] = []
     @Transient private var cancellables = Set<AnyCancellable>()
 
     public init() {
@@ -108,16 +108,14 @@ public final class ClaimsStore: AppStore {
         self.allActiveClaims = claims
     }
 
-    enum ActiveClaimType: Equatable, Identifiable, Codable {
+    public enum ActiveClaimType: Equatable, Identifiable, Codable, Sendable {
         case claim(model: ClaimModel)
         case claimInProgress(model: ClaimInProgressModel)
 
-        var id: String {
+        public var id: String {
             switch self {
-            case .claim(let model):
-                return model.id
-            case .claimInProgress(let model):
-                return model.id
+            case .claim(let model): model.id
+            case .claimInProgress(let model): model.id
             }
         }
     }

--- a/Projects/Claims/Sources/Views/ClaimStatusBar.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatusBar.swift
@@ -155,6 +155,9 @@ struct ClaimStatusBar: View {
                 HStack {
                     ClaimStatusBar(status: .closed, outcome: .notCompensated)
                 }
+                HStack {
+                    ClaimStatusBar(status: .none, outcome: nil)
+                }
             }
         }
         .sectionContainerStyle(.transparent)

--- a/Projects/Claims/Sources/Views/ClaimStatusCard.swift
+++ b/Projects/Claims/Sources/Views/ClaimStatusCard.swift
@@ -35,6 +35,7 @@ struct ClaimStatusCard: View {
                     }
                 }
             )
+            .hCardBackgroundColor(.light)
         case let .claimInProgress(model):
             StatusCard(
                 onSelected: nil,
@@ -47,36 +48,7 @@ struct ClaimStatusCard: View {
                 subTitle: model.createdAt.getSubTitle,
                 bottomComponent: {
                     VStack(spacing: .padding16) {
-                        HStack(alignment: .top, spacing: .padding6) {
-                            VStack {
-                                Rectangle()
-                                    .fill(hFillColor.Opaque.disabled)
-                                    .frame(height: 4)
-                                    .cornerRadius(.cornerRadiusXS)
-                                hText(L10n.Claim.StatusBar.submitted, style: .label)
-                                    .foregroundColor(hFillColor.Opaque.disabled)
-                            }
-                            .frame(maxWidth: .infinity)
-                            VStack {
-                                Rectangle()
-                                    .fill(hFillColor.Opaque.disabled)
-                                    .frame(height: 4)
-                                    .cornerRadius(.cornerRadiusXS)
-                                hText(L10n.Claim.StatusBar.beingHandled, style: .label)
-                                    .foregroundColor(hFillColor.Opaque.disabled)
-                            }
-                            .frame(maxWidth: .infinity)
-
-                            VStack {
-                                Rectangle()
-                                    .fill(hFillColor.Opaque.disabled)
-                                    .frame(height: 4)
-                                    .cornerRadius(.cornerRadiusXS)
-                                hText(L10n.Claim.StatusBar.closed, style: .label)
-                                    .foregroundColor(hFillColor.Opaque.disabled)
-                            }
-                            .frame(maxWidth: .infinity)
-                        }
+                        ClaimStatusBar(status: .none, outcome: nil)
                         HStack(spacing: .padding8) {
                             hButton(.medium, .secondary, content: .init(title: L10n.resumeClaimDeleteButton)) {
                                 showDeleteConfirmation = true
@@ -96,6 +68,7 @@ struct ClaimStatusCard: View {
                     }
                 }
             )
+            .hCardBackgroundColor(.light)
             .alert(
                 L10n.resumeClaimDeleteTitle,
                 isPresented: $showDeleteConfirmation

--- a/Projects/Claims/Sources/Views/ClaimsCard.swift
+++ b/Projects/Claims/Sources/Views/ClaimsCard.swift
@@ -1,30 +1,28 @@
 import AppStateContainer
 import SwiftUI
 import hCore
+import hCoreUI
 
 @MainActor
 public struct ClaimsCard: View {
-    @AppObservedObject var store: ClaimsStore
+    let allActiveClaims: [ClaimsStore.ActiveClaimType]
 
-    public init() {}
+    public init(allActiveClaims: [ClaimsStore.ActiveClaimType]) {
+        self.allActiveClaims = allActiveClaims
+    }
 
     public var body: some View {
-        VStack {
-            if !store.allActiveClaims.isEmpty {
-                if store.allActiveClaims.count == 1, let claim = store.allActiveClaims.first {
-                    ClaimStatusCard(claimType: claim, enableTap: true)
-                } else {
-                    ClaimSection(claims: $store.allActiveClaims)
+        if !allActiveClaims.isEmpty {
+            hSection {
+                VStack {
+                    if allActiveClaims.count == 1, let claim = allActiveClaims.first {
+                        ClaimStatusCard(claimType: claim, enableTap: true)
+                    } else {
+                        ClaimSection(claims: .constant(allActiveClaims))
+                    }
                 }
             }
-        }
-        .hWithoutDivider
-        .task {
-            while !Task.isCancelled {
-                await store.fetchActiveClaims()
-                await store.fetchClaimInProgress()
-                try? await Task.sleep(for: .seconds(120))
-            }
+            .sectionContainerStyle(.transparent)
         }
     }
 }

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -95,6 +95,13 @@ struct ActiveHomeView: View {
                 .offset(y: bottomOverscrollExtension)
         }
     }
+
+    @ViewBuilder private var bannerSection: some View {
+        if !bottomVm.items.isEmpty {
+            hSection { HomeBottomScrollView(vm: bottomVm) }
+                .sectionContainerStyle(.transparent)
+        }
+    }
 }
 
 /// Clips a view by trimming `topInset` points off its top edge, revealing the rest below.
@@ -113,13 +120,6 @@ private struct TopClipShape: Shape {
                 height: rect.height - inset + bottomExtension
             )
         )
-    }
-
-    @ViewBuilder private var bannerSection: some View {
-        if !bottomVm.items.isEmpty {
-            hSection { HomeBottomScrollView(vm: bottomVm) }
-                .sectionContainerStyle(.transparent)
-        }
     }
 }
 

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -8,6 +8,7 @@ import hCoreUI
 
 struct ActiveHomeView: View {
     @AppObservedObject private var homeStore: HomeStore
+    @AppObservedObject private var claimsStore: ClaimsStore
     @StateObject private var bottomVm = HomeBottomScrollViewModel()
     @State private var greetingHeight: CGFloat = 0
     @State private var headerHeight: CGFloat = 0
@@ -82,12 +83,8 @@ struct ActiveHomeView: View {
 
     private var sheetContent: some View {
         VStack(spacing: .padding40) {
-            hSection {
-                ClaimsCard()
-            }
-            hSection {
-                HomeBottomScrollView(vm: bottomVm)
-            }
+            ClaimsCard(allActiveClaims: claimsStore.allActiveClaims)
+            bannerSection
             TodoList(todos: bottomVm.todos)
         }
         .sectionContainerStyle(.transparent)
@@ -116,6 +113,13 @@ private struct TopClipShape: Shape {
                 height: rect.height - inset + bottomExtension
             )
         )
+    }
+
+    @ViewBuilder private var bannerSection: some View {
+        if !bottomVm.items.isEmpty {
+            hSection { HomeBottomScrollView(vm: bottomVm) }
+                .sectionContainerStyle(.transparent)
+        }
     }
 }
 

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -44,10 +44,13 @@ public struct HomeScreen: View {
 
 @MainActor
 class HomeVM: ObservableObject {
-    private var cancellables = Set<AnyCancellable>()
+    private var chatNotificationsTimerCancellable: AnyCancellable?
+    private var claimsTimerCancellable: AnyCancellable?
     private let contractStore: ContractStore = globalAppStateContainer.get()
     private let homeStore: HomeStore = globalAppStateContainer.get()
     private let claimsStore: ClaimsStore = globalAppStateContainer.get()
+    private let crossSellStore: CrossSellStore = globalAppStateContainer.get()
+    private let paymentStore: PaymentStore = globalAppStateContainer.get()
 
     init() {
         addObserverForApplicationDidBecomeActive()
@@ -58,17 +61,12 @@ class HomeVM: ObservableObject {
         Task { await homeStore.fetchMemberState() }
         Task { await homeStore.fetchImportantMessages() }
         Task { await homeStore.fetchQuickActions() }
-        Task { await homeStore.fetchChatNotifications() }
-        if homeStore.hasMissedCharge {
-            Task { await homeStore.fetchMissedCharge() }
-        }
-        let crossSellStore: CrossSellStore = globalAppStateContainer.get()
+        if homeStore.hasMissedCharge { Task { await homeStore.fetchMissedCharge() } }
         Task { await crossSellStore.fetchRecommendedCrossSellId() }
         Task { await contractStore.fetchContracts() }
-        let paymentStore: PaymentStore = globalAppStateContainer.get()
         Task { await paymentStore.fetchPaymentStatus() }
 
-        Timer.publish(every: 10, on: .main, in: .common)
+        chatNotificationsTimerCancellable = Timer.publish(every: 10, on: .main, in: .common)
             .autoconnect()
             .prepend(.now)
             .receive(on: RunLoop.main)
@@ -76,9 +74,8 @@ class HomeVM: ObservableObject {
                 guard VisibleScreenTracker.isVisible(HomeScreen.self) else { return }
                 Task { await homeStore.fetchChatNotifications() }
             }
-            .store(in: &cancellables)
 
-        Timer.publish(every: 120, on: .main, in: .common)
+        claimsTimerCancellable = Timer.publish(every: 120, on: .main, in: .common)
             .autoconnect()
             .receive(on: RunLoop.main)
             .prepend(.now)
@@ -90,7 +87,6 @@ class HomeVM: ObservableObject {
                     _ = await (fetchActive, fetchInProgress)
                 }
             }
-            .store(in: &cancellables)
     }
 
     private func addObserverForApplicationDidBecomeActive() {

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -45,37 +45,52 @@ public struct HomeScreen: View {
 @MainActor
 class HomeVM: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
-    private var chatNotificationPullTimerCancellable: AnyCancellable?
-    private var chatNotificationPullTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
-    let contractStore: ContractStore = globalAppStateContainer.get()
+    private let contractStore: ContractStore = globalAppStateContainer.get()
+    private let homeStore: HomeStore = globalAppStateContainer.get()
+    private let claimsStore: ClaimsStore = globalAppStateContainer.get()
 
     init() {
         addObserverForApplicationDidBecomeActive()
-        let store: HomeStore = globalAppStateContainer.get()
-        Task { await store.fetchMissedCharge() }
+        Task { await homeStore.fetchMissedCharge() }
     }
 
     func fetchHomeState() {
-        let store: HomeStore = globalAppStateContainer.get()
-        Task { await store.fetchMemberState() }
-        Task { await store.fetchImportantMessages() }
-        Task { await store.fetchQuickActions() }
-        Task { await store.fetchChatNotifications() }
-        if store.hasMissedCharge {
-            Task { await store.fetchMissedCharge() }
+        Task { await homeStore.fetchMemberState() }
+        Task { await homeStore.fetchImportantMessages() }
+        Task { await homeStore.fetchQuickActions() }
+        Task { await homeStore.fetchChatNotifications() }
+        if homeStore.hasMissedCharge {
+            Task { await homeStore.fetchMissedCharge() }
         }
         let crossSellStore: CrossSellStore = globalAppStateContainer.get()
         Task { await crossSellStore.fetchRecommendedCrossSellId() }
         Task { await contractStore.fetchContracts() }
         let paymentStore: PaymentStore = globalAppStateContainer.get()
         Task { await paymentStore.fetchPaymentStatus() }
-        chatNotificationPullTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
-        chatNotificationPullTimerCancellable = chatNotificationPullTimer.receive(on: RunLoop.main)
-            .sink { _ in
+
+        Timer.publish(every: 10, on: .main, in: .common)
+            .autoconnect()
+            .prepend(.now)
+            .receive(on: RunLoop.main)
+            .sink { [self] _ in
                 guard VisibleScreenTracker.isVisible(HomeScreen.self) else { return }
-                let store: HomeStore = globalAppStateContainer.get()
-                Task { await store.fetchChatNotifications() }
+                Task { await homeStore.fetchChatNotifications() }
             }
+            .store(in: &cancellables)
+
+        Timer.publish(every: 120, on: .main, in: .common)
+            .autoconnect()
+            .receive(on: RunLoop.main)
+            .prepend(.now)
+            .sink { [self] _ in
+                guard VisibleScreenTracker.isVisible(HomeScreen.self) else { return }
+                Task {
+                    async let fetchActive = claimsStore.fetchActiveClaims()
+                    async let fetchInProgress: Void = claimsStore.fetchClaimInProgress()
+                    _ = await (fetchActive, fetchInProgress)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     private func addObserverForApplicationDidBecomeActive() {


### PR DESCRIPTION
## [RND-2069]

- Claim card gets the light chrome and the draft card reuses ClaimStatusBar
- Sheet sections hide themselves when empty; the claims poll moves to HomeVM

## Blockers

- None

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification