### PR TITLE
Payment protection: 90 day qualification info on change amount summary

### DIFF
--- a/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierSummaryScreen.swift
@@ -51,6 +51,7 @@ extension ChangeTierViewModel {
         return QuoteSummary(
             contracts: contracts,
             activationDate: self.activationDate,
+            noticeInfo: summaryNoticeInfo,
             totalPrice: .comparison(old: totalPremium.gross, new: totalPremium.net)
         )
     }

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -327,8 +327,14 @@ public class ChangeTierViewModel: ObservableObject {
         isPaymentProtection ? L10n.InsuranceDetails.changeAmountSubtitle : L10n.tierFlowSelectCoverageSubtitle
     }
 
+    /// Raising the payment protection amount comes with a 90 day qualification period before the new amount applies
     var summaryNoticeInfo: String? {
-        isPaymentProtection ? L10n.changeTierPaymentProtectionInfo : nil
+        guard isPaymentProtection,
+            let currentTier,
+            let selectedTier,
+            selectedTier.level > currentTier.level
+        else { return nil }
+        return L10n.changeTierPaymentProtectionInfo
     }
 
     private func getData() async throws -> ChangeTierIntentModelState {

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -327,6 +327,10 @@ public class ChangeTierViewModel: ObservableObject {
         isPaymentProtection ? L10n.InsuranceDetails.changeAmountSubtitle : L10n.tierFlowSelectCoverageSubtitle
     }
 
+    var summaryNoticeInfo: String? {
+        isPaymentProtection ? L10n.changeTierPaymentProtectionInfo : nil
+    }
+
     private func getData() async throws -> ChangeTierIntentModelState {
         switch changeTierInput {
         case let .contractWithSource(source):

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -334,7 +334,7 @@ public class ChangeTierViewModel: ObservableObject {
             let selectedTier,
             selectedTier.level > currentTier.level
         else { return nil }
-        return L10n.changeTierPaymentProtectionInfo
+        return L10n.changeInsuranceAmountPaymentProtectionInfo
     }
 
     private func getData() async throws -> ChangeTierIntentModelState {

--- a/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
+++ b/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
@@ -324,7 +324,7 @@ final class ChangeTierViewModelTests: XCTestCase {
     func testSummaryNoticeInfoForIncreasedPaymentProtectionAmount() async throws {
         let model = try await modelForSummaryNoticeInfo(typeOfContract: .sePaymentProtection)
         model.setTier(for: "max")
-        assert(model.summaryNoticeInfo == L10n.changeTierPaymentProtectionInfo)
+        assert(model.summaryNoticeInfo == L10n.changeInsuranceAmountPaymentProtectionInfo)
     }
 
     func testSummaryNoticeInfoForNotIncreasedPaymentProtectionAmount() async throws {

--- a/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
+++ b/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
@@ -320,4 +320,52 @@ final class ChangeTierViewModelTests: XCTestCase {
             assertionFailure("not proper state")
         }
     }
+
+    func testSummaryNoticeInfoForIncreasedPaymentProtectionAmount() async throws {
+        let model = try await modelForSummaryNoticeInfo(typeOfContract: .sePaymentProtection)
+        model.setTier(for: "max")
+        assert(model.summaryNoticeInfo == L10n.changeTierPaymentProtectionInfo)
+    }
+
+    func testSummaryNoticeInfoForNotIncreasedPaymentProtectionAmount() async throws {
+        let model = try await modelForSummaryNoticeInfo(typeOfContract: .sePaymentProtection)
+        model.setTier(for: "standard")
+        assert(model.summaryNoticeInfo == nil)
+    }
+
+    func testSummaryNoticeInfoForNonPaymentProtectionContract() async throws {
+        let model = try await modelForSummaryNoticeInfo(typeOfContract: .seHouse)
+        model.setTier(for: "max")
+        assert(model.summaryNoticeInfo == nil)
+    }
+
+    /// Builds a loaded view model where the current tier is level 1, "standard" is level 1 and "max" is level 2.
+    private func modelForSummaryNoticeInfo(typeOfContract: TypeOfContract) async throws -> ChangeTierViewModel {
+        let changeTierIntentModel: ChangeTierIntentModel = .init(
+            contractId: "contractId",
+            displayName: "display name",
+            activationDate: Date(),
+            tiers: tiers,
+            currentTier: currentTier,
+            currentQuote: nil,
+            selectedTier: nil,
+            selectedQuote: nil,
+            canEditTier: true,
+            typeOfContract: typeOfContract,
+            relatedAddons: [:]
+        )
+
+        let mockService = MockData.createMockChangeTier(fetchTier: { _ in
+            changeTierIntentModel
+        })
+
+        sut = mockService
+
+        let model = ChangeTierViewModel(
+            changeTierInput: .contractWithSource(data: .init(source: .changeTier, contractId: "contractId"))
+        )
+        vm = model
+        try await Task.sleep(seconds: 0.03)
+        return model
+    }
 }

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -103,9 +103,9 @@
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR" = "Please enter year of construction";
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL" = "Year of construction";
 "CHANGE_ADDRESS_YOU_PLUS" = "You + %1$li";
+"CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO" = "Your updated amount will take effect after your qualification period. Your current amount remains active during this period.";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Change payout account";
 "CHANGE_TIER_BUTTON_TITLE" = "Change coverage level";
-"CHANGE_TIER_PAYMENT_PROTECTION_INFO" = "Your updated amount will take effect after 90 days. Your current amount remains active during this period.";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Enable push notifications to ensure you receive all our messages.";
 "CHAT_CONVERSATION_CLAIM_TITLE" = "Claim";
 "CHAT_CONVERSATION_CLOSED" = "Closed";
@@ -174,6 +174,12 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_RECORDING_TITLE" = "Recording";
 "CLAIM_CHAT_SKIPPED_STEP" = "Skipped";
 "CLAIM_CHAT_SKIP_STEP" = "Skip";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE" = "Roughly how long had the stroller been there before you noticed it was gone?";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE" = "A day or more";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT" = "Overnight";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS" = "2-8 hours";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS" = "Under 2 hours";
+"CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE" = "Was the stroller locked? Tell us in your own words, e.g. what kind of lock you used.";
 "CLAIM_CHAT_SUBMIT_CLAIM" = "Submit your claim";
 "CLAIM_CHAT_TASK_CONTENT_DESCRIPTION" = "Processing information, please wait.";
 "CLAIM_CHAT_TITLE" = "Claim";

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "CHANGE_ADDRESS_YOU_PLUS" = "You + %1$li";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Change payout account";
 "CHANGE_TIER_BUTTON_TITLE" = "Change coverage level";
+"CHANGE_TIER_PAYMENT_PROTECTION_INFO" = "Your updated amount will take effect after 90 days. Your current amount remains active during this period.";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Enable push notifications to ensure you receive all our messages.";
 "CHAT_CONVERSATION_CLAIM_TITLE" = "Claim";
 "CHAT_CONVERSATION_CLOSED" = "Closed";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -103,9 +103,9 @@
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_ERROR" = "Ange byggår";
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL" = "Byggår";
 "CHANGE_ADDRESS_YOU_PLUS" = "Du + %1$li";
+"CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO" = "Det nya försäkringsbeloppet börjar gälla efter att kvalificeringstiden passerat. Ditt nuvarande belopp gäller som vanligt under tiden.";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Ändra utbetalningskonto";
 "CHANGE_TIER_BUTTON_TITLE" = "Ändra skyddsnivå";
-"CHANGE_TIER_PAYMENT_PROTECTION_INFO" = "";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Aktivera pushnotiser så du inte missar några av våra meddelanden.";
 "CHAT_CONVERSATION_CLAIM_TITLE" = "Skadeärende";
 "CHAT_CONVERSATION_CLOSED" = "Avslutad";
@@ -174,6 +174,12 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CLAIM_CHAT_RECORDING_TITLE" = "Inspelning";
 "CLAIM_CHAT_SKIPPED_STEP" = "Saknas";
 "CLAIM_CHAT_SKIP_STEP" = "Hoppa över";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_ALONE_TIME_MESSAGE" = "Ungefär hur länge stod barnvagnen där innan du märkte att den var borta?";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_FULL_DAY_OR_MORE" = "Ett dygn eller mer";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_OVERNIGHT" = "Över natten";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_TWO_TO_EIGHT_HOURS" = "2-8 timmar";
+"CLAIM_CHAT_STROLLER_THEFT_LEFT_UNDER_TWO_HOURS" = "Under 2 timmar";
+"CLAIM_CHAT_STROLLER_THEFT_LOCK_DESCRIPTION_MESSAGE" = "Var barnvagnen låst? Berätta gärna med egna ord, t.ex. vilket lås du använde.";
 "CLAIM_CHAT_SUBMIT_CLAIM" = "Skicka in ditt skadeärende";
 "CLAIM_CHAT_TASK_CONTENT_DESCRIPTION" = "Bearbetar information, vänligen vänta.";
 "CLAIM_CHAT_TITLE" = "Skadeanmälan";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "CHANGE_ADDRESS_YOU_PLUS" = "Du + %1$li";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Ändra utbetalningskonto";
 "CHANGE_TIER_BUTTON_TITLE" = "Ändra skyddsnivå";
+"CHANGE_TIER_PAYMENT_PROTECTION_INFO" = "";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Aktivera pushnotiser så du inte missar några av våra meddelanden.";
 "CHAT_CONVERSATION_CLAIM_TITLE" = "Skadeärende";
 "CHAT_CONVERSATION_CLOSED" = "Avslutad";


### PR DESCRIPTION
[GEN-5624](https://app.notion.com/p/hedviginsurance/App-If-increased-amount-in-change-amount-flow-Information-box-about-90-day-qualification-period-3c2c3f71cb0a80729756c7847c13419a)

When a member **increases** their payment protection amount, the change amount summary screen now shows an info box about the 90 day qualification period before the higher amount takes effect.

## Changes

- `ChangeTierViewModel.summaryNoticeInfo` returns `CHANGE_TIER_PAYMENT_PROTECTION_INFO` when the contract is payment protection and the selected tier level is higher than the current one — `nil` otherwise, so lowering or keeping the amount shows nothing.
- `ChangeTierSummaryScreen` passes it into `QuoteSummary.noticeInfo`, which renders as an `InfoCard` above the price section (existing hook, already used by MoveFlow and Addons).
- Tests cover increase, no increase, and non–payment protection contracts.

## Note

`CHANGE_TIER_PAYMENT_PROTECTION_INFO` is still empty in `sv-SE`. Payment protection is SE-only, so the translation needs to land before this reaches members or the info box renders empty.