### PR TITLE
fix: draft claim test session feedback (GEN-5675)

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/SubmitClaim/ClaimIntentClientOctopus.swift
@@ -424,6 +424,7 @@ extension ClaimIntentStepContent {
                         .compactMap { file in
                             guard let url = URL(string: file.url) else { return nil }
                             return ClaimIntentStepContentFileUploadFile(
+                                id: file.id,
                                 url: url,
                                 contentType: .findBy(mimeType: file.contentType),
                                 fileName: file.fileName

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimChatModel.swift
@@ -335,12 +335,14 @@ public struct ClaimIntentStepContentFileUpload: Sendable {
     }
 }
 
-public struct ClaimIntentStepContentFileUploadFile: Sendable {
+public struct ClaimIntentStepContentFileUploadFile: Sendable, Identifiable {
+    public let id: String
     public let url: URL
     public let contentType: MimeType
     public let fileName: String
 
-    public init(url: URL, contentType: MimeType, fileName: String) {
+    public init(id: String, url: URL, contentType: MimeType, fileName: String) {
+        self.id = id
         self.url = url
         self.contentType = contentType
         self.fileName = fileName

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
@@ -47,6 +47,12 @@ final class SubmitClaimFileUploadStep: ClaimIntentStepHandler {
         }
     }
 
+    /// Drops the files restored from `model.currentFiles`. Their `id` is the file URL rather than a
+    /// real file id, so they cannot be re-submitted as-is when the step is shown for input again.
+    func clearResumedFiles() {
+        fileUploadVm.fileGridViewModel.files = []
+    }
+
     override func accessibilityEditHint() -> String {
         if state.isSkipped {
             return L10n.claimChatSkippedStep

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
@@ -22,7 +22,7 @@ final class SubmitClaimFileUploadStep: ClaimIntentStepHandler {
         self.model = model
         let resumedUploads: [FileModel] = model.currentFiles.map { file in
             FileModel(
-                fileId: file.url.absoluteString,
+                fileId: file.id,
                 signedUrl: file.url.absoluteString,
                 mimeType: file.contentType.mime,
                 name: file.fileName
@@ -45,12 +45,6 @@ final class SubmitClaimFileUploadStep: ClaimIntentStepHandler {
         } catch {
             throw error
         }
-    }
-
-    /// Drops the files restored from `model.currentFiles`. Their `id` is the file URL rather than a
-    /// real file id, so they cannot be re-submitted as-is when the step is shown for input again.
-    func clearResumedFiles() {
-        fileUploadVm.fileGridViewModel.files = []
     }
 
     override func accessibilityEditHint() -> String {
@@ -203,7 +197,7 @@ public class FilesUploadViewModel: ObservableObject {
                             uploadedFileIds = model.fileIds
                         }
                     }
-                    return uploadedFileIds
+                    return uploadedFileIds + alreadyUploadedFiles
                 }
 
                 delayTimer = nil

--- a/Projects/SubmitClaimChat/Sources/Navigation/SubmitClaimFlowNavigation.swift
+++ b/Projects/SubmitClaimChat/Sources/Navigation/SubmitClaimFlowNavigation.swift
@@ -81,7 +81,8 @@ extension View {
                 title: L10n.resumeClaimLeaveTitle,
                 message: L10n.resumeClaimLeaveBody,
                 confirmButtonTitle: L10n.resumeClaimLeaveConfirm,
-                cancelButtonTitle: L10n.resumeClaimLeaveCancel
+                cancelButtonTitle: L10n.resumeClaimLeaveCancel,
+                confirmButtonRole: ButtonRole.affirmative
             )
         } else {
             withAlertDismiss(message: L10n.Claims.Alert.body)

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
@@ -464,6 +464,7 @@ final class SubmitClaimChatViewModel: ObservableObject {
             }
         }
         let handler = createStepHandler(for: claimIntent)
+        (handler as? SubmitClaimFileUploadStep)?.clearResumedFiles()
         if let currentStep = currentStep {
             if currentStep is SubmitClaimTaskStep && !(handler is SubmitClaimTaskStep) {
                 handler.state.showLoadingAnimation = false
@@ -500,9 +501,7 @@ final class SubmitClaimChatViewModel: ObservableObject {
 
     private func handleRegretStep(currentClaimIntent: ClaimIntent, newClaimIntent: ClaimIntent) {
         let handler = createStepHandler(for: newClaimIntent)
-        if let handler = handler as? SubmitClaimFileUploadStep {
-            handler.fileUploadVm.fileGridViewModel.files = []
-        }
+        (handler as? SubmitClaimFileUploadStep)?.clearResumedFiles()
         self.progress = newClaimIntent.progress
         Task { @MainActor in
             if let indexToRemove = allSteps.firstIndex(where: { $0.id == currentClaimIntent.currentStep.id }) {

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
@@ -464,7 +464,6 @@ final class SubmitClaimChatViewModel: ObservableObject {
             }
         }
         let handler = createStepHandler(for: claimIntent)
-        (handler as? SubmitClaimFileUploadStep)?.clearResumedFiles()
         if let currentStep = currentStep {
             if currentStep is SubmitClaimTaskStep && !(handler is SubmitClaimTaskStep) {
                 handler.state.showLoadingAnimation = false
@@ -501,7 +500,6 @@ final class SubmitClaimChatViewModel: ObservableObject {
 
     private func handleRegretStep(currentClaimIntent: ClaimIntent, newClaimIntent: ClaimIntent) {
         let handler = createStepHandler(for: newClaimIntent)
-        (handler as? SubmitClaimFileUploadStep)?.clearResumedFiles()
         self.progress = newClaimIntent.progress
         Task { @MainActor in
             if let indexToRemove = allSteps.firstIndex(where: { $0.id == currentClaimIntent.currentStep.id }) {

--- a/Projects/hCoreUI/Sources/View+dismissButton.swift
+++ b/Projects/hCoreUI/Sources/View+dismissButton.swift
@@ -24,12 +24,15 @@ extension View {
     /// and dismisses directly otherwise. Use when the alert should depend on runtime state.
     /// `title`, `confirmButtonTitle`, and `cancelButtonTitle` fall back to the generic
     /// "Are you sure?" / "Yes" / "No" copy when not provided.
+    /// Pass `ButtonRole.affirmative` as `confirmButtonRole` when confirming does not
+    /// discard anything, so the button is not styled as destructive.
     public func withDismissButton(
         withAlert: Bool,
         title: String? = nil,
         message: String? = nil,
         confirmButtonTitle: String? = nil,
-        cancelButtonTitle: String? = nil
+        cancelButtonTitle: String? = nil,
+        confirmButtonRole: ButtonRole? = .destructive
     ) -> some View {
         modifier(
             DismissButton(
@@ -37,7 +40,8 @@ extension View {
                 title: title,
                 message: message,
                 confirmButtonTitle: confirmButtonTitle,
-                cancelButtonTitle: cancelButtonTitle
+                cancelButtonTitle: cancelButtonTitle,
+                confirmButtonRole: confirmButtonRole
             )
         )
     }
@@ -50,6 +54,7 @@ private struct DismissButton: ViewModifier {
     let message: String?
     let confirmButtonTitle: String?
     let cancelButtonTitle: String?
+    let confirmButtonRole: ButtonRole?
     let action: (() -> Void)?
     @EnvironmentObject var router: NavigationRouter
     @State var isAlertPresented = false
@@ -61,6 +66,7 @@ private struct DismissButton: ViewModifier {
         confirmButtonTitle: String? = nil,
         cancelButtonTitle: String? = nil,
         reducedTopSpacing: Int = 0,
+        confirmButtonRole: ButtonRole? = .destructive,
         action: (() -> Void)? = nil
     ) {
         self.reducedTopSpacing = reducedTopSpacing
@@ -69,6 +75,7 @@ private struct DismissButton: ViewModifier {
         self.message = message
         self.confirmButtonTitle = confirmButtonTitle
         self.cancelButtonTitle = cancelButtonTitle
+        self.confirmButtonRole = confirmButtonRole
         self.action = action
     }
 
@@ -105,6 +112,7 @@ private struct DismissButton: ViewModifier {
                         confirmButton: confirmButtonTitle,
                         cancelButton: cancelButtonTitle,
                         isPresented: $isAlertPresented,
+                        confirmButtonRole: confirmButtonRole,
                         action: action
                     )
                     .foregroundColor(hTextColor.Opaque.primary)
@@ -122,6 +130,7 @@ extension View {
         confirmButton: String? = nil,
         cancelButton: String? = nil,
         isPresented: Binding<Bool>,
+        confirmButtonRole: ButtonRole? = .destructive,
         action: (() -> Void)? = nil
     ) -> some View {
         modifier(
@@ -130,7 +139,8 @@ extension View {
                 message: message,
                 confirmButton: confirmButton ?? L10n.General.yes,
                 cancelButton: cancelButton ?? L10n.General.no,
-                isPresented: isPresented
+                isPresented: isPresented,
+                confirmButtonRole: confirmButtonRole
             )
         )
     }
@@ -141,6 +151,7 @@ private struct DismissAlertPopup: ViewModifier {
     let message: String
     let confirmButton: String
     let cancelButton: String
+    let confirmButtonRole: ButtonRole?
     let action: (() -> Void)?
     @Binding var isPresented: Bool
     @EnvironmentObject var router: NavigationRouter
@@ -151,6 +162,7 @@ private struct DismissAlertPopup: ViewModifier {
         confirmButton: String = L10n.General.yes,
         cancelButton: String = L10n.General.no,
         isPresented: Binding<Bool>,
+        confirmButtonRole: ButtonRole? = .destructive,
         action: (() -> Void)? = nil
     ) {
         self.title = title
@@ -158,6 +170,7 @@ private struct DismissAlertPopup: ViewModifier {
         self.confirmButton = confirmButton
         self.cancelButton = cancelButton
         self._isPresented = isPresented
+        self.confirmButtonRole = confirmButtonRole
         self.action = action
     }
     func body(content: Content) -> some View {
@@ -167,7 +180,7 @@ private struct DismissAlertPopup: ViewModifier {
                     Button(cancelButton, role: .cancel) {
                         isPresented = false
                     }
-                    Button(confirmButton, role: .destructive) {
+                    Button(confirmButton, role: confirmButtonRole) {
                         router.dismiss()
                         action?()
                     }
@@ -175,6 +188,19 @@ private struct DismissAlertPopup: ViewModifier {
             } message: {
                 hText(message)
             }
+    }
+}
+
+extension ButtonRole {
+    /// Role for a confirm button that does not discard anything — "Leave" on a saved draft, for example.
+    /// `.confirm` from iOS 26, where it renders as the affirmative action; no role below that,
+    /// since `.destructive` would tint a harmless action red.
+    public static var affirmative: ButtonRole? {
+        if #available(iOS 26.0, *) {
+            return .confirm
+        } else {
+            return nil
+        }
     }
 }
 

--- a/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/SubmitClaimChat/ClaimIntent.graphql
@@ -69,6 +69,7 @@ fragment ClaimIntentStepContentFragment on ClaimIntentStepContent {
     ... on ClaimIntentStepContentFileUpload {
         uploadUri
         currentFiles {
+            id
             url
             contentType
             fileName


### PR DESCRIPTION
Two iOS fixes from the [Draft claim submission test session](https://app.notion.com/p/hedviginsurance/Draft-claim-submission-3c7c3f71cb0a806d81f9f1072e509a82).

### "Leave" is not a destructive action

> Should "Leave" when leaving really be destructive? I mean we do save your claim as a draft → Yes remove

The alert says "What you've filled in is saved as a draft for 7 days", so nothing is discarded. The confirm button now uses `ButtonRole.affirmative`, a new hCoreUI helper: `.confirm` from iOS 26, where it renders as the affirmative action, and no role below that — `.destructive` would tint a harmless action red on iOS 16–18 too.

`confirmButtonRole` is plumbed through `withDismissButton` / `configureAlert` as `ButtonRole?` and still defaults to `.destructive`, so every other confirmation alert is unchanged. The generic `withAlertDismiss` alert ("Are you sure?" / "progress will be lost") genuinely is destructive, which is why this is opt-in per call site rather than a global mapping.

### Resumed file upload step keeps its files and re-submits them

> Resuming claim after regreting file step still has files on it

The files shown were real server-side files — the problem was that they could not be submitted again. `currentFiles` restored from the backend carried the file URL as their `id`, so `uploadFiles` would have sent URLs where the backend expects file ids, and the only safe workaround was to drop them.

`ClaimIntentStepContentFragment` now selects `currentFiles.id`, propagated through `ClaimIntentStepContentFileUploadFile` (now `Identifiable`) and the Octopus mapping, so a restored file gets a real `fileId`. `uploadFiles` returns `uploadedFileIds + alreadyUploadedFiles`, submitting the restored files alongside anything newly picked instead of only when there is nothing new to upload.

With restored files re-submittable, the clearing in `handleRegretStep` is gone: regretting back into a file upload step now shows what you already uploaded and lets you add or remove from there rather than starting over.

Steps replayed from `previousSteps` are untouched, so a resumed claim's completed file upload step still shows its thumbnails in the transcript.

### Testing

Not yet verified on device — needs a resume run through both paths:

- Leave a resumable claim and check the "Leave" button is not red (iOS 16–18) and is the affirmative action (iOS 26).
- Regret into a file upload step → previously uploaded files are still listed. Continue as-is, and with a file removed and a new one added, and check the submitted set matches what the step showed.
- Leave and resume into a file upload step → same, and earlier completed file upload steps still show their thumbnails above it. Important: Use My things -> Bike theft flow  
