### PR TITLE
fix: hide home toolbar on scroll

### DIFF
--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -705,7 +705,7 @@ struct HomeTab: View {
     @ObservedObject var homeNavigationVm: HomeNavigationViewModel
     @ObservedObject var loggedInVm: LoggedInNavigationViewModel
     var body: some View {
-        hNavigationStack(router: homeNavigationVm.router, tracking: self) {
+        hNavigationStack(router: homeNavigationVm.router, options: .navigationBarHidden, tracking: self) {
             HomeScreen()
                 .routerDestination(for: ClaimModel.self, options: [.hidesBottomBarWhenPushed]) { claim in
                     openClaimDetails(

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -15,6 +15,9 @@ struct ActiveHomeView: View {
     @State private var greetingHeight: CGFloat = 0
     @State private var headerHeight: CGFloat = 0
     @State private var scrollOffset: CGFloat = 0
+    @State private var navBarHeight: CGFloat = 0
+    @State private var topSafeAreaInset: CGFloat = 0
+
     private let scrollSpace = "homeScroll"
 
     /// Keeps the surface's white reaching a touch past the last item, like the old sheet did.
@@ -71,8 +74,26 @@ struct ActiveHomeView: View {
             }
             .coordinateSpace(name: scrollSpace)
             .ignoresSafeArea(edges: .bottom)
+            .onGeometryChange(for: CGFloat.self, of: \.safeAreaInsets.top) { topSafeAreaInset = $0 }
+            .overlay(alignment: .top) {
+                HomeNavigationBar()
+                    .padding(.vertical, .padding8)
+                    .onGeometryChange(for: CGFloat.self, of: \.size.height) { navBarHeight = $0 }
+                    .opacity(toolbarOpacity)
+                    .offset(y: toolbarOffset * Double.pi)
+            }
         }
         .background { heroBackground }
+    }
+
+    private var toolbarOffset: CGFloat {
+        guard greetingHeight > 0 else { return 0 }
+        return min(0, scrollOffset + greetingHeight - navBarHeight)
+    }
+
+    private var toolbarOpacity: CGFloat {
+        guard navBarHeight > 0 else { return 1 }
+        return max(0, 1 + toolbarOffset / (navBarHeight + topSafeAreaInset))
     }
 
     private var heroBackground: some View {
@@ -106,6 +127,57 @@ struct ActiveHomeView: View {
         if !bottomVm.items.isEmpty {
             hSection { HomeBottomScrollView(vm: bottomVm) }
                 .sectionContainerStyle(.transparent)
+        }
+    }
+}
+
+private struct HomeNavigationBar: View {
+    @AppObservedObject private var homeStore: HomeStore
+    @EnvironmentObject private var navigationVm: HomeNavigationViewModel
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: .padding8) {
+                toolbar()
+            }
+        } else {
+            toolbar()
+        }
+    }
+
+    private func toolbar() -> some View {
+        HStack(spacing: .padding8) {
+            Spacer()
+            ForEach(homeStore.toolbarOptionTypes, id: \.self) { type in
+                barButton(for: type)
+            }
+        }
+        .padding(.horizontal, .padding16)
+    }
+
+    @ViewBuilder
+    private func barButton(for type: ToolbarOptionType) -> some View {
+        let button = ToolbarButtonView(
+            type: type,
+            placement: .trailing,
+            action: { [weak navigationVm] type in
+                switch type {
+                case .crossSell:
+                    NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .home))
+                case .firstVet:
+                    navigationVm?.quickActionsVm
+                        .perform(.firstVet(partners: homeStore.quickActions.getFirstVetPartners ?? []))
+                case .chat: navigationVm?.router.push(HomeRouterAction.inbox)
+                case .travelCertificate, .insuranceEvidence:
+                    break
+                }
+            },
+            size: .padding40
+        )
+        if #available(iOS 26.0, *) {
+            button.glassEffect(.regular.interactive(), in: Circle())
+        } else {
+            button
         }
     }
 }

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -75,25 +75,21 @@ struct ActiveHomeView: View {
             .coordinateSpace(name: scrollSpace)
             .ignoresSafeArea(edges: .bottom)
             .onGeometryChange(for: CGFloat.self, of: \.safeAreaInsets.top) { topSafeAreaInset = $0 }
-            .overlay(alignment: .top) {
+            .overlay(alignment: .topTrailing) {
                 HomeNavigationBar()
-                    .padding(.vertical, .padding8)
+                    .padding(.vertical, .padding4)
                     .onGeometryChange(for: CGFloat.self, of: \.size.height) { navBarHeight = $0 }
-                    .opacity(toolbarOpacity)
-                    .offset(y: toolbarOffset * Double.pi)
+                    .opacity(showNavigation ? 1 : 0)
+                    .offset(y: showNavigation ? 0 : -30)
+                    .animation(.easeInOut(duration: 0.2), value: scrollOffset)
             }
         }
         .background { heroBackground }
     }
 
