### PR TITLE
Use insurance amount wording for the tier flow loading state on payment protection

### DIFF
--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -123,7 +123,8 @@ class PushNotificationHandler {
                         .init(
                             contractId: contractId,
                             contractDisplayName: contract.currentAgreement?.productVariant.displayName ?? "",
-                            contractExposureName: contract.exposureDisplayName
+                            contractExposureName: contract.exposureDisplayName,
+                            typeOfContract: contract.typeOfContract
                         )
                     ]
                 )
@@ -135,7 +136,8 @@ class PushNotificationHandler {
                     .init(
                         contractId: $0.id,
                         contractDisplayName: $0.currentAgreement?.productVariant.displayName ?? "",
-                        contractExposureName: $0.exposureDisplayName
+                        contractExposureName: $0.exposureDisplayName,
+                        typeOfContract: $0.typeOfContract
                     )
                 }
             viewModel?.isChangeTierPresented = ChangeTierContractsInput(

--- a/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
+++ b/Projects/ChangeTier/Sources/Navigation/ChangeTierNavigation.swift
@@ -34,7 +34,11 @@ public class ChangeTierNavigationViewModel: ObservableObject {
         if changeTierContractsInput.contracts.count == 1, let first = changeTierContractsInput.contracts.first {
             vm = .init(
                 changeTierInput: .contractWithSource(
-                    data: .init(source: changeTierContractsInput.source, contractId: first.contractId)
+                    data: .init(
+                        source: changeTierContractsInput.source,
+                        contractId: first.contractId,
+                        typeOfContract: first.typeOfContract
+                    )
                 )
             )
             self.changeTierContractsInput = nil
@@ -111,14 +115,19 @@ public struct ChangeTierInputData: Equatable, Identifiable, Codable {
 
     public init(
         source: ChangeTierSource,
-        contractId: String
+        contractId: String,
+        typeOfContract: TypeOfContract? = nil
     ) {
         self.source = source
         self.contractId = contractId
+        self.typeOfContract = typeOfContract
     }
 
     public let source: ChangeTierSource
     public let contractId: String
+    /// Known upfront by the entry points that already hold the contract, so the flow can use the right
+    /// wording before the tiers have been fetched. Nil when the caller only knows the contract id.
+    public let typeOfContract: TypeOfContract?
 }
 
 public struct ChangeTierContractsInput: Equatable, Identifiable {
@@ -141,15 +150,18 @@ public struct ChangeTierContract: Hashable {
     public var contractId: String
     public var contractDisplayName: String
     public var contractExposureName: String
+    public var typeOfContract: TypeOfContract?
 
     public init(
         contractId: String,
         contractDisplayName: String,
-        contractExposureName: String
+        contractExposureName: String,
+        typeOfContract: TypeOfContract? = nil
     ) {
         self.contractId = contractId
         self.contractDisplayName = contractDisplayName
         self.contractExposureName = contractExposureName
+        self.typeOfContract = typeOfContract
     }
 }
 

--- a/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierLandingScreen.swift
@@ -31,7 +31,7 @@ public struct ChangeTierLandingScreen: View {
             .hStateViewButtonConfig(dataLoaderErrorButtons)
         } else {
             ProcessingStateView(
-                loadingViewText: L10n.tierFlowProcessing,
+                loadingViewText: vm.processingText,
                 state: $vm.viewState,
                 duration: 6
             )

--- a/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
+++ b/Projects/ChangeTier/Sources/Views/ChangeTierViewModel.swift
@@ -87,6 +87,11 @@ public class ChangeTierViewModel: ObservableObject {
     ) {
         self.changeTierInput = changeTierInput
         self.dataProvider = dataProvider
+        //set upfront when known so the loading state already uses the right wording
+        switch changeTierInput {
+        case let .contractWithSource(data): self.typeOfContract = data.typeOfContract
+        case let .existingIntent(intent, _): self.typeOfContract = intent.typeOfContract
+        }
         fetchTiers()
     }
 
@@ -294,6 +299,10 @@ public class ChangeTierViewModel: ObservableObject {
 
     var isPaymentProtection: Bool {
         typeOfContract?.isPaymentProtection == true
+    }
+
+    var processingText: String {
+        isPaymentProtection ? L10n.tierFlowProcessingPaymentProtection : L10n.tierFlowProcessing
     }
 
     var flowTitle: String {

--- a/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
+++ b/Projects/ChangeTier/Sources/Views/SelectInsuranceScreen.swift
@@ -32,7 +32,8 @@ struct SelectInsuranceScreen: View {
                         changeTierInput: .contractWithSource(
                             data: .init(
                                 source: changeTierContractsInput.source,
-                                contractId: selectedContract.contractId
+                                contractId: selectedContract.contractId,
+                                typeOfContract: selectedContract.typeOfContract
                             )
                         )
                     )

--- a/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
+++ b/Projects/ChangeTier/Tests/ViewModelTests/ChangeTierViewModelTests.swift
@@ -320,4 +320,48 @@ final class ChangeTierViewModelTests: XCTestCase {
             assertionFailure("not proper state")
         }
     }
+
+    func testProcessingTextUsesPaymentProtectionCopyBeforeTiersAreFetched() async throws {
+        let mockService = MockData.createMockChangeTier()
+        sut = mockService
+
+        let model = ChangeTierViewModel(
+            changeTierInput: .contractWithSource(
+                data: .init(source: .changeTier, contractId: "contractId", typeOfContract: .sePaymentProtection)
+            )
+        )
+        vm = model
+
+        //the loading text is on screen before the fetch resolves, so no waiting here on purpose
+        assert(model.isPaymentProtection)
+        assert(model.processingText == L10n.tierFlowProcessingPaymentProtection)
+    }
+
+    func testProcessingTextUsesCoverageCopyForNonPaymentProtectionContracts() async throws {
+        let mockService = MockData.createMockChangeTier()
+        sut = mockService
+
+        let model = ChangeTierViewModel(
+            changeTierInput: .contractWithSource(
+                data: .init(source: .changeTier, contractId: "contractId", typeOfContract: .seHouse)
+            )
+        )
+        vm = model
+
+        assert(!model.isPaymentProtection)
+        assert(model.processingText == L10n.tierFlowProcessing)
+    }
+
+    func testProcessingTextFallsBackToCoverageCopyWhenTypeOfContractIsUnknown() async throws {
+        let mockService = MockData.createMockChangeTier()
+        sut = mockService
+
+        let model = ChangeTierViewModel(
+            changeTierInput: .contractWithSource(data: .init(source: .changeTier, contractId: "contractId"))
+        )
+        vm = model
+
+        assert(!model.isPaymentProtection)
+        assert(model.processingText == L10n.tierFlowProcessing)
+    }
 }

--- a/Projects/Contracts/Sources/ContractsNavigation.swift
+++ b/Projects/Contracts/Sources/ContractsNavigation.swift
@@ -87,7 +87,11 @@ public struct ContractsNavigation<Content: View>: View {
                         contractsNavigationVm.editStakeholdersVm.start(fromContract: configContract)
                     case .changeTier:
                         contractsNavigationVm.changeTierInput = .contractWithSource(
-                            data: .init(source: .changeTier, contractId: contract.id)
+                            data: .init(
+                                source: .changeTier,
+                                contractId: contract.id,
+                                typeOfContract: contract.typeOfContract
+                            )
                         )
                     case .cancellation:
                         let config = TerminationConfirmConfig(contract: contract)

--- a/Projects/Home/Sources/Navigation/QuickActionsViewModel.swift
+++ b/Projects/Home/Sources/Navigation/QuickActionsViewModel.swift
@@ -54,7 +54,8 @@ public final class QuickActionsViewModel: ObservableObject {
                     .init(
                         contractId: $0.id,
                         contractDisplayName: $0.currentAgreement?.productVariant.displayName ?? "",
-                        contractExposureName: $0.exposureDisplayName
+                        contractExposureName: $0.exposureDisplayName,
+                        typeOfContract: $0.typeOfContract
                     )
                 }
             isChangeTierPresented = .init(

--- a/Projects/Home/Tests/QuickActionsViewModelTests.swift
+++ b/Projects/Home/Tests/QuickActionsViewModelTests.swift
@@ -131,7 +131,8 @@ final class QuickActionsViewModelTests: XCTestCase {
         let expectedContract = ChangeTierContract(
             contractId: "eligible",
             contractDisplayName: "Home Insurance",
-            contractExposureName: "Apartment"
+            contractExposureName: "Apartment",
+            typeOfContract: .seHouse
         )
         XCTAssertEqual(vm.isChangeTierPresented?.source, .changeTier)
         XCTAssertEqual(vm.isChangeTierPresented?.contracts, [expectedContract])
@@ -205,7 +206,8 @@ final class QuickActionsViewModelTests: XCTestCase {
 
 // Minimal Contract fixture -- only the fields the view model actually reads
 // (id, supportsChangeTier, supportsTermination, currentAgreement.productVariant.displayName,
-// exposureDisplayName) vary between call sites; the rest are fixed filler to satisfy the memberwise init.
+// exposureDisplayName, typeOfContract) vary between call sites; the rest are fixed filler to satisfy
+// the memberwise init.
 private func makeContract(
     id: String,
     displayName: String,

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL" = "Year of construction";
 "CHANGE_ADDRESS_YOU_PLUS" = "You + %1$li";
 "CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO" = "Your new amount takes effect once your qualification period ends. Until then, your current amount applies.";
+"CHANGE_INSURANCE_AMOUNT_PROCESSING" = "Fetching insurance amount...";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Change payout account";
 "CHANGE_TIER_BUTTON_TITLE" = "Change coverage level";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Enable push notifications to ensure you receive all our messages.";
@@ -680,6 +681,7 @@ figma: https://www.figma.com/design/SNVLvLq7ztclXiDqqMNXgY?node-id=419-7269#9590
 "TIER_FLOW_PREVIOUS_PRICE" = "Your previous price %1$@";
 "TIER_FLOW_PRICE_LABEL_WITHOUT_CURRENCY" = "From %@/mo";
 "TIER_FLOW_PROCESSING" = "Fetching coverage levels...";
+"TIER_FLOW_PROCESSING_PAYMENT_PROTECTION" = "Fetching insurance amounts...";
 "TIER_FLOW_SELECT_ADDON_SUBTITLE" = "Days covered when travelling";
 "TIER_FLOW_SELECT_COVERAGE_SUBTITLE" = "Find the right coverage for you";
 "TIER_FLOW_SELECT_COVERAGE_TITLE" = "Select your coverage";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "CHANGE_ADDRESS_YEAR_OF_CONSTRUCTION_LABEL" = "Byggår";
 "CHANGE_ADDRESS_YOU_PLUS" = "Du + %1$li";
 "CHANGE_INSURANCE_AMOUNT_PAYMENT_PROTECTION_INFO" = "Det nya beloppet börjar gälla när din kvalificeringstid är slut. Fram till dess gäller ditt nuvarande belopp.";
+"CHANGE_INSURANCE_AMOUNT_PROCESSING" = "Hämtar försäkringsbelopp...";
 "CHANGE_PAYOUT_METHOD_BUTTON_LABEL" = "Ändra utbetalningskonto";
 "CHANGE_TIER_BUTTON_TITLE" = "Ändra skyddsnivå";
 "CHAT_ACTIVATE_NOTIFICATIONS_BODY" = "Aktivera pushnotiser så du inte missar några av våra meddelanden.";
@@ -680,6 +681,7 @@ figma: https://www.figma.com/design/SNVLvLq7ztclXiDqqMNXgY?node-id=419-7269#9590
 "TIER_FLOW_PREVIOUS_PRICE" = "Ditt tidigare pris %1$@";
 "TIER_FLOW_PRICE_LABEL_WITHOUT_CURRENCY" = "Från %@/mån";
 "TIER_FLOW_PROCESSING" = "Hämtar skyddsnivåer...";
+"TIER_FLOW_PROCESSING_PAYMENT_PROTECTION" = "Hämtar försäkringsbelopp...";
 "TIER_FLOW_SELECT_ADDON_SUBTITLE" = "Välj antalet resdagar som täcks";
 "TIER_FLOW_SELECT_COVERAGE_SUBTITLE" = "Hitta rätt skydd";
 "TIER_FLOW_SELECT_COVERAGE_TITLE" = "Välj din skyddsnivå";


### PR DESCRIPTION
## [APP-XXX]

Payment protection contracts reuse the tier flow, so the landing screen's loading state said "Fetching coverage levels..." even though the flow is about an insurance amount, not a coverage level.

- Added `TIER_FLOW_PROCESSING_PAYMENT_PROTECTION` — en: "Fetching insurance amounts...", sv-SE: "Hämtar försäkringsbelopp..." — following the amount vocabulary the rest of the payment protection flow already uses (`insurance_details.change_amount`)
- `ChangeTierViewModel.processingText` picks the copy off `isPaymentProtection`, used by `ChangeTierLandingScreen`
- Plumbed `typeOfContract` into `ChangeTierInputData` / `ChangeTierContract` so the type is known before the tiers are fetched. Without this the new text would never show: `typeOfContract` was only assigned from the fetch response, so `isPaymentProtection` was still `false` for the whole time the loading text is on screen. Both properties are optional and default to `nil`, so existing call sites are unaffected
- `ChangeTierViewModel.init` seeds `typeOfContract` from the input (from the intent on the `.existingIntent` path); the fetch response still overwrites it afterwards
- Passed the contract type at the entry points that already hold it: `ContractsNavigation`, `QuickActionsViewModel`, `LoggedInNavigation` (both push and quick-action paths), `SelectInsuranceScreen`, `ChangeTierNavigationViewModel`
- Tests for the three cases (payment protection, regular contract, unknown type), asserted right after init so they cover the pre-fetch window

The termination path needed no change — it pre-fetches and hands over `.existingIntent`, which already carries the type. The commit/summary processing screen was left alone; its copy ("Processing changes...", "Changes complete") is product-neutral.

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
