### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -156,7 +156,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        Main_nativeKt.doInitKoin(
+        Main_nativeKt.doInitDiGraph(
             accessTokenFetcher: IosAccessTokenFetcher(),
             deviceIdFetcher: IosDeviceIdFetcher(),
             featureManager: IosFeatureManager(isFeatureEnabledBlock: { _ in false }),

--- a/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+DependenciesTemplate.swift
@@ -58,7 +58,7 @@ public enum ExternalDependencies: CaseIterable {
     public func swiftPackages() -> [Package] {
         switch self {
         case .apollo:
-            return [.package(url: "https://github.com/apollographql/apollo-ios", .upToNextMajor(from: "2.1.2"))]
+            return [.package(url: "https://github.com/apollographql/apollo-ios", .upToNextMajor(from: "2.3.0"))]
         case .dynamiccolor:
             return [
                 .package(url: "https://github.com/yannickl/DynamicColor", .upToNextMajor(from: "5.0.1"))
@@ -66,7 +66,7 @@ public enum ExternalDependencies: CaseIterable {
         case .disk:
             return [.package(url: "https://github.com/HedvigInsurance/Disk", .upToNextMajor(from: "0.6.6"))]
         case .kingfisher:
-            return [.package(url: "https://github.com/onevcat/Kingfisher", .upToNextMajor(from: "8.9.0"))]
+            return [.package(url: "https://github.com/onevcat/Kingfisher", .upToNextMajor(from: "8.11.0"))]
         case .snapkit:
             return [.package(url: "https://github.com/SnapKit/SnapKit", .upToNextMajor(from: "5.7.1"))]
         case .markdownkit:
@@ -78,15 +78,15 @@ public enum ExternalDependencies: CaseIterable {
             ]
         case .reveal: return []
         case .datadog:
-            return [.package(url: "https://github.com/DataDog/dd-sdk-ios.git", .exact("3.10.0"))]
+            return [.package(url: "https://github.com/DataDog/dd-sdk-ios.git", .exact("3.14.0"))]
         case .umbrella:
             if isLocalUmbrellaMode { return [] }
             return [
-                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260604114947"))
+                .package(url: "https://github.com/HedvigInsurance/umbrella.git", .exact("0.0.20260804093137"))
             ]
         case .kmpNativeCoroutines:
             return [
-                .package(url: "https://github.com/rickclephas/KMP-NativeCoroutines.git", .exact("1.0.2"))
+                .package(url: "https://github.com/rickclephas/KMP-NativeCoroutines.git", .exact("1.0.5"))
             ]
         case .tagkit:
             return [
@@ -102,15 +102,15 @@ public enum ExternalDependencies: CaseIterable {
             ]
         case .unleashProxyClientSwift:
             return [
-                .package(url: "https://github.com/Unleash/unleash-proxy-client-swift", .upToNextMajor(from: "2.4.0"))
+                .package(url: "https://github.com/Unleash/unleash-proxy-client-swift", .upToNextMajor(from: "2.5.0"))
             ]
         case .apolloIosCodegen:
             return [
-                .package(url: "https://github.com/apollographql/apollo-ios-codegen", .upToNextMajor(from: "2.1.2"))
+                .package(url: "https://github.com/apollographql/apollo-ios-codegen", .upToNextMajor(from: "2.3.0"))
             ]
         case .argumentParser:
             return [
-                .package(url: "https://github.com/apple/swift-argument-parser", .exact(.init(stringLiteral: "1.7.1")))
+                .package(url: "https://github.com/apple/swift-argument-parser", .exact(.init(stringLiteral: "1.8.2")))
             ]
         case .appStateContainer:
             return [
@@ -130,7 +130,7 @@ public enum ExternalDependencies: CaseIterable {
             ]
         case .rive:
             return [
-                .package(url: "https://github.com/rive-app/rive-ios", .upToNextMajor(from: "6.15.0"))
+                .package(url: "https://github.com/rive-app/rive-ios", .upToNextMajor(from: "6.22.0"))
             ]
         }
     }


### PR DESCRIPTION
Upgrades all direct SwiftPM dependencies that had newer releases:

| Package | From | To |
|---|---|---|
| Apollo iOS + codegen | 2.2.0 / 2.1.2 | 2.3.0 |
| Kingfisher | 8.9.0 | 8.11.0 |
| Rive | 6.20.5 | 6.22.0 |
| Unleash proxy client | 2.4.0 | 2.5.0 |
| Datadog SDK | 3.10.0 | 3.14.0 |
| umbrella | 0.0.20260604114947 | 0.0.20260804093137 |
| KMP-NativeCoroutines | 1.0.2 | 1.0.5 |
| swift-argument-parser | 1.7.1 | 1.8.2 |

Notes:
- umbrella and KMP-NativeCoroutines are bumped together — the android repo moved to kmpNativeCoroutines 1.0.5 on July 23, so the Aug 4 umbrella build requires the matching Swift package version.
- Range-pinned packages had their `from:` floors raised, since no `Package.resolved` is tracked — the floors are what guarantee CI resolves the new versions.
- Existing checked-in Apollo generated code compiles against the 2.3.0 runtime; no codegen re-run needed.
- Skipped: SnapKit 6.0.0 (major, needs migration), tuist bump, fastlane gem stack (separate PR).

Verified with a full `Ugglan` scheme simulator build — no new warnings.