### PR TITLE
fix: submit claim flow keyboard handling

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Models/ClaimChatScrollCoordinator.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/ClaimChatScrollCoordinator.swift
@@ -23,7 +23,9 @@ final class ClaimChatScrollCoordinator: ObservableObject {
                 .throttle(for: .milliseconds(200), scheduler: DispatchQueue.main, latest: true)
                 .removeDuplicates()
                 .sink(receiveValue: { [weak self] _ in
-                    UIApplication.dismissKeyboard()
+                    if self?.scrollView?.viewController?.presentedViewController == nil {
+                        UIApplication.dismissKeyboard()
+                    }
                     self?.checkForScrollOffset()
                 })
         }

--- a/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/SubmitClaimChatScreen.swift
@@ -113,22 +113,27 @@ public struct SubmitClaimChatScreen: View {
                     ScrollToBottomButton(scrollAction: scrollToBottom)
                 }
                 if !viewModel.shouldHideCurrentInput {
-                    CurrentStepView(step: currentStep)
-                        .padding(.top, .padding16)
-                        .background {
-                            GeometryReader { proxy in
-                                Color.clear
-                                    .onAppear {
-                                        viewModel.currentStepInputHeight = proxy.size.height
-                                    }
-                                    .onChange(of: proxy.size) { value in
-                                        viewModel.currentStepInputHeight = value.height
-                                    }
+                    ScrollView {
+                        CurrentStepView(step: currentStep)
+                            .padding(.top, .padding16)
+                            .background {
+                                GeometryReader { proxy in
+                                    Color.clear
+                                        .onAppear {
+                                            viewModel.currentStepInputHeight = proxy.size.height
+                                        }
+                                        .onChange(of: proxy.size) { value in
+                                            viewModel.currentStepInputHeight = value.height
+                                        }
+                                }
                             }
-                        }
-                        .transition(.offset(x: 0, y: 1000))
-                        .animation(.easeInOut(duration: 0.5), value: viewModel.shouldHideCurrentInput)
-                        .accessibilityFocused($isCurrentStepFocused)
+                    }
+                    .frame(maxHeight: viewModel.currentStepInputHeight)
+                    .addScrollBounce()
+                    .transition(.offset(x: 0, y: 1000))
+                    .animation(.easeInOut(duration: 0.5), value: viewModel.shouldHideCurrentInput)
+                    .accessibilityFocused($isCurrentStepFocused)
+                    .dismissKeyboard()
                 }
             }
         }
@@ -156,6 +161,16 @@ public struct SubmitClaimChatScreen: View {
     }
 }
 
+extension View {
+    @ViewBuilder
+    func addScrollBounce() -> some View {
+        if #available(iOS 16.4, *) {
+            self.scrollBounceBehavior(.basedOnSize)
+        } else {
+            self
+        }
+    }
+}
 struct ScrollToBottomButton: View {
     let scrollAction: () -> Void
 

--- a/Projects/hCoreUI/Sources/hForm/hFloatingTextField.swift
+++ b/Projects/hCoreUI/Sources/hForm/hFloatingTextField.swift
@@ -137,20 +137,6 @@ public struct hFloatingTextField<Value: hTextFieldFocusStateCompliant>: View {
         }
         .introspect(.textField, on: .iOS(.v13...)) { [weak vm] textField in
             vm?.textField = textField
-            if masking.keyboardType == .numberPad {
-                let toolbar = UIToolbar()
-                let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-
-                let doneButton = UIBarButtonItem(
-                    barButtonSystemItem: .done,
-                    target: self,
-                    action: #selector(textField.dismissKeyboad)
-                )
-                toolbar.tintColor = .brand(.primaryText())
-                toolbar.sizeToFit()
-                toolbar.setItems([space, doneButton], animated: false)
-                vm?.textField?.inputAccessoryView = toolbar
-            }
         }
         .onAppear {
             updateMoveLabel(false)

--- a/Projects/hCoreUI/Sources/hForm/hForm.swift
+++ b/Projects/hCoreUI/Sources/hForm/hForm.swift
@@ -441,46 +441,8 @@ public struct BackgroundBlurView: UIViewRepresentable {
         for subview in view.subviews {
             subview.backgroundColor = UIColor.clear
         }
-        return MaskedView(subView: view)
+        return view
     }
 
     public func updateUIView(_ view: UIView, context _: Context) {}
-}
-
-private class MaskedView: UIView {
-    init(subView: UIView) {
-        super.init(frame: .zero)
-        backgroundColor = .clear
-        self.addSubview(subView)
-        subView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        let transparent = UIColor(white: 0, alpha: 0).cgColor
-        let opaque = UIColor(white: 0, alpha: 1).cgColor
-
-        let maskLayer = CALayer()
-        maskLayer.frame = bounds
-
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = CGRect(
-            x: bounds.origin.x,
-            y: 0,
-            width: bounds.size.width,
-            height: bounds.size.height
-        )
-        gradientLayer.startPoint = .init(x: 0.5, y: 0)
-        gradientLayer.endPoint = .init(x: 0.5, y: 1)
-        let point: NSNumber = NSNumber(value: 20 / bounds.size.height)
-        gradientLayer.colors = [transparent, opaque, opaque]
-        gradientLayer.locations = [0.0, point, 1]
-
-        maskLayer.addSublayer(gradientLayer)
-        layer.mask = maskLayer
-    }
 }


### PR DESCRIPTION
## Description

Keyboard and input-area fixes for the submit claim chat flow.

- **Keyboard dismissed behind sheets** — `ClaimChatScrollCoordinator` no longer dismisses the keyboard on scroll when the scroll view's view controller has something presented on top of it, so scrolling underneath a sheet doesn't steal first responder from it
- **Current step input clipped by the keyboard** — `CurrentStepView` is now wrapped in a `ScrollView` capped at `currentStepInputHeight`, with `scrollBounceBehavior(.basedOnSize)` on iOS 16.4+ so it only bounces when the content actually overflows, plus `dismissKeyboard()` on the container
- **Number pad toolbar removed** — dropped the injected `UIToolbar` "Done" accessory on `hFloatingTextField` for `.numberPad` masking
- **Cleared masked background view** — `BackgroundBlurView` returns the blur view directly instead of wrapping it in `MaskedView`, removing the gradient `CALayer` mask
