### PR TITLE
fix: set proper place for file picker

### DIFF
--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -47,13 +47,6 @@ public struct ClaimDetailView: View {
                 }
             }
         }
-        .showFileSourcePicker(
-            $vm.showFileSourcePicker,
-            selecedFiles: { [weak vm] files in
-                guard let vm else { return }
-                vm.showAddFiles(with: files)
-            }
-        )
         .modally(item: $vm.showFilesView) { [weak vm] item in
             ClaimFilesView(endPoint: item.endPoint, files: item.files) { _ in
                 let claimStore: ClaimsStore = globalAppStateContainer.get()
@@ -309,6 +302,13 @@ public struct ClaimDetailView: View {
                                 .primary,
                                 content: .init(title: L10n.ClaimStatus.UploadedFiles.uploadButton)
                             ) { [weak vm] in vm?.showFileSourcePicker = true }
+                            .showFileSourcePicker(
+                                $vm.showFileSourcePicker,
+                                selecedFiles: { [weak vm] files in
+                                    guard let vm else { return }
+                                    vm.showAddFiles(with: files)
+                                }
+                            )
                         }
                     }
                     .sectionContainerStyle(.transparent)

--- a/Projects/Claims/Sources/Views/ClaimFilesView.swift
+++ b/Projects/Claims/Sources/Views/ClaimFilesView.swift
@@ -56,7 +56,11 @@ public struct ClaimFilesView: View {
                                 content: .init(title: L10n.ClaimStatusDetail.addMoreFiles)
                             ) { [weak vm] in vm?.showFileSourcePicker = true }
                             .disabled(vm.isLoading)
-
+                            .showFileSourcePicker($vm.showFileSourcePicker) { [weak vm] files in
+                                for file in files {
+                                    vm?.add(file: file)
+                                }
+                            }
                             hButton(
                                 .large,
                                 .primary,
@@ -69,11 +73,6 @@ public struct ClaimFilesView: View {
                     .padding(.vertical, .padding16)
                 }
                 .sectionContainerStyle(.transparent)
-            }
-        }
-        .showFileSourcePicker($vm.showFileSourcePicker) { [weak vm] files in
-            for file in files {
-                vm?.add(file: file)
             }
         }
     }

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFileUploadView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFileUploadView.swift
@@ -17,9 +17,6 @@ struct SubmitClaimFileUploadView: View {
 
     var body: some View {
         showFilesView
-            .showFileSourcePicker($viewModel.showFileSourcePicker) { files in
-                fileUploadVm.addFiles(with: files)
-            }
             .onChange(of: fileUploadVm.hasFiles) { hasFiles in
                 viewModel.setDisableSkip(to: hasFiles)
             }
@@ -40,6 +37,9 @@ struct SubmitClaimFileUploadView: View {
                         } else {
                             addFilesButton
                         }
+                    }
+                    .showFileSourcePicker($viewModel.showFileSourcePicker) { files in
+                        fileUploadVm.addFiles(with: files)
                     }
                     .hButtonIsLoading(false)
                 }


### PR DESCRIPTION
- alert for selecting source of files was showing on whole elements instead of just a button where it is called from

## Blockers

- Blocker

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