-    private var toolbarOffset: CGFloat {
-        guard greetingHeight > 0 else { return 0 }
-        return min(0, scrollOffset + greetingHeight - navBarHeight)
-    }
-
-    private var toolbarOpacity: CGFloat {
-        guard navBarHeight > 0 else { return 1 }
-        return max(0, 1 + toolbarOffset / (navBarHeight + topSafeAreaInset))
+    private var showNavigation: Bool {
+        guard greetingHeight > 0 else { return true }
+        return scrollOffset + greetingHeight - navBarHeight > 0
     }
 
     private var heroBackground: some View {
@@ -147,7 +143,6 @@ private struct HomeNavigationBar: View {
 
     private func toolbar() -> some View {
         HStack(spacing: .padding8) {
-            Spacer()
             ForEach(homeStore.toolbarOptionTypes, id: \.self) { type in
                 barButton(for: type)
             }
@@ -172,7 +167,7 @@ private struct HomeNavigationBar: View {
                     break
                 }
             },
-            size: .padding40
+            size: .padding40 + .padding4
         )
         if #available(iOS 26.0, *) {
             button.glassEffect(.regular.interactive(), in: Circle())

--- a/Projects/Home/Sources/Screens/HomeScreen.swift
+++ b/Projects/Home/Sources/Screens/HomeScreen.swift
@@ -13,29 +13,11 @@ import hCoreUI
 
 public struct HomeScreen: View {
     @StateObject var vm = HomeVM()
-    @AppObservedObject var homeStore: HomeStore
-    @EnvironmentObject var navigationVm: HomeNavigationViewModel
 
     public init() {}
 
     public var body: some View {
         ActiveHomeView()
-            .setHomeNavigationBars(
-                with: $homeStore.toolbarOptionTypes,
-                action: { [weak navigationVm] type in
-                    switch type {
-                    case .crossSell:
-                        NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .home))
-                    case .firstVet:
-                        navigationVm?.quickActionsVm
-                            .perform(.firstVet(partners: homeStore.quickActions.getFirstVetPartners ?? []))
-                    case .chat:
-                        navigationVm?.router.push(HomeRouterAction.inbox)
-                    case .travelCertificate, .insuranceEvidence:
-                        break
-                    }
-                }
-            )
             .trackVisibility(as: HomeScreen.self)
             .task {
                 vm.fetchHomeState()

--- a/Projects/hCoreUI/Sources/ToolbarButtonView/ToolbarButtonView.swift
+++ b/Projects/hCoreUI/Sources/ToolbarButtonView/ToolbarButtonView.swift
@@ -8,6 +8,7 @@ public struct ToolbarButtonView: View {
     let type: ToolbarOptionType
     let placement: ListToolBarPlacement
     let useSpacing: Bool
+    let size: CGFloat?
     private var leadingSpacing: CGFloat {
         if #available(iOS 26.0, *) {
             return 0
@@ -43,12 +44,14 @@ public struct ToolbarButtonView: View {
         type: ToolbarOptionType,
         placement: ListToolBarPlacement,
         action: @escaping (_: ToolbarOptionType) -> Void,
-        useSpacing: Bool = false
+        useSpacing: Bool = false,
+        size: CGFloat? = nil
     ) {
         self.type = type
         self.placement = placement
         self.action = action
         self.useSpacing = useSpacing
+        self.size = size
     }
 
     public var body: some View {
@@ -78,7 +81,11 @@ public struct ToolbarButtonView: View {
                             .offset(badgeOffset)
                     }
                 }
+                .frame(width: size, height: size)
             }
+            // The inner image is accessibility-hidden, so the button synthesizes no label
+            // of its own — without this, VoiceOver announces a bare "Button".
+            .accessibilityLabel(type.accessibilityDisplayName)
             .padding(.leading, useSpacing ? leadingSpacing : 0)
             .padding(.trailing, useSpacing ? trailingSpacing : 0)
         }


### PR DESCRIPTION
## [RND-2069]

- Render the home toolbar as an overlay on the scroll view instead of the navigation bar
- The rising sheet pushes it off screen 1:1 with the scroll, fading on the way

## Blockers

- None

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification