### PR TITLE
chore: add HOME user flow for home screen cross-sells

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
@@ -98,25 +98,27 @@ extension CrossSellSource {
 
     private var asGraphQLUserFlow: OctopusGraphQL.UserFlow {
         switch self {
-        case .home: return .homeXSell
-        case .closedClaim: return .smartXSell
-        case .changeTier: return .smartXSell
-        case .addon: return .smartXSell
-        case .movingFlow: return .smartXSell
-        case .insurances: return .insurances
-        case .onboarding: return .onboarding
+        case .homeXSell: .homeXSell
+        case .closedClaim: .smartXSell
+        case .changeTier: .smartXSell
+        case .addon: .smartXSell
+        case .movingFlow: .smartXSell
+        case .home: .home
+        case .insurances: .insurances
+        case .onboarding: .onboarding
         }
     }
 
     private var asGraphQLFlowSource: OctopusGraphQL.FlowSource? {
         switch self {
-        case .home: return nil
-        case .closedClaim: return .closedClaim
-        case .changeTier: return .changeTier
-        case .addon: return .addon
-        case .movingFlow: return .moving
-        case .insurances: return nil
-        case .onboarding: return nil
+        case .homeXSell: nil
+        case .closedClaim: .closedClaim
+        case .changeTier: .changeTier
+        case .addon: .addon
+        case .movingFlow: .moving
+        case .home: nil
+        case .insurances: nil
+        case .onboarding: nil
         }
     }
 
@@ -124,7 +126,7 @@ extension CrossSellSource {
         switch self {
         case let .changeTier(contractId), let .movingFlow(contractId): contractId
         case let .closedClaim(_, contractId): contractId
-        case .home, .addon, .insurances, .onboarding: nil
+        case .homeXSell, .addon, .home, .insurances, .onboarding: nil
         }
     }
 

--- a/Projects/CrossSell/Sources/Service/CrossSellClient.swift
+++ b/Projects/CrossSell/Sources/Service/CrossSellClient.swift
@@ -9,21 +9,23 @@ public protocol CrossSellClient: Sendable {
 public enum CrossSellSource: Codable, Equatable, Sendable {
     public typealias RawValue = String
 
-    case home
+    case homeXSell
     case closedClaim(claimId: String, contractId: String?)
     case changeTier(contractId: String)
     case addon
     case movingFlow(contractId: String)
+    case home
     case insurances
     case onboarding
 
     public var rawValue: RawValue {
         switch self {
-        case .home: "home"
+        case .homeXSell: "homeXSell"
         case .closedClaim: "closedClaim"
         case .changeTier: "changeTier"
         case .addon: "addon"
         case .movingFlow: "movingFlow"
+        case .home: "home"
         case .insurances: "insurances"
         case .onboarding: "onboarding"
         }

--- a/Projects/CrossSell/Sources/Store/CrossSellStore.swift
+++ b/Projects/CrossSell/Sources/Store/CrossSellStore.swift
@@ -44,9 +44,10 @@ public final class CrossSellStore: AppStore {
 
     public func fetchHomeCrossSells() async {
         do {
-            let crossSells = try await crossSellService.getCrossSell(source: .home)
-            homeCrossSells = crossSells
-            let recommendedId = crossSells.recommended?.id
+            async let home = crossSellService.getCrossSell(source: .home)
+            let recommendedId = try await crossSellService.getCrossSell(source: .homeXSell).recommended?.id
+
+            homeCrossSells = try await home
             hasNewOffer = recommendedId != nil && recommendedId != lastSeenRecommendedProductId
         } catch {}
     }

--- a/Projects/CrossSell/Tests/StoreTests/CrossSellStoreTests.swift
+++ b/Projects/CrossSell/Tests/StoreTests/CrossSellStoreTests.swift
@@ -32,8 +32,7 @@ final class CrossSellStoreTests: XCTestCase {
             store.fetchCrossSellError == nil && store.crossSells == CrossSell.getDefault
         }
 
-        assert(mockService.events.count == 1)
-        assert(mockService.events.first == .getCrossSell)
+        assert(mockService.events == [.getCrossSell])
     }
 
     func testFetchCrossSalesFailure() async throws {
@@ -47,8 +46,7 @@ final class CrossSellStoreTests: XCTestCase {
         try await Task.sleep(seconds: 0.5)
         assert(store.fetchCrossSellError != nil)
         assert(store.crossSells?.others.isEmpty == nil)
-        assert(mockService.events.count == 1)
-        assert(mockService.events.first == .getCrossSell)
+        assert(mockService.events == [.getCrossSell])
     }
 
     func testFetchHomeCrossSellsSuccess() async {
@@ -64,8 +62,7 @@ final class CrossSellStoreTests: XCTestCase {
         }
 
         assert(store.hasNewOffer == true)
-        assert(mockService.events.count == 1)
-        assert(mockService.events.first == .getCrossSell)
+        assert(mockService.events == [.getCrossSell, .getCrossSell])
     }
 
     func testFetchAddonBannersDataSuccess() async {
@@ -79,8 +76,7 @@ final class CrossSellStoreTests: XCTestCase {
             store.fetchAddonBannersError == nil && store.addonBanners == AddonBanner.getDefault
         }
 
-        assert(mockService.events.count == 1)
-        assert(mockService.events.first == .getAddonBanners)
+        assert(mockService.events == [.getAddonBanners])
     }
 
     func testFetchAddonBannerDataFailure() async throws {
@@ -94,8 +90,7 @@ final class CrossSellStoreTests: XCTestCase {
         try await Task.sleep(seconds: 0.5)
         assert(store.fetchAddonBannersError != nil)
         assert(store.crossSells?.others.isEmpty == nil)
-        assert(mockService.events.count == 1)
-        assert(mockService.events.first == .getAddonBanners)
+        assert(mockService.events == [.getAddonBanners])
     }
 }
 

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -191,7 +191,7 @@ private struct HomeNavigationBar: View {
             action: { [weak navigationVm] type in
                 switch type {
                 case .crossSell:
-                    NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .home))
+                    NotificationCenter.default.post(name: .openCrossSell, object: CrossSellInfo(type: .homeXSell))
                 case .firstVet:
                     navigationVm?.quickActionsVm
                         .perform(.firstVet(partners: homeStore.quickActions.getFirstVetPartners ?? []))

--- a/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
@@ -6,28 +6,13 @@ struct HomeCrossSellsSection: View {
     let crossSells: CrossSells?
 
     var body: some View {
-        if let crossSells, !crossSells.all.isEmpty {
+        if let crossSells, !crossSells.others.isEmpty {
             CrossSellStackComponent(
-                crossSells: crossSells.all,
+                crossSells: crossSells.others,
                 discountAvailable: crossSells.discountAvailable,
                 withHeader: true,
                 headerTitle: L10n.crossSellSubtitle
             )
-        }
-    }
-}
-
-extension CrossSells {
-    fileprivate var all: [CrossSell] {
-        (recommended?.toCrossSell()).map { [$0] + others } ?? others
-    }
-}
-
-extension RecommendedCrossSell {
-    fileprivate func toCrossSell() -> CrossSell? {
-        switch self {
-        case let .insurance(insurance): insurance
-        case .addon: nil
         }
     }
 }

--- a/Projects/Home/Sources/Screens/Components/HomeOngoingQuotesSection.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeOngoingQuotesSection.swift
@@ -65,7 +65,6 @@ private struct OngoingQuoteCard: View {
         .hShadow(type: .custom(opacity: 0.05, radius: 5, xOffset: 0, yOffset: 4), show: true)
         .hShadow(type: .custom(opacity: 0.1, radius: 1, xOffset: 0, yOffset: 2), show: true)
         .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isButton)
         .accessibilityHint(L10n.voiceoverPressTo + " " + L10n.generalContinueButton)
         .onTapGesture { resume() }
         .accessibilityAddTraits(.isButton)

--- a/Projects/hCoreUI/Sources/StatusCard.swift
+++ b/Projects/hCoreUI/Sources/StatusCard.swift
@@ -76,7 +76,6 @@ where MainContent: View, BottomContent: View {
                 onSelected()
             }
         }
-        .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(onSelected != nil ? .isButton : [])
         .modifier(StatusCardBackgroundModifier())
     }


### PR DESCRIPTION
- Add `CrossSellSource.home` mapped to the new `HOME` user flow; rename the old case to `.homeXSell` (`HOME_X_SELL`)
- Home screen cross-sell section now lists `others` from `HOME`; the new-offer badge is still derived from `HOME_X_SELL`'s recommended id (both fetched concurrently)
- Remove duplicate `.isButton` accessibility traits in `OngoingQuoteCard`/`StatusCard`