### PR TITLE
feat: change insurance amount wording for payment protection in tier flow

### DIFF
--- a/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
@@ -80,13 +80,13 @@ public struct ChangeTierLandingScreen: View {
                 title: .init(
                     .small,
                     .body2,
-                    L10n.tierFlowTitle,
+                    vm.flowTitle,
                     alignment: .leading
                 ),
                 subTitle: .init(
                     .small,
                     .body2,
-                    vm.canEditDeductible ? L10n.tierFlowSubtitle : L10n.tierFlowSubtitleWithoutDeductible
+                    vm.flowSubtitle
                 )
             )
             .hFormAttachToBottom {
@@ -161,7 +161,7 @@ public struct ChangeTierLandingScreen: View {
                 VStack(alignment: .leading, spacing: .padding4) {
                     hFloatingField(
                         value: vm.selectedTier?.name ?? "",
-                        placeholder: L10n.tierFlowCoverageLabel
+                        placeholder: vm.tierFieldLabel
                     ) {}
                     .hBackgroundOption(option: [.locked])
                     .hFieldTrailingView {
@@ -178,13 +178,13 @@ public struct ChangeTierLandingScreen: View {
         } else {
             DropdownView(
                 value: vm.selectedTier?.name ?? "",
-                placeHolder: vm.selectedTier != nil
-                    ? L10n.tierFlowCoverageLabel : L10n.tierFlowCoveragePlaceholder
+                placeHolder: vm.tierFieldPlaceholder
             ) { [weak vm, weak changeTierNavigationVm] in
-                let selectedItem = vm?.selectedTier?.name ?? vm?.tiers.first?.name
-                changeTierNavigationVm?.isEditTierPresented = .init(
+                guard let vm, let changeTierNavigationVm else { return }
+                let selectedItem = vm.selectedTier?.name ?? vm.tiers.first?.name
+                changeTierNavigationVm.isEditTierPresented = .init(
                     selectedItem: selectedItem,
-                    type: .tiers(tiers: vm?.tiers.sorted(by: { $0.level < $1.level }) ?? [])
+                    type: .tiers(tiers: vm.tiers.sorted(by: { $0.level < $1.level }))
                 )
             }
             .accessibilityHint(L10n.voiceoverPressTo + L10n.contractEditInfo)

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -292,6 +292,41 @@ public class ChangeTierViewModel: ObservableObject {
         calculateTotal()
     }
 
+    var isPaymentProtection: Bool {
+        typeOfContract?.isPaymentProtection == true
+    }
+
+    var flowTitle: String {
+        isPaymentProtection ? L10n.InsuranceDetails.changeAmount : L10n.tierFlowTitle
+    }
+
+    var flowSubtitle: String {
+        if isPaymentProtection {
+            return L10n.InsuranceDetails.changeAmountSubtitle
+        }
+        return canEditDeductible ? L10n.tierFlowSubtitle : L10n.tierFlowSubtitleWithoutDeductible
+    }
+
+    var tierFieldLabel: String {
+        isPaymentProtection ? L10n.tierFlowSelectPaymentProtectionDropdownTitle : L10n.tierFlowCoverageLabel
+    }
+
+    var tierFieldPlaceholder: String {
+        if selectedTier != nil {
+            return tierFieldLabel
+        }
+        return isPaymentProtection
+            ? L10n.tierFlowSelectPaymentProtectionDropdownTitle : L10n.tierFlowCoveragePlaceholder
+    }
+
+    var selectTierTitle: String {
+        isPaymentProtection ? L10n.offerPresenterInsuranceAmountTitle : L10n.tierFlowSelectCoverageTitle
+    }
+
+    var selectTierSubtitle: String {
+        isPaymentProtection ? L10n.InsuranceDetails.changeAmountSubtitle : L10n.tierFlowSelectCoverageSubtitle
+    }
+
     private func getData() async throws -> ChangeTierIntentModelState {
         switch changeTierInput {
         case let .contractWithSource(source):

--- a/Projects/ChangeTier/Sources/Views/EditScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/EditScreen.swift
@@ -22,10 +22,10 @@ struct EditScreen: View {
         hForm {
             hSection {
                 VStack(alignment: .leading, spacing: 0) {
-                    hText(type.title, style: .heading1)
+                    hText(title, style: .heading1)
                         .foregroundColor(hTextColor.Opaque.primary)
                         .accessibilityAddTraits(.isHeader)
-                    hText(type.subTitle, style: .heading1)
+                    hText(subTitle, style: .heading1)
                         .foregroundColor(hTextColor.Opaque.secondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -41,6 +41,22 @@ struct EditScreen: View {
         .hFormContentPosition(.compact)
         .hFormAttachToBottom {
             bottomView
+        }
+    }
+
+    private var title: String {
+        switch type {
+        case .tiers: return vm.selectTierTitle
+        case .deductible: return L10n.tierFlowSelectDeductibleTitle
+        case let .addon(addon): return addon.addonSubtype
+        }
+    }
+
+    private var subTitle: String {
+        switch type {
+        case .tiers: return vm.selectTierSubtitle
+        case .deductible: return L10n.tierFlowSelectDeductibleSubtitle
+        case .addon: return L10n.tierFlowSelectAddonSubtitle
         }
     }
 
@@ -193,22 +209,6 @@ enum EditTierType: Equatable {
     case tiers(tiers: [Tier])
     case deductible(quotes: [Quote])
     case addon(addon: AddonQuote)
-
-    var title: String {
-        switch self {
-        case .tiers: return L10n.tierFlowSelectCoverageTitle
-        case .deductible: return L10n.tierFlowSelectDeductibleTitle
-        case let .addon(addon): return addon.addonSubtype
-        }
-    }
-
-    var subTitle: String {
-        switch self {
-        case .tiers: return L10n.tierFlowSelectCoverageSubtitle
-        case .deductible: return L10n.tierFlowSelectDeductibleSubtitle
-        case .addon: return L10n.tierFlowSelectAddonSubtitle
-        }
-    }
 }
 
 #Preview {

--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -65,6 +65,7 @@ public struct ContractsNavigation<Content: View>: View {
         ) { contract in
             EditContractScreen(
                 editTypes: EditType.getTypes(for: contract),
+                isPaymentProtection: contract.typeOfContract.isPaymentProtection,
                 onSelectedType: { selectedType in
                     contractsNavigationVm.changeYourInformationContract = nil
                     switch selectedType {

--- a/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
+++ b/Projects/Home/Sources/Navigation/HelpCenterNavigation.swift
@@ -174,6 +174,8 @@ public struct HelpCenterNavigation<Content: View>: View {
             content: { actionsWrapper in
                 EditContractScreen(
                     editTypes: actionsWrapper.quickActions.compactMap(\.asEditType),
+                    isPaymentProtection: !tierChangeableContracts.isEmpty
+                        && tierChangeableContracts.allSatisfy(\.typeOfContract.isPaymentProtection),
                     onSelectedType: { selectedType in
                         handle(quickAction: selectedType.asQuickAction)
                     }
@@ -225,6 +227,10 @@ public struct HelpCenterNavigation<Content: View>: View {
         .environmentObject(helpCenterVm)
     }
 
+    private var tierChangeableContracts: [Contracts.Contract] {
+        contractStore.activeContracts.filter(\.supportsChangeTier)
+    }
+
     private func handle(quickAction: QuickAction) {
         switch quickAction {
         case .connectPayments:
@@ -249,8 +255,8 @@ public struct HelpCenterNavigation<Content: View>: View {
         case .editCoInsured: helpCenterVm.editStakeholdersVm.start(stakeholderType: .coInsured)
         case .editCoOwners: helpCenterVm.editStakeholdersVm.start(stakeholderType: .coOwner)
         case .upgradeCoverage:
-            let contractsSupportingChangingTier: [ChangeTierContract] = contractStore.activeContracts
-                .filter(\.supportsChangeTier)
+            let contractsSupportingChangingTier: [ChangeTierContract] =
+                tierChangeableContracts
                 .map {
                     .init(
                         contractId: $0.id,

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -407,24 +407,25 @@ A message is then appended under the image next to the timestamp to indicate tha
 "MY_PAYMENT_TITLE" = "Payments";
 "MY_PAYMENT_UPDATING_MESSAGE" = "You have just added or changed your bank account, your new bank account will appear here after your bank has accepted autogiro. Usually within 2 working days.";
 "NEW_MESSAGE_BUTTON" = "New message";
+"OFFER_PRESENTER_INSURANCE_AMOUNT_TITLE" = "Choose insurance amount";
 "OFFER_UPDATE_SUMMARY_TITLE" = "Summary";
 "ONBOARDING_ADDED_LABEL" = "Added";
 "ONBOARDING_ADD_BUTTON" = "Add";
 "ONBOARDING_ADD_COINSURED_TITLE" = "Add co-insured";
 "ONBOARDING_ADD_COOWNERS_TITLE" = "Add co-owners";
-"ONBOARDING_ADD_INFO_LATER_LABEL" = "You can add this information later";
+"ONBOARDING_ADD_INFO_LATER_LABEL" = "You can add this later";
 "ONBOARDING_ADD_PET_CHIP_IDS_TITLE" = "Add your pets ID numbers";
 "ONBOARDING_ANALYTICS_ALLOW_BUTTON" = "Allow";
-"ONBOARDING_ANALYTICS_DENY_BUTTON" = "Deny";
-"ONBOARDING_ANALYTICS_SUBTITLE" = "We use technical tools to see how you use the app, so we can make it better.\n\nProduct analytics is completely optional and can be turned off any time in settings. This data is never used for marketing.";
+"ONBOARDING_ANALYTICS_DENY_BUTTON" = "Don't allow";
+"ONBOARDING_ANALYTICS_SUBTITLE" = "We use technical tools to collect data on how you use the app, so we can improve the experience.\n\nProduct analytics is completely optional and can be turned off anytime in settings. This data is not used for marketing.";
 "ONBOARDING_ANALYTICS_TITLE" = "Help us make the app better";
-"ONBOARDING_CHANGE_SETTINGS_LATER_LABEL" = "You can change these settings later";
+"ONBOARDING_CHANGE_SETTINGS_LATER_LABEL" = "You can change this anytime in settings";
 "ONBOARDING_CONNECT_PAYMENT_BANK_LABEL" = "Bank";
-"ONBOARDING_CONNECT_PAYMENT_FOOTNOTE" = "Adding a payment method is required to keep your insurance active";
-"ONBOARDING_CONNECT_PAYMENT_SUBTITLE" = "Add a payment method to activate your insurance";
+"ONBOARDING_CONNECT_PAYMENT_FOOTNOTE" = "You can change accounts later in settings";
+"ONBOARDING_CONNECT_PAYMENT_SUBTITLE" = "You need to connect a payment method to keep your insurance active";
 "ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER" = "You can switch accounts later in settings";
-"ONBOARDING_CONNECT_PAYMENT_TITLE" = "Connect payment";
-"ONBOARDING_CONTINUE_TO_APP_BUTTON" = "Continue to app";
+"ONBOARDING_CONNECT_PAYMENT_TITLE" = "Connect payment method";
+"ONBOARDING_CONTINUE_TO_APP_BUTTON" = "Go to the app";
 "ONBOARDING_CROSS_SELL_SUBTITLE" = "You get a 15%% discount when you have two or more insurances with us. The discount applies to home, car, and pet insurance";
 "ONBOARDING_CROSS_SELL_TITLE" = "Get bundle discount";
 "ONBOARDING_DO_THIS_LATER_BUTTON" = "Do this later";
@@ -673,6 +674,7 @@ figma: https://www.figma.com/design/SNVLvLq7ztclXiDqqMNXgY?node-id=419-7269#9590
 "TIER_FLOW_SELECT_DEDUCTIBLE_SUBTITLE" = "Amount deducted from your compensation";
 "TIER_FLOW_SELECT_DEDUCTIBLE_TITLE" = "Select your deductible";
 "TIER_FLOW_SELECT_INSURANCE_SUBTITLE" = "Select the insurance you want to edit";
+"TIER_FLOW_SELECT_PAYMENT_PROTECTION_DROPDOWN_TITLE" = "Monthly compensation";
 /* button on Summary screen */
 "TIER_FLOW_SHOW_COVERAGE" = "Show your coverage";
 "TIER_FLOW_SUBTITLE" = "Set your coverage level and deductible";
@@ -838,6 +840,8 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "insurance_certificate_title" = "Insurance certificate";
 /* Figma */
 "insurance_details.change_address_button" = "Change address";
+"insurance_details.change_amount" = "Change insurance amount";
+"insurance_details.change_amount_subtitle" = "Your monthly compensation";
 "insurance_details.change_coverage" = "Change coverage";
 "insurance_details.move_button" = "Move to new address";
 /* Figma */

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -407,24 +407,25 @@ A message is then appended under the image next to the timestamp to indicate tha
 "MY_PAYMENT_TITLE" = "Betalning";
 "MY_PAYMENT_UPDATING_MESSAGE" = "Du har precis lagt till eller ändrat ditt bankkonto, ditt nya bankkonto kommer synas här efter din bank accepterat autogirot inom 2 arbetsdagar.";
 "NEW_MESSAGE_BUTTON" = "Nytt meddelande";
+"OFFER_PRESENTER_INSURANCE_AMOUNT_TITLE" = "Välj försäkringsbelopp";
 "OFFER_UPDATE_SUMMARY_TITLE" = "Sammanfattning";
 "ONBOARDING_ADDED_LABEL" = "Tillagd";
 "ONBOARDING_ADD_BUTTON" = "Lägg till";
 "ONBOARDING_ADD_COINSURED_TITLE" = "Lägg till medförsäkrade";
-"ONBOARDING_ADD_COOWNERS_TITLE" = "Lägg till medägare";
-"ONBOARDING_ADD_INFO_LATER_LABEL" = "Du kan lägga till informationen senare";
+"ONBOARDING_ADD_COOWNERS_TITLE" = "Lägg till delägare";
+"ONBOARDING_ADD_INFO_LATER_LABEL" = "Du kan lägga till det här senare";
 "ONBOARDING_ADD_PET_CHIP_IDS_TITLE" = "Lägg till dina djurs ID-nummer";
 "ONBOARDING_ANALYTICS_ALLOW_BUTTON" = "Tillåt";
-"ONBOARDING_ANALYTICS_DENY_BUTTON" = "Neka";
-"ONBOARDING_ANALYTICS_SUBTITLE" = "Vi använder tekniska verktyg för att se hur du använder appen, så att vi kan göra den bättre.\n\nProduktanalys är helt frivilligt och kan när som helst stängas av i inställningarna. Denna data används aldrig för marknadsföring.";
-"ONBOARDING_ANALYTICS_TITLE" = "Hjälp oss göra appen bättre";
-"ONBOARDING_CHANGE_SETTINGS_LATER_LABEL" = "Du kan ändra inställningarna senare";
+"ONBOARDING_ANALYTICS_DENY_BUTTON" = "Tillåt inte";
+"ONBOARDING_ANALYTICS_SUBTITLE" = "Vi använder tekniska verktyg för att samla in data om hur du använder appen, så att vi kan förbättra upplevelsen.\n\nProduktanalysen är helt frivillig och kan stängas av när du vill i inställningarna. Uppgifterna används inte för marknadsföring.";
+"ONBOARDING_ANALYTICS_TITLE" = "Hjälp oss att göra appen bättre";
+"ONBOARDING_CHANGE_SETTINGS_LATER_LABEL" = "Du kan ändra det här när du vill i inställningarna";
 "ONBOARDING_CONNECT_PAYMENT_BANK_LABEL" = "Bank";
 "ONBOARDING_CONNECT_PAYMENT_FOOTNOTE" = "Du behöver lägga till ett betalsätt för att din försäkring ska fortsätta gälla";
-"ONBOARDING_CONNECT_PAYMENT_SUBTITLE" = "Lägg till ett betalsätt för att aktivera din försäkring";
+"ONBOARDING_CONNECT_PAYMENT_SUBTITLE" = "Du behöver lägga till en betalningsmetod för att din försäkring ska fortsätta gälla";
 "ONBOARDING_CONNECT_PAYMENT_SWITCH_ACCOUNTS_LATER" = "Du kan byta konto senare i inställningar";
 "ONBOARDING_CONNECT_PAYMENT_TITLE" = "Koppla betalning";
-"ONBOARDING_CONTINUE_TO_APP_BUTTON" = "Fortsätt till appen";
+"ONBOARDING_CONTINUE_TO_APP_BUTTON" = "Till appen";
 "ONBOARDING_CROSS_SELL_SUBTITLE" = "Du får 15%% samlingsrabatt när du har två eller fler försäkringar för hem, bil eller djur";
 "ONBOARDING_CROSS_SELL_TITLE" = "Få samlingsrabatt";
 "ONBOARDING_DO_THIS_LATER_BUTTON" = "Gör det senare";
@@ -673,6 +674,7 @@ figma: https://www.figma.com/design/SNVLvLq7ztclXiDqqMNXgY?node-id=419-7269#9590
 "TIER_FLOW_SELECT_DEDUCTIBLE_SUBTITLE" = "Belopp avdraget från din ersättning";
 "TIER_FLOW_SELECT_DEDUCTIBLE_TITLE" = "Välj din självrisk";
 "TIER_FLOW_SELECT_INSURANCE_SUBTITLE" = "Välj den försäkring du vill uppdatera";
+"TIER_FLOW_SELECT_PAYMENT_PROTECTION_DROPDOWN_TITLE" = "Ersättning per månad";
 /* button on Summary screen */
 "TIER_FLOW_SHOW_COVERAGE" = "Visa ditt skydd";
 "TIER_FLOW_SUBTITLE" = "Välj din skyddsnivå och självrisk";
@@ -838,6 +840,8 @@ We want members to submit a bug report to us directly instead of writing bad rev
 "insurance_certificate_title" = "Försäkringsbrev";
 /* Figma */
 "insurance_details.change_address_button" = "Ändra adress";
+"insurance_details.change_amount" = "Ändra försäkringsbelopp";
+"insurance_details.change_amount_subtitle" = "Ersättning per månad";
 "insurance_details.change_coverage" = "Ändra skydd";
 "insurance_details.move_button" = "Flytta till ny adress";
 /* Figma */

--- a/Projects/hCore/Sources/Models/EditType.swift
+++ b/Projects/hCore/Sources/Models/EditType.swift
@@ -6,23 +6,27 @@ public enum EditType: String, Codable, Hashable, CaseIterable {
     case cancellation
     case removeAddons
 
-    public var title: String {
+    /// Payment protection contracts reuse the tier flow with "insurance amount" wording instead of "coverage".
+    public func title(isPaymentProtection: Bool = false) -> String {
         switch self {
         case .coInsured: return L10n.contractEditCoinsured
         case .coOwners: return L10n.editCoownerTitle
         case .changeAddress: return L10n.InsuranceDetails.changeAddressButton
-        case .changeTier: return L10n.InsuranceDetails.changeCoverage
+        case .changeTier:
+            return isPaymentProtection ? L10n.InsuranceDetails.changeAmount : L10n.InsuranceDetails.changeCoverage
         case .cancellation: return L10n.hcQuickActionsCancellationTitle
         case .removeAddons: return L10n.removeAddonButtonTitle
         }
     }
 
-    public var subtitle: String {
+    public func subtitle(isPaymentProtection: Bool = false) -> String {
         switch self {
         case .changeAddress: return L10n.hcQuickActionsChangeAddressSubtitle
         case .coInsured: return L10n.hcQuickActionsCoInsuredSubtitle
         case .coOwners: return L10n.editCoownerSubtitle
-        case .changeTier: return L10n.hcQuickActionsUpgradeCoverageSubtitle
+        case .changeTier:
+            return isPaymentProtection
+                ? L10n.InsuranceDetails.changeAmountSubtitle : L10n.hcQuickActionsUpgradeCoverageSubtitle
         case .cancellation: return L10n.hcQuickActionsTerminationSubtitle
         case .removeAddons: return L10n.hcQuickActionsRemoveAddonSubtitle
         }

--- a/Projects/hCore/Sources/Models/TypeOfContract.swift
+++ b/Projects/hCore/Sources/Models/TypeOfContract.swift
@@ -38,6 +38,11 @@ public enum TypeOfContract: String, Codable, CaseIterable, Sendable {
 }
 
 extension TypeOfContract {
+    /// Payment protection contracts reuse the tier flow but with "insurance amount" wording instead of "coverage".
+    public var isPaymentProtection: Bool {
+        self == .sePaymentProtection
+    }
+
     public static func resolve(for typeOfContract: String) -> Self {
         if let concreteTypeOfContract = Self(rawValue: typeOfContract) {
             return concreteTypeOfContract

--- a/Projects/hCoreUI/Sources/Views/EditContractScreen.swift
+++ b/Projects/hCoreUI/Sources/Views/EditContractScreen.swift
@@ -6,11 +6,17 @@ public struct EditContractScreen: View {
     @State var selectedValue: String?
 
     let editTypes: [EditType]
+    let isPaymentProtection: Bool
     let onSelectedType: (EditType) -> Void
     @EnvironmentObject var router: NavigationRouter
 
-    public init(editTypes: [EditType], onSelectedType: @escaping (EditType) -> Void) {
+    public init(
+        editTypes: [EditType],
+        isPaymentProtection: Bool = false,
+        onSelectedType: @escaping (EditType) -> Void
+    ) {
         self.editTypes = editTypes
+        self.isPaymentProtection = isPaymentProtection
         self.onSelectedType = onSelectedType
     }
 
@@ -28,10 +34,13 @@ public struct EditContractScreen: View {
                                         spacing: .padding2
                                     ) {
                                         HStack {
-                                            hText(editType.title)
+                                            hText(editType.title(isPaymentProtection: isPaymentProtection))
                                         }
-                                        hText(editType.subtitle, style: .label)
-                                            .foregroundColor(hTextColor.Translucent.secondary)
+                                        hText(
+                                            editType.subtitle(isPaymentProtection: isPaymentProtection),
+                                            style: .label
+                                        )
+                                        .foregroundColor(hTextColor.Translucent.secondary)
                                     }
                                     .asAnyView
                                 },
@@ -60,7 +69,8 @@ public struct EditContractScreen: View {
                         .disabled(selectedType == nil)
                         .accessibilityHint(
                             selectedType != nil
-                                ? L10n.voiceoverOptionSelected + (selectedType?.title ?? "")
+                                ? L10n.voiceoverOptionSelected
+                                    + (selectedType?.title(isPaymentProtection: isPaymentProtection) ?? "")
                                 : L10n.voiceoverPickerInfo(selectedType?.buttonTitle ?? L10n.generalContinueButton)
                         )
 


### PR DESCRIPTION
## What

Adds a new `EditType.changeAmount` so payment-protection contracts get "insurance amount" wording instead of "coverage" throughout the change-tier flow.

- `TypeOfContract.isPaymentProtection` helper (`sePaymentProtection`)
- Contract detail edit list shows "Change insurance amount" for payment protection; routes to the same change-tier flow
- `ChangeTierLandingScreen` and `EditScreen` swap title/subtitle/dropdown labels based on contract type (`EditTierType.tiers` now carries `typeOfContract`)
- Help center member-level quick action uses the payment-protection wording when all tier-changeable contracts are payment protection
- New en/sv strings for the amount wording

Also includes updated onboarding copy in en/sv `Localizable.strings` (analytics consent, connect payment, "add later" labels).