### PR TITLE
fix: Onboarding test session fixes (GEN-5511)

### DIFF
--- a/Projects/Home/Tests/MockFeatureFlagsClient.swift
+++ b/Projects/Home/Tests/MockFeatureFlagsClient.swift
@@ -31,7 +31,8 @@ extension FeatureData {
             isPuppyGuideEnabled: false,
             isResumeClaimEnabled: false,
             isOnboardingEnabled: false,
-            isTerminationRedirectionEnabled: false
+            isTerminationRedirectionEnabled: false,
+            isAnalyticsEnabled: false
         )
     }
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -42,6 +42,7 @@ public struct OnboardingContract: Hashable, Identifiable, Sendable {
 }
 
 public enum OnboardingStepList {
+    @MainActor
     public static func compute(
         contracts: [Contracts.Contract],
         isPaymentConnected: Bool,
@@ -50,10 +51,13 @@ public enum OnboardingStepList {
         foreverData: ForeverData? = nil
     ) -> [OnboardingStep] {
         var steps: [OnboardingStep] = [
-            .welcome,
-            .analyticsConsent,
-            .phoneNumber(phoneNumber: contactInfo.phone),
+            .welcome
         ]
+        if Dependencies.featureFlags().isAnalyticsEnabled {
+            steps.append(.analyticsConsent)
+        }
+        steps.append(.phoneNumber(phoneNumber: contactInfo.phone))
+
         let coInsuredContracts = contracts.filter(\.hasMissingCoInsured).map(OnboardingContract.init)
         if !coInsuredContracts.isEmpty {
             steps.append(.coInsured(contracts: coInsuredContracts))

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -53,7 +53,6 @@ public enum OnboardingStepList {
             .welcome,
             .analyticsConsent,
             .phoneNumber(phoneNumber: contactInfo.phone),
-            .theme,
         ]
         let coInsuredContracts = contracts.filter(\.hasMissingCoInsured).map(OnboardingContract.init)
         if !coInsuredContracts.isEmpty {
@@ -78,6 +77,7 @@ public enum OnboardingStepList {
         if !isPaymentConnected {
             steps.append(.connectPayment(isConnected: false))
         }
+        steps.append(.theme)
         if !crossSells.isEmpty {
             steps.append(.crossSell(crossSells))
         }

--- a/Projects/Onboarding/Sources/Screens/OnboardingAnalyticsScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingAnalyticsScreen.swift
@@ -6,7 +6,7 @@ struct OnboardingAnalyticsScreen: View {
     @EnvironmentObject var vm: OnboardingNavigationViewModel
 
     var body: some View {
-        AnalyticsConsentScreen(showsGraphic: true) { _ in
+        AnalyticsConsentScreen { _ in
             await delay(0.8)
             vm.advance(after: .analyticsConsent)
         }

--- a/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
@@ -82,6 +82,7 @@ struct OnboardingMissingInfoScreen: View {
                                 .foregroundColor(hTextColor.Opaque.negative)
                         }
                         .frame(width: 20, height: 20)
+                        .transition(.scale.animation(.bouncy))
                     } else {
                         hButton(.small, .primary, content: .init(title: L10n.generalAddButton)) {
                             add(onboardingContract)
@@ -89,6 +90,7 @@ struct OnboardingMissingInfoScreen: View {
                         .accessibilityLabel(
                             L10n.generalAddButton + ", " + onboardingContract.contract.exposureDisplayNameShort
                         )
+                        .transition(.scale(scale: 0, anchor: .trailing).combined(with: .opacity).animation(.easeInOut))
                     }
                 }
                 .hRowContentAlignment(.center)
@@ -107,10 +109,9 @@ struct OnboardingMissingInfoScreen: View {
         .hFormAttachToBottom {
             hSection {
                 VStack(spacing: .padding16) {
-                    if hasMissingInfo {
-                        hText(L10n.onboardingAddInfoLaterLabel, style: .label)
-                            .foregroundColor(hTextColor.Opaque.secondary)
-                    }
+                    hText(L10n.onboardingAddInfoLaterLabel, style: .label)
+                        .foregroundColor(hTextColor.Opaque.secondary)
+                        .opacity(hasMissingInfo ? 1 : 0)
                     VStack(spacing: .padding8) {
                         hContinueButton { vm.advance(after: step) }
                     }
@@ -120,11 +121,19 @@ struct OnboardingMissingInfoScreen: View {
         }
         .onReceive(EditStakeholdersViewModel.updatedStakeholderForContractId) { contractId in
             guard let contractId, let stakeholderType = type.stakeholderType else { return }
-            vm.markStakeholderAdded(contractId: contractId, type: stakeholderType)
+            Task {
+                await delay(1)
+                vm.markStakeholderAdded(contractId: contractId, type: stakeholderType)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .petChipIdAdded)) { notification in
             guard type == .petChipIds, let model = notification.object as? PetIdAddedModel else { return }
-            vm.markPetChipIdAdded(model)
+            Task {
+                await delay(0.4)
+                vm.markPetChipIdAdded(model)
+            }
+        }
+        .task {
         }
     }
 

--- a/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
@@ -68,8 +68,7 @@ struct OnboardingMissingInfoScreen: View {
                     ContractInformation(
                         title: onboardingContract.contract.currentAgreement?.productVariant.displayName,
                         subtitle: onboardingContract.getSubtitle(),
-                        pillowImage: onboardingContract.contract.pillowType?.bgImage,
-                        size: .small
+                        pillowImage: onboardingContract.contract.pillowType?.bgImage
                     )
                 }
                 .horizontalPadding(.padding12)

--- a/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
@@ -113,11 +113,6 @@ struct OnboardingMissingInfoScreen: View {
                     }
                     VStack(spacing: .padding8) {
                         hContinueButton { vm.advance(after: step) }
-                        if hasMissingInfo {
-                            hButton(.large, .secondary, content: .init(title: L10n.onboardingDoThisLaterButton)) {
-                                vm.advance(after: step)
-                            }
-                        }
                     }
                 }
             }

--- a/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingMissingInfoScreen.swift
@@ -133,8 +133,6 @@ struct OnboardingMissingInfoScreen: View {
                 vm.markPetChipIdAdded(model)
             }
         }
-        .task {
-        }
     }
 
     private func add(_ onboardingContract: OnboardingContract) {

--- a/Projects/Onboarding/Sources/Screens/OnboardingPhoneScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingPhoneScreen.swift
@@ -3,44 +3,51 @@ import SwiftUI
 import hCore
 import hCoreUI
 
-struct OnboardingPhoneScreen: View {
+struct OnboardingPhoneScreen: View, KeyboardReadable {
     let phoneNumber: String
     @EnvironmentObject var vm: OnboardingNavigationViewModel
     @StateObject private var phoneVm = OnboardingPhoneViewModel()
     let digits = [["1", "2", "3"], ["4", "5", "6"], ["7", "8", "9"], ["*", "0", "#"]]
     @State private var animateDigits: [String] = []
+    @State private var keyboardVisible = false
     var body: some View {
         hForm {
-            hSection {
-                VStack(spacing: .padding8) {
-                    ForEach(digits, id: \.self) { row in
-                        HStack(spacing: .padding10) {
-                            ForEach(row, id: \.self) { digit in
-                                hText(digit)
-                                    .frame(width: 36, height: 36)
-                                    .background(getColor(for: digit))
-                                    .cornerRadius(.padding12)
-                                    .scaleEffect(animateDigits.contains(digit) ? 1.25 : 1)
-                                    .animation(.defaultSpring, value: animateDigits.contains(digit))
-                                    .onTapGesture {
-                                        if Int(digit) != nil {
-                                            phoneVm.phone.append(digit)
+            if !keyboardVisible {
+                hSection {
+                    VStack(spacing: .padding8) {
+                        ForEach(digits, id: \.self) { row in
+                            HStack(spacing: .padding10) {
+                                ForEach(row, id: \.self) { digit in
+                                    hText(digit)
+                                        .frame(width: 44, height: 44)
+                                        .background(getColor(for: digit))
+                                        .cornerRadius(.padding12)
+                                        .scaleEffect(animateDigits.contains(digit) ? 1.25 : 1)
+                                        .animation(.defaultSpring, value: animateDigits.contains(digit))
+                                        .onTapGesture {
+                                            if Int(digit) != nil {
+                                                phoneVm.phone.append(digit)
+                                            }
+                                            ImpactGenerator.soft()
+                                            animateDigits.append(digit)
+                                            Task {
+                                                await delay(0.2)
+                                                animateDigits.removeFirst()
+                                            }
                                         }
-                                        ImpactGenerator.soft()
-                                        animateDigits.append(digit)
-                                        Task {
-                                            await delay(0.2)
-                                            animateDigits.removeFirst()
-                                        }
-                                    }
-                                    .accessibilityAddTraits(.isButton)
+                                        .accessibilityAddTraits(.isButton)
+                                        .accessibilityHidden(true)
+                                }
                             }
                         }
                     }
+                    .padding(.vertical, .padding16)
                 }
+                .sectionContainerStyle(.transparent)
+                .transition(.opacity)
             }
-            .sectionContainerStyle(.transparent)
         }
+        .hSetScrollBounce(to: true)
         .hFormTitle(
             title: .init(.small, .body1, L10n.onboardingPhoneTitle, alignment: .leading),
             subTitle: .init(
@@ -80,6 +87,10 @@ struct OnboardingPhoneScreen: View {
         }
         .disabled(phoneVm.isLoading)
         .onAppear { phoneVm.prefill(phone: phoneNumber) }
+        .onReceive(keyboardPublisher) { keyboardHeight in
+            withAnimation(.spring) { keyboardVisible = keyboardHeight != nil }
+        }
+        .dismissKeyboard()
     }
 
     @hColorBuilder

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -9,7 +9,7 @@ public class OnboardingClientDemo: OnboardingClient {
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         await delay(1)
-        return await OnboardingClientDemo.getSteps()
+        return OnboardingClientDemo.getSteps()
     }
 
     public func updateContactInfo(phone: String) async throws {}

--- a/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
+++ b/Projects/Onboarding/Sources/Service/DemoImplementation/OnboardingClientDemo.swift
@@ -9,7 +9,7 @@ public class OnboardingClientDemo: OnboardingClient {
 
     public func getOnboardingSteps() async throws -> [OnboardingStep] {
         await delay(1)
-        return OnboardingClientDemo.getSteps()
+        return await OnboardingClientDemo.getSteps()
     }
 
     public func updateContactInfo(phone: String) async throws {}

--- a/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
+++ b/Projects/Onboarding/Tests/OnboardingStepComputationTests.swift
@@ -8,6 +8,17 @@ import hCore
 
 @MainActor
 final class OnboardingStepComputationTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        Dependencies.shared.add(module: Module { () -> FeatureFlags in FeatureFlags.shared })
+        FeatureFlags.shared.data = .mock(isAnalyticsEnabled: true)
+    }
+
+    override func tearDown() async throws {
+        FeatureFlags.shared.data = .mock(isAnalyticsEnabled: false)
+        try await super.tearDown()
+    }
+
     func testStaticStepsAlwaysPresent() {
         let steps = OnboardingStepList.compute(
             contracts: [],
@@ -23,6 +34,16 @@ final class OnboardingStepComputationTests: XCTestCase {
                 .theme,
             ]
         )
+    }
+
+    func testAnalyticsConsentStepHiddenWhenAnalyticsDisabled() {
+        FeatureFlags.shared.data = .mock(isAnalyticsEnabled: false)
+        let steps = OnboardingStepList.compute(
+            contracts: [],
+            isPaymentConnected: true,
+            crossSells: []
+        )
+        XCTAssertFalse(steps.contains(.analyticsConsent))
     }
 
     func testPhoneNumberStepCarriesContactInfo() {
@@ -158,11 +179,11 @@ final class OnboardingStepComputationTests: XCTestCase {
                 .welcome,
                 .analyticsConsent,
                 .phoneNumber(phoneNumber: ""),
-                .theme,
                 .coInsured(contracts: [.init(contract: contract)]),
                 .coOwners(contracts: [.init(contract: contract)]),
                 .petChipIds(contracts: [.init(contract: contract)]),
                 .connectPayment(isConnected: false),
+                .theme,
                 .crossSell([.mock]),
             ]
         )
@@ -200,6 +221,25 @@ extension OnboardingStepComputationTests {
             coInsured: coInsured,
             coOwners: coOwners,
             missingPetChipId: missingPetChipId
+        )
+    }
+}
+
+extension FeatureData {
+    fileprivate static func mock(isAnalyticsEnabled: Bool) -> FeatureData {
+        .init(
+            isUpdateNecessary: false,
+            isSubmitClaimEnabled: false,
+            osVersionTooLow: false,
+            emailPreferencesEnabled: false,
+            isDemoMode: false,
+            isAddonsRemovalFromMovingFlowEnabled: false,
+            isNewConversationFromInboxEnabled: false,
+            isPuppyGuideEnabled: false,
+            isResumeClaimEnabled: false,
+            isOnboardingEnabled: true,
+            isTerminationRedirectionEnabled: false,
+            isAnalyticsEnabled: isAnalyticsEnabled
         )
     }
 }

--- a/Projects/Profile/Sources/Views/Screens/SettingsScreen/AnalyticsConsentScreen.swift
+++ b/Projects/Profile/Sources/Views/Screens/SettingsScreen/AnalyticsConsentScreen.swift
@@ -6,27 +6,22 @@ public struct AnalyticsConsentScreen: View {
     @AppStorage(AnalyticsConsent.hasConsentedKey) private var consentGiven: Bool?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var handlingConsent = false
-    private let showsGraphic: Bool
     private let onConsentSelected: @MainActor (_ given: Bool) async -> Void
 
     public init(
-        showsGraphic: Bool = false,
         onConsentSelected: @escaping @MainActor (_ given: Bool) async -> Void
     ) {
-        self.showsGraphic = showsGraphic
         self.onConsentSelected = onConsentSelected
     }
 
     public var body: some View {
         hForm {
-            if showsGraphic {
-                hSection {
-                    VStack(spacing: .padding16) {
-                        graphic
-                    }
+            hSection {
+                VStack(spacing: .padding16) {
+                    graphic
                 }
-                .sectionContainerStyle(.transparent)
             }
+            .sectionContainerStyle(.transparent)
         }
         .hFormContentPosition(.center)
         .hFormTitle(

--- a/Projects/Profile/Sources/Views/Screens/SettingsScreen/AnalyticsConsentScreen.swift
+++ b/Projects/Profile/Sources/Views/Screens/SettingsScreen/AnalyticsConsentScreen.swift
@@ -5,7 +5,7 @@ import hCoreUI
 public struct AnalyticsConsentScreen: View {
     @AppStorage(AnalyticsConsent.hasConsentedKey) private var consentGiven: Bool?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var handlingConsent = true
+    @State private var handlingConsent = false
     private let showsGraphic: Bool
     private let onConsentSelected: @MainActor (_ given: Bool) async -> Void
 
@@ -43,31 +43,39 @@ public struct AnalyticsConsentScreen: View {
                 VStack(spacing: .padding16) {
                     privacyPolicyLink
                     VStack(spacing: .padding8) {
-                        hButton(.large, .secondary, content: .init(title: L10n.onboardingAnalyticsAllowButton)) {
-                            select(given: true)
+                        hButton(
+                            .large,
+                            consentGiven == true ? .primary : .secondary,
+                            content: .init(title: L10n.onboardingAnalyticsAllowButton)
+                        ) {
+                            await select(given: true)
                         }
-                        hButton(.large, .secondary, content: .init(title: L10n.onboardingAnalyticsDenyButton)) {
-                            select(given: false)
+                        hButton(
+                            .large,
+                            consentGiven == false ? .primary : .secondary,
+                            content: .init(title: L10n.onboardingAnalyticsDenyButton)
+                        ) {
+                            await select(given: false)
                         }
                     }
-                    .disabled(!handlingConsent)
                 }
             }
             .sectionContainerStyle(.transparent)
         }
     }
 
-    private func select(given: Bool) {
-        if given {
-            AnalyticsConsent.give()
-        } else {
-            AnalyticsConsent.revoke()
+    private func select(given: Bool) async {
+        guard !handlingConsent else { return }
+        withAnimation {
+            if given {
+                AnalyticsConsent.give()
+            } else {
+                AnalyticsConsent.revoke()
+            }
         }
+        handlingConsent = true
+        await onConsentSelected(given)
         handlingConsent = false
-        Task {
-            await onConsentSelected(given)
-            handlingConsent = true
-        }
     }
 
     private var graphic: some View {

--- a/Projects/Profile/Sources/Views/Screens/SettingsScreen/SettingsView.swift
+++ b/Projects/Profile/Sources/Views/Screens/SettingsScreen/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @EnvironmentObject var profileNavigationVm: ProfileNavigationViewModel
     @AppStorage(ThemeOption.storageKey) private var themeRawValue = ThemeOption.system.rawValue
     @AppStorage(AnalyticsConsent.hasConsentedKey) private var analyticsConsentGiven: Bool?
+    @InjectObservableObject var featureFlags: FeatureFlags
 
     var body: some View {
         hForm {
@@ -46,14 +47,16 @@ struct SettingsView: View {
                     )
                     MemberSubscriptionPreferenceView(vm: memberSubscriptionPreferenceVm)
                         .environmentObject(profileNavigationVm)
-                    hFloatingField(
-                        value: analyticsConsentGiven == true
-                            ? L10n.settingsUsageDataEnabled : L10n.settingsUsageDataDisabled,
-                        placeholder: L10n.settingsUsageDataTitle,
-                        onTap: {
-                            profileNavigationVm.profileRouter.push(ProfileRouterType.usageData)
-                        }
-                    )
+                    if featureFlags.isAnalyticsEnabled {
+                        hFloatingField(
+                            value: analyticsConsentGiven == true
+                                ? L10n.settingsUsageDataEnabled : L10n.settingsUsageDataDisabled,
+                            placeholder: L10n.settingsUsageDataTitle,
+                            onTap: {
+                                profileNavigationVm.profileRouter.push(ProfileRouterType.usageData)
+                            }
+                        )
+                    }
                 }
                 .accessibilityAddTraits(.isButton)
                 NotificationsCardView()

--- a/Projects/hCore/Sources/AskForRating.swift
+++ b/Projects/hCore/Sources/AskForRating.swift
@@ -11,6 +11,7 @@ public struct AskForRating {
         UserDefaults.standard.set(numberOfSessions, forKey: userDefaultsKey)
     }
 
+    @MainActor
     public func askAccordingToTheNumberOfSessions() {
         guard !UserDefaults.standard.bool(forKey: userDefaultsCompletedKey) else { return }
 
@@ -21,7 +22,11 @@ public struct AskForRating {
         }
     }
 
+    @MainActor
     public func askForReview() {
+        if Dependencies.featureFlags().isOnboardingEnabled && !OnboardingPresentationState.hasSeenOnboarding {
+            return
+        }
         guard !UserDefaults.standard.bool(forKey: userDefaultsCompletedKey) else { return }
         UserDefaults.standard.set(true, forKey: userDefaultsCompletedKey)
         DispatchQueue.main.async {

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagUnleash.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagUnleash.swift
@@ -85,7 +85,8 @@ public class FeatureFlagsUnleash: FeatureFlagsClient {
             isPuppyGuideEnabled: !unleashClient.isEnabled(name: "disable_puppy_guide"),
             isResumeClaimEnabled: unleashClient.isEnabled(name: "enable_claim_intent_resume"),
             isOnboardingEnabled: !unleashClient.isEnabled(name: "disable_onboarding"),
-            isTerminationRedirectionEnabled: !unleashClient.isEnabled(name: "disable_termination_redirection")
+            isTerminationRedirectionEnabled: !unleashClient.isEnabled(name: "disable_termination_redirection"),
+            isAnalyticsEnabled: !unleashClient.isEnabled(name: "disable_analytics")
         )
         featureDataPublisher.send(data)
     }

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagsDemo.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagsDemo.swift
@@ -21,7 +21,8 @@ public class FeatureFlagsDemo: @unchecked Sendable, FeatureFlagsClient {
             isPuppyGuideEnabled: false,
             isResumeClaimEnabled: false,
             isOnboardingEnabled: false,
-            isTerminationRedirectionEnabled: false
+            isTerminationRedirectionEnabled: false,
+            isAnalyticsEnabled: false
         )
         featureDataPublisher.send(data)
     }
@@ -38,7 +39,8 @@ public class FeatureFlagsDemo: @unchecked Sendable, FeatureFlagsClient {
             isPuppyGuideEnabled: false,
             isResumeClaimEnabled: false,
             isOnboardingEnabled: false,
-            isTerminationRedirectionEnabled: false
+            isTerminationRedirectionEnabled: false,
+            isAnalyticsEnabled: false
         )
         featureDataPublisher.send(data)
     }

--- a/Projects/hCore/Sources/FeatureFlags/FeatureFlagsProtocol.swift
+++ b/Projects/hCore/Sources/FeatureFlags/FeatureFlagsProtocol.swift
@@ -20,6 +20,7 @@ public struct FeatureData: Codable, Equatable {
     public let isResumeClaimEnabled: Bool
     public let isOnboardingEnabled: Bool
     public let isTerminationRedirectionEnabled: Bool
+    public let isAnalyticsEnabled: Bool
 
     public init(
         isUpdateNecessary: Bool,
@@ -32,7 +33,8 @@ public struct FeatureData: Codable, Equatable {
         isPuppyGuideEnabled: Bool,
         isResumeClaimEnabled: Bool,
         isOnboardingEnabled: Bool,
-        isTerminationRedirectionEnabled: Bool
+        isTerminationRedirectionEnabled: Bool,
+        isAnalyticsEnabled: Bool
     ) {
         self.isUpdateNecessary = isUpdateNecessary
         self.isSubmitClaimEnabled = isSubmitClaimEnabled
@@ -45,6 +47,7 @@ public struct FeatureData: Codable, Equatable {
         self.isResumeClaimEnabled = isResumeClaimEnabled
         self.isOnboardingEnabled = isOnboardingEnabled
         self.isTerminationRedirectionEnabled = isTerminationRedirectionEnabled
+        self.isAnalyticsEnabled = isAnalyticsEnabled
     }
 }
 
@@ -77,7 +80,8 @@ public class FeatureFlags: ObservableObject {
         isPuppyGuideEnabled: false,
         isResumeClaimEnabled: false,
         isOnboardingEnabled: false,
-        isTerminationRedirectionEnabled: true
+        isTerminationRedirectionEnabled: false,
+        isAnalyticsEnabled: false
     )
 
     @Published public var hasFetchedInitialData = false

--- a/Projects/hCore/Sources/Masking.swift
+++ b/Projects/hCore/Sources/Masking.swift
@@ -64,7 +64,7 @@ public struct Masking {
         case .none: return true
         case .disabledSuggestion: return true
         case .phoneNumber:
-            let phoneRegEx = "^\\+?[0-9]{7,15}$"
+            let phoneRegEx = "^\\+?[0-9]{6,15}$"
             let phonePredicate = NSPredicate(format: "SELF MATCHES %@", phoneRegEx)
             return phonePredicate.evaluate(with: text)
         case .euroBonus: return text.count > 3

--- a/Projects/hCoreUI/Sources/Views/ContractInformation.swift
+++ b/Projects/hCoreUI/Sources/Views/ContractInformation.swift
@@ -5,20 +5,17 @@ public struct ContractInformation: View {
     let subtitle: String?
     let pillowImage: Image?
     let status: String?
-    let size: ContractInformationSizeType
 
     public init(
         title: String?,
         subtitle: String?,
         pillowImage: Image?,
-        status: String? = nil,
-        size: ContractInformationSizeType = .regular,
+        status: String? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
         self.pillowImage = pillowImage
         self.status = status
-        self.size = size
     }
 
     public var body: some View {
@@ -26,11 +23,11 @@ public struct ContractInformation: View {
             if let pillowImage {
                 pillowImage
                     .resizable()
-                    .frame(width: size.pillowSize, height: size.pillowSize)
+                    .frame(width: 48, height: 48)
             }
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center) {
-                    hText(title ?? "", style: size.titleStyle)
+                    hText(title ?? "", style: .heading1)
                     Spacer()
                     if let status {
                         hPill(text: status, color: .grey)
@@ -39,7 +36,7 @@ public struct ContractInformation: View {
                     }
                 }
                 if let subtitle {
-                    hText(subtitle, style: size.subtitleStyle)
+                    hText(subtitle, style: .body1)
                         .foregroundColor(hTextColor.Translucent.secondary)
                         .transition(.opacity)
                 }
@@ -47,38 +44,6 @@ public struct ContractInformation: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .accessibilityElement(children: .combine)
-    }
-}
-
-public enum ContractInformationSizeType {
-    case regular
-    case small
-
-    var pillowSize: CGFloat {
-        switch self {
-        case .regular:
-            return 48
-        case .small:
-            return 40
-        }
-    }
-
-    var titleStyle: HFontTextStyle {
-        switch self {
-        case .regular:
-            return .heading1
-        case .small:
-            return .label
-        }
-    }
-
-    var subtitleStyle: HFontTextStyle {
-        switch self {
-        case .regular:
-            return .body1
-        case .small:
-            return .label
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Fixes for the iOS items from the onboarding test session ([Notion page](https://app.notion.com/p/hedviginsurance/Onboarding-3c2c3f71cb0a80ce97cddd8937206d9f)):

- **Showing rate** — skip asking for App Store review while onboarding is enabled
- **Skip analytics screen until legal is done** — added analytics feature flag
- **Data consent Allow/Deny** — buttons are no longer disabled after selection; the selected choice is highlighted instead
- **Move theme step after "bank"** — theme step now comes after the connect payment step
- **Animate checkmark after adding co-insured info / chip ID** — added delay for added missing info + transitions when returning to the onboarding flow
- **"Do it later" button when info is already added** — only the continue button is shown on the missing info screen when everything is filled in
- **Chip ID screen font size / updated Figma design** — removed ContractInformation size option
- **Number pad for screen readers** — number pad is hidden when the keyboard is presented