### PR TITLE
chore: refactor Contract information display items

### DIFF
--- a/Projects/Chat/Sources/Views/InboxView.swift
+++ b/Projects/Chat/Sources/Views/InboxView.swift
@@ -107,7 +107,7 @@ public struct InboxView: View {
         hRow {
             rowViewContent(for: conversation)
         }
-        .shouldShowDivider(vm.shouldHideDivider(for: conversation))
+        .shouldHideDivider(vm.shouldHideDivider(for: conversation))
     }
 
     func rowViewContent(for conversation: Conversation) -> some View {

--- a/Projects/Contracts/Sources/Models/Contract + displayItems.swift
+++ b/Projects/Contracts/Sources/Models/Contract + displayItems.swift
@@ -1,50 +1,34 @@
-import hCore
 import EditStakeholders
+import hCore
 
 extension Contract {
     func getDisplayItems() -> [ContractInformationDisplayItem] {
-        var items = [ContractInformationDisplayItem]()
-        if let displayItems = currentAgreement?.getDisplayItems() {
-            items.append(contentsOf: displayItems)
-        }
-        if supportsCoInsured || supportsCoOwners || typeOfContract.isPaymentProtection {
-            let supportedPplValue = switch coInsured.count {
-            case 0: L10n.changeAddressOnlyYou
-            default: L10n.changeAddressYouPlus(coInsured.count)
-            }
-            items.append(
-                .init(
-                    id: "supportedPpl",
-                    type: .regular(title: L10n.coinsuredEditTitle, value: supportedPplValue, subtitle: nil)
-                )
+        var items = currentAgreement?.getDisplayItems() ?? []
+        guard supportsCoInsured || supportsCoOwners || typeOfContract.isPaymentProtection else { return items }
+
+        let coInsuredValue =
+            coInsured.isEmpty ? L10n.changeAddressOnlyYou : L10n.changeAddressYouPlus(coInsured.count)
+        items.append(
+            .init(
+                id: "supportedPpl",
+                type: .regular(title: L10n.coinsuredEditTitle, value: coInsuredValue, subtitle: nil)
             )
-            
-            items.append(
-                .init(
-                    id: "owner",
-                    type: .stakeholderItem(
-                        item: nil
-                    )
-                )
-            )
-            for stakeholderItem in stakeholderItems() {
-                items.append(.init(id: stakeholderItem.id, type: .stakeholderItem(item: stakeholderItem)))
-            }
-        }
+        )
+        // A stakeholder item without a person renders the contract owner.
+        items.append(.init(id: "owner", type: .stakeholder(item: nil)))
+        items.append(contentsOf: stakeholderItems.map { .init(id: $0.id, type: .stakeholder(item: $0)) })
         return items
     }
-    
-    fileprivate func stakeholderItems() -> [StakeholderItem] {
+
+    private var stakeholderItems: [StakeholderItem] {
         coInsured.map { $0.asStakeholderItem(type: .coInsured) }
             + coOwners.map { $0.asStakeholderItem(type: .coOwner) }
     }
 }
 
-
-
 extension Agreement {
     func getDisplayItems() -> [ContractInformationDisplayItem] {
-        let displayItems = displayItems.map { displayItem in
+        let items = displayItems.map { displayItem in
             ContractInformationDisplayItem(
                 id: displayItem.id,
                 type: .regular(
@@ -54,23 +38,17 @@ extension Agreement {
                 )
             )
         }
-
-        let itemCostDisplayItem = itemCost.map({ itemCost in
-            ContractInformationDisplayItem(id: "itemCost", type: .itemCost(cost: itemCost))
-        })
-        if let itemCostDisplayItem {
-            return displayItems + [itemCostDisplayItem]
-        }
-        return displayItems
+        guard let itemCost else { return items }
+        return items + [.init(id: "itemCost", type: .itemCost(cost: itemCost))]
     }
 }
 
 struct ContractInformationDisplayItem: Identifiable {
     let id: String
-    let type: ContractInformationDisplayItemType
+    let type: ItemType
 
-    enum ContractInformationDisplayItemType {
-        case stakeholderItem(item: StakeholderItem?)
+    enum ItemType {
+        case stakeholder(item: StakeholderItem?)
         case itemCost(cost: ItemCost)
         case regular(title: String, value: String, subtitle: String?)
     }

--- a/Projects/Contracts/Sources/Models/Contract + displayItems.swift
+++ b/Projects/Contracts/Sources/Models/Contract + displayItems.swift
@@ -1,0 +1,77 @@
+import hCore
+import EditStakeholders
+
+extension Contract {
+    func getDisplayItems() -> [ContractInformationDisplayItem] {
+        var items = [ContractInformationDisplayItem]()
+        if let displayItems = currentAgreement?.getDisplayItems() {
+            items.append(contentsOf: displayItems)
+        }
+        if supportsCoInsured || supportsCoOwners || typeOfContract.isPaymentProtection {
+            let supportedPplValue = switch coInsured.count {
+            case 0: L10n.changeAddressOnlyYou
+            default: L10n.changeAddressYouPlus(coInsured.count)
+            }
+            items.append(
+                .init(
+                    id: "supportedPpl",
+                    type: .regular(title: L10n.coinsuredEditTitle, value: supportedPplValue, subtitle: nil)
+                )
+            )
+            
+            items.append(
+                .init(
+                    id: "owner",
+                    type: .stakeholderItem(
+                        item: nil
+                    )
+                )
+            )
+            for stakeholderItem in stakeholderItems() {
+                items.append(.init(id: stakeholderItem.id, type: .stakeholderItem(item: stakeholderItem)))
+            }
+        }
+        return items
+    }
+    
+    fileprivate func stakeholderItems() -> [StakeholderItem] {
+        coInsured.map { $0.asStakeholderItem(type: .coInsured) }
+            + coOwners.map { $0.asStakeholderItem(type: .coOwner) }
+    }
+}
+
+
+
+extension Agreement {
+    func getDisplayItems() -> [ContractInformationDisplayItem] {
+        let displayItems = displayItems.map { displayItem in
+            ContractInformationDisplayItem(
+                id: displayItem.id,
+                type: .regular(
+                    title: displayItem.displayTitle,
+                    value: displayItem.displayValue,
+                    subtitle: displayItem.displaySubtitle
+                )
+            )
+        }
+
+        let itemCostDisplayItem = itemCost.map({ itemCost in
+            ContractInformationDisplayItem(id: "itemCost", type: .itemCost(cost: itemCost))
+        })
+        if let itemCostDisplayItem {
+            return displayItems + [itemCostDisplayItem]
+        }
+        return displayItems
+    }
+}
+
+struct ContractInformationDisplayItem: Identifiable {
+    let id: String
+    let type: ContractInformationDisplayItemType
+
+    enum ContractInformationDisplayItemType {
+        case stakeholderItem(item: StakeholderItem?)
+        case itemCost(cost: ItemCost)
+        case regular(title: String, value: String, subtitle: String?)
+    }
+}

--- a/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
+++ b/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
@@ -56,9 +56,3 @@ struct ContractDisplayItemRow<StakeholderRow: View>: View {
         }
     }
 }
-
-extension ContractDisplayItemRow where StakeholderRow == EmptyView {
-    init(item: ContractInformationDisplayItem) {
-        self.init(item: item) { _ in EmptyView() }
-    }
-}

--- a/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
+++ b/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
@@ -13,7 +13,7 @@ struct ContractDisplayItemRow<StakeholderRow: View>: View {
 
     init(
         item: ContractInformationDisplayItem,
-        @ViewBuilder stakeholderRow: @escaping (StakeholderItem?) -> StakeholderRow
+        @ViewBuilder stakeholderRow: @escaping (StakeholderItem?) -> StakeholderRow = { _ in EmptyView() }
     ) {
         self.item = item
         self.stakeholderRow = stakeholderRow

--- a/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
+++ b/Projects/Contracts/Sources/View/Components/ContractDisplayItemRow.swift
@@ -1,0 +1,64 @@
+import EditStakeholders
+import SwiftUI
+import hCore
+import hCoreUI
+
+/// Renders a single row of a contract's or an agreement's display items.
+///
+/// Screens that only show agreement items use `init(item:)`; screens that also
+/// list people pass a builder for the stakeholder rows.
+struct ContractDisplayItemRow<StakeholderRow: View>: View {
+    private let item: ContractInformationDisplayItem
+    private let stakeholderRow: (StakeholderItem?) -> StakeholderRow
+
+    init(
+        item: ContractInformationDisplayItem,
+        @ViewBuilder stakeholderRow: @escaping (StakeholderItem?) -> StakeholderRow
+    ) {
+        self.item = item
+        self.stakeholderRow = stakeholderRow
+    }
+
+    @ViewBuilder
+    var body: some View {
+        switch item.type {
+        case let .regular(title, value, subtitle):
+            hRow {
+                VStack(alignment: .leading, spacing: 0) {
+                    hText(title)
+                    if let subtitle {
+                        hText(subtitle, style: .label)
+                            .foregroundColor(hTextColor.Translucent.secondary)
+                    }
+                }
+            }
+            .withCustomAccessory {
+                Group {
+                    Spacer()
+                    if let date = value.localDateToDate?.displayDateDDMMMYYYYFormat {
+                        hText(date)
+                    } else {
+                        ZStack {
+                            hText(value)
+                            hText(" ")
+                        }
+                    }
+                }
+                .foregroundColor(hTextColor.Opaque.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        case let .itemCost(cost):
+            hRow {
+                ItemCostView(itemCost: cost)
+            }
+        case let .stakeholder(stakeholderItem):
+            stakeholderRow(stakeholderItem)
+        }
+    }
+}
+
+extension ContractDisplayItemRow where StakeholderRow == EmptyView {
+    init(item: ContractInformationDisplayItem) {
+        self.init(item: item) { _ in EmptyView() }
+    }
+}

--- a/Projects/Contracts/Sources/View/Components/ItemCostView.swift
+++ b/Projects/Contracts/Sources/View/Components/ItemCostView.swift
@@ -6,15 +6,6 @@ struct ItemCostView: View {
     let itemCost: ItemCost
     @State private var detentPriceBreakdownModel: PriceFieldModel.PriceFieldInfoModel?
     var body: some View {
-        hSection {
-            hRow {
-                content
-            }
-        }
-        .showPriceBreakdown(for: $detentPriceBreakdownModel)
-    }
-
-    private var content: some View {
         HStack(spacing: .padding2) {
             hText(L10n.detailsTableInsurancePremium)
             Spacer()
@@ -34,6 +25,7 @@ struct ItemCostView: View {
         .accessibilityAction {
             infoButtonTapAction()
         }
+        .showPriceBreakdown(for: $detentPriceBreakdownModel)
     }
 
     private func infoButtonTapAction() {

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -10,7 +10,6 @@ import hCoreUI
 
 struct ContractInformationView: View {
     @AppObservedObject var store: ContractStore
-    @StateObject private var vm = ContractsInformationViewModel()
     @EnvironmentObject private var contractsNavigationVm: ContractsNavigationViewModel
     let id: String
     var body: some View {
@@ -19,90 +18,128 @@ struct ContractInformationView: View {
                 VStack(spacing: .padding16) {
                     updatedContractView(contract)
                         .transition(.opacity.combined(with: .scale))
-
-                    if let displayItems = contract.currentAgreement?.displayItems {
-                        hSection {
-                            hSection(displayItems, id: \.id) { item in
-                                hRow {
-                                    VStack(alignment: .leading, spacing: 0) {
-                                        hText(item.displayTitle)
-                                        if let subtitle = item.displaySubtitle {
-                                            hText(subtitle, style: .label)
-                                                .foregroundColor(hTextColor.Translucent.secondary)
-                                        }
-                                    }
-                                }
-                                .withCustomAccessory {
-                                    Spacer()
-                                    Group {
-                                        if let date = item.displayValue.localDateToDate?.displayDateDDMMMYYYYFormat {
-                                            hText(date)
-                                        } else {
-                                            ZStack {
-                                                hText(item.displayValue)
-                                                hText(" ")
+                    hSection(contract.getDisplayItems()) { element in
+                        switch element.type {
+                        case let .coinsured(coInsured):
+                            hRow {
+                                if let coInsured {
+                                    if coInsured.stakeholder.hasMissingInfo {
+                                        StakeholderField(
+                                            accessoryView: getAccessoryView(
+                                                contract: contract,
+                                                stakeholder: coInsured.stakeholder
+                                            )
+                                            .foregroundColor(hSignalColor.Amber.element),
+                                            date: coInsured.stakeholder.terminatesOn
+                                                ?? coInsured.stakeholder.activatesOn,
+                                            stakeholderType: coInsured.stakeholderType,
+                                        )
+                                        .onTapGesture {
+                                            if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo),
+                                                coInsured.stakeholder.terminatesOn == nil
+                                            {
+                                                let contract: StakeholdersConfig = .init(
+                                                    contract: contract,
+                                                    stakeholderType: coInsured.stakeholderType,
+                                                    fromInfoCard: false
+                                                )
+                                                contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
                                             }
                                         }
-                                    }
-                                    .foregroundColor(hTextColor.Opaque.secondary)
-                                }
-                                .accessibilityElement(children: .combine)
-                            }
-
-                            if let currentAgreementCost = contract.currentAgreement?.itemCost {
-                                if !displayItems.isEmpty {
-                                    hRowDivider()
-                                        .hWithoutHorizontalPadding([.divider])
-                                        .padding(.horizontal, .padding16)
-                                }
-
-                                ItemCostView(itemCost: currentAgreementCost)
-                            }
-
-                            if contract.supportsCoInsured || contract.supportsCoOwners {
-                                hRowDivider()
-                                    .hWithoutHorizontalPadding([.divider])
-                                    .padding(.horizontal, .padding16)
-                                addCoInsuredView(contract: contract)
-                            }
-                        }
-                        .sectionContainerStyle(.opaque)
-                        .hWithoutHorizontalPadding([.section])
-
-                        missingStakeholderInfoCards(for: contract)
-                        missingPetIdInfoCard(for: contract)
-
-                        addonsView(contract: contract)
-
-                        VStack(spacing: .padding8) {
-                            if contract.showEditInfo {
-                                hButton(
-                                    .large,
-                                    .secondary,
-                                    content: .init(title: vm.getButtonText(contract))
-                                ) {
-                                    if contract.onlyCoInsured() {
-                                        let contract: StakeholdersConfig = .init(
-                                            contract: contract,
-                                            stakeholderType: .coInsured,
-                                            fromInfoCard: false
+                                        .accessibilityAddTraits(.isButton)
+                                        .accessibilityAddTraits(
+                                            {
+                                                if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo)
+                                                    && coInsured.stakeholder.terminatesOn == nil
+                                                {
+                                                    return .isButton
+                                                }
+                                                return AccessibilityTraits()
+                                            }()
                                         )
-
-                                        contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
                                     } else {
-                                        contractsNavigationVm.changeYourInformationContract = contract
+                                        StakeholderField(
+                                            stakeholder: coInsured.stakeholder,
+                                            accessoryView: EmptyView(),
+                                            date: coInsured.date,
+                                            stakeholderType: coInsured.stakeholderType,
+                                        )
+                                    }
+                                } else {
+                                    ContractOwnerField(
+                                        enabled: true,
+                                        hasContentBelow: false,
+                                        fullName: contract.fullName,
+                                        SSN: contract.ssn ?? ""
+                                    )
+                                }
+                            }
+                        case let .itemCost(cost):
+                            hRow {
+                                ItemCostView(itemCost: cost)
+                            }
+                        case let .regular(title, value, subtitle):
+                            hRow {
+                                VStack(alignment: .leading, spacing: 0) {
+                                    hText(title)
+                                    if let subtitle {
+                                        hText(subtitle, style: .label)
+                                            .foregroundColor(hTextColor.Translucent.secondary)
                                     }
                                 }
                             }
-                            moveAddressButton(contract: contract)
+                            .withCustomAccessory {
+                                Group {
+                                    Spacer()
+                                    if let date = value.localDateToDate?.displayDateDDMMMYYYYFormat {
+                                        hText(date)
+                                    } else {
+                                        ZStack {
+                                            hText(value)
+                                            hText(" ")
+                                        }
+                                    }
+                                }
+                                .foregroundColor(hTextColor.Opaque.secondary)
+                            }
+                            .accessibilityElement(children: .combine)
                         }
+                    }
+                    .sectionContainerStyle(.opaque)
+                    .hWithoutHorizontalPadding([.section])
+
+                    missingStakeholderInfoCards(for: contract)
+                    missingPetIdInfoCard(for: contract)
+
+                    addonsView(contract: contract)
+
+                    VStack(spacing: .padding8) {
+                        if contract.showEditInfo {
+                            hButton(
+                                .large,
+                                .secondary,
+                                content: .init(title: contract.showEditInfoButtonText)
+                            ) {
+                                if contract.onlyCoInsured() {
+                                    let contract: StakeholdersConfig = .init(
+                                        contract: contract,
+                                        stakeholderType: .coInsured,
+                                        fromInfoCard: false
+                                    )
+
+                                    contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
+                                } else {
+                                    contractsNavigationVm.changeYourInformationContract = contract
+                                }
+                            }
+                        }
+                        moveAddressButton(contract: contract)
                     }
                 }
                 .padding(.horizontal, .padding16)
                 .padding(.bottom, .padding16)
             }
         }
-        .sectionContainerStyle(.transparent)
     }
 
     func insuredField(contract: Contract) -> some View {
@@ -118,75 +155,6 @@ struct ContractInformationView: View {
             }
         }
         .accessibilityElement(children: .combine)
-    }
-
-    @ViewBuilder
-    private func addCoInsuredView(contract: Contract) -> some View {
-        let nbOfMissingStakeholders = contract.nbOfMissingCoInsured + contract.nbOfMissingCoOwners
-        VStack(spacing: 0) {
-            hSection {
-                if contract.supportsCoInsured {
-                    HStack {
-                        hRow {
-                            insuredField(contract: contract)
-                        }
-                    }
-                }
-
-                let hasContentBelow =
-                    !vm.stakeholderItems(for: contract).isEmpty || nbOfMissingStakeholders > 0
-                ContractOwnerField(
-                    enabled: true,
-                    hasContentBelow: hasContentBelow,
-                    fullName: contract.fullName,
-                    SSN: contract.ssn ?? ""
-                )
-                .padding(.top, .padding16)
-            }
-
-            hSection(vm.stakeholderItems(for: contract)) { item in
-                hRow {
-                    if item.stakeholder.hasMissingInfo {
-                        StakeholderField(
-                            accessoryView: getAccessoryView(contract: contract, stakeholder: item.stakeholder)
-                                .foregroundColor(hSignalColor.Amber.element),
-                            date: item.stakeholder.terminatesOn ?? item.stakeholder.activatesOn,
-                            stakeholderType: item.stakeholderType,
-                        )
-                        .onTapGesture {
-                            if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo),
-                                item.stakeholder.terminatesOn == nil
-                            {
-                                let contract: StakeholdersConfig = .init(
-                                    contract: contract,
-                                    stakeholderType: item.stakeholderType,
-                                    fromInfoCard: false
-                                )
-                                contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
-                            }
-                        }
-                        .accessibilityAddTraits(.isButton)
-                        .accessibilityAddTraits(
-                            {
-                                if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo)
-                                    && item.stakeholder.terminatesOn == nil
-                                {
-                                    return .isButton
-                                }
-                                return AccessibilityTraits()
-                            }()
-                        )
-                    } else {
-                        StakeholderField(
-                            stakeholder: item.stakeholder,
-                            accessoryView: EmptyView(),
-                            date: item.date,
-                            stakeholderType: item.stakeholderType,
-                        )
-                    }
-                }
-            }
-        }
     }
 
     @ViewBuilder
@@ -352,23 +320,6 @@ struct ContractInformationView: View {
     }
 }
 
-@MainActor
-private class ContractsInformationViewModel: ObservableObject {
-    func stakeholderItems(for contract: Contract) -> [StakeholderItem] {
-        contract.coInsured.map { $0.asStakeholderItem(type: .coInsured) }
-            + contract.coOwners.map { $0.asStakeholderItem(type: .coOwner) }
-    }
-
-    @MainActor
-    func getButtonText(_ contract: Contract) -> String {
-        switch true {
-        case contract.onlyCoInsured(): L10n.contractEditCoinsured
-        case contract.onlyCoOwners(): L10n.editCoownerTitle
-        default: L10n.contractEditInfoLabel
-        }
-    }
-}
-
 extension Stakeholder {
     func asStakeholderItem(type: StakeholderType) -> StakeholderItem {
         .init(
@@ -458,6 +409,78 @@ public struct AddonAction: Equatable, Identifiable {
             case .upgrade: return L10n.addonFlowUpgradeAddon
             case .removal: return L10n.removeAddonButtonTitle
             }
+        }
+    }
+}
+
+extension Contract {
+    func getDisplayItems() -> [ContractInformationDisplayItem] {
+        var items = [ContractInformationDisplayItem]()
+        if let displayItems = currentAgreement?.getDisplayItems() {
+            items.append(contentsOf: displayItems)
+        }
+        if supportsCoInsured || supportsCoOwners {
+            items.append(
+                .init(
+                    id: "owner",
+                    type: .coinsured(
+                        item: nil
+                    )
+                )
+            )
+            for stakeholder in stakeholderItems() {
+                items.append(.init(id: stakeholder.id, type: .coinsured(item: stakeholder)))
+            }
+        }
+        return items
+    }
+}
+
+extension Agreement {
+    func getDisplayItems() -> [ContractInformationDisplayItem] {
+        let displayItems = displayItems.map { displayItem in
+            ContractInformationDisplayItem(
+                id: displayItem.id,
+                type: .regular(
+                    title: displayItem.displayTitle,
+                    value: displayItem.displayValue,
+                    subtitle: displayItem.displaySubtitle
+                )
+            )
+        }
+
+        let itemCostDisplayItem = itemCost.map({ itemCost in
+            ContractInformationDisplayItem(id: "itemCost", type: .itemCost(cost: itemCost))
+        })
+        if let itemCostDisplayItem {
+            return displayItems + [itemCostDisplayItem]
+        }
+        return displayItems
+    }
+}
+
+struct ContractInformationDisplayItem: Identifiable {
+    let id: String
+    let type: ContractInformationDisplayItemType
+
+    enum ContractInformationDisplayItemType {
+        case coinsured(item: StakeholderItem?)
+        case itemCost(cost: ItemCost)
+        case regular(title: String, value: String, subtitle: String?)
+    }
+}
+
+extension Contract {
+    fileprivate func stakeholderItems() -> [StakeholderItem] {
+        coInsured.map { $0.asStakeholderItem(type: .coInsured) }
+            + coOwners.map { $0.asStakeholderItem(type: .coOwner) }
+    }
+
+    fileprivate var showEditInfoButtonText: String {
+        switch true {
+        case onlyCoInsured(): L10n.contractEditCoinsured
+        case onlyCoOwners(): L10n.editCoownerTitle
+        default: L10n.contractEditInfoLabel
         }
     }
 }

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -12,6 +12,7 @@ struct ContractInformationView: View {
     @AppObservedObject var store: ContractStore
     @EnvironmentObject private var contractsNavigationVm: ContractsNavigationViewModel
     let id: String
+
     var body: some View {
         Group {
             if let contract = store.contractForId(id) {
@@ -20,60 +21,8 @@ struct ContractInformationView: View {
                         .transition(.opacity.combined(with: .scale))
                     hSection(contract.getDisplayItems()) { element in
                         switch element.type {
-                        case let .coinsured(coInsured):
-                            hRow {
-                                if let coInsured {
-                                    if coInsured.stakeholder.hasMissingInfo {
-                                        StakeholderField(
-                                            accessoryView: getAccessoryView(
-                                                contract: contract,
-                                                stakeholder: coInsured.stakeholder
-                                            )
-                                            .foregroundColor(hSignalColor.Amber.element),
-                                            date: coInsured.stakeholder.terminatesOn
-                                                ?? coInsured.stakeholder.activatesOn,
-                                            stakeholderType: coInsured.stakeholderType,
-                                        )
-                                        .onTapGesture {
-                                            if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo),
-                                                coInsured.stakeholder.terminatesOn == nil
-                                            {
-                                                let contract: StakeholdersConfig = .init(
-                                                    contract: contract,
-                                                    stakeholderType: coInsured.stakeholderType,
-                                                    fromInfoCard: false
-                                                )
-                                                contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
-                                            }
-                                        }
-                                        .accessibilityAddTraits(.isButton)
-                                        .accessibilityAddTraits(
-                                            {
-                                                if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo)
-                                                    && coInsured.stakeholder.terminatesOn == nil
-                                                {
-                                                    return .isButton
-                                                }
-                                                return AccessibilityTraits()
-                                            }()
-                                        )
-                                    } else {
-                                        StakeholderField(
-                                            stakeholder: coInsured.stakeholder,
-                                            accessoryView: EmptyView(),
-                                            date: coInsured.date,
-                                            stakeholderType: coInsured.stakeholderType,
-                                        )
-                                    }
-                                } else {
-                                    ContractOwnerField(
-                                        enabled: true,
-                                        hasContentBelow: false,
-                                        fullName: contract.fullName,
-                                        SSN: contract.ssn ?? ""
-                                    )
-                                }
-                            }
+                        case let .stakeholderItem(stakeholderItem):
+                            coInsuredView(stakeholderItem: stakeholderItem, contract: contract)
                         case let .itemCost(cost):
                             hRow {
                                 ItemCostView(itemCost: cost)
@@ -142,19 +91,59 @@ struct ContractInformationView: View {
         }
     }
 
-    func insuredField(contract: Contract) -> some View {
-        VStack {
-            HStack {
-                hText(L10n.coinsuredEditTitle)
-                Spacer()
-                hText(
-                    contract.coInsured.count > 0
-                        ? L10n.changeAddressYouPlus(contract.coInsured.count) : L10n.changeAddressOnlyYou
+    private func coInsuredView(stakeholderItem: StakeholderItem?, contract: Contract) -> some View {
+        hRow {
+            if let stakeholderItem {
+                if stakeholderItem.stakeholder.hasMissingInfo {
+                    StakeholderField(
+                        accessoryView: getAccessoryView(
+                            contract: contract,
+                            stakeholder: stakeholderItem.stakeholder
+                        )
+                        .foregroundColor(hSignalColor.Amber.element),
+                        date: stakeholderItem.stakeholder.terminatesOn
+                            ?? stakeholderItem.stakeholder.activatesOn,
+                        stakeholderType: stakeholderItem.stakeholderType,
+                    )
+                    .onTapGesture {
+                        if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo),
+                            stakeholderItem.stakeholder.terminatesOn == nil
+                        {
+                            let contract: StakeholdersConfig = .init(
+                                contract: contract,
+                                stakeholderType: stakeholderItem.stakeholderType,
+                                fromInfoCard: false
+                            )
+                            contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
+                        }
+                    }
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityAddTraits(
+                        {
+                            if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo)
+                                && stakeholderItem.stakeholder.terminatesOn == nil
+                            {
+                                return .isButton
+                            }
+                            return AccessibilityTraits()
+                        }()
+                    )
+                } else {
+                    StakeholderField(
+                        stakeholder: stakeholderItem.stakeholder,
+                        accessoryView: EmptyView(),
+                        date: stakeholderItem.date,
+                        stakeholderType: stakeholderItem.stakeholderType,
+                    )
+                }
+            } else {
+                ContractOwnerField(
+                    enabled: true,
+                    fullName: contract.fullName,
+                    SSN: contract.ssn ?? ""
                 )
-                .foregroundColor(hTextColor.Opaque.secondary)
             }
         }
-        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -414,68 +403,6 @@ public struct AddonAction: Equatable, Identifiable {
 }
 
 extension Contract {
-    func getDisplayItems() -> [ContractInformationDisplayItem] {
-        var items = [ContractInformationDisplayItem]()
-        if let displayItems = currentAgreement?.getDisplayItems() {
-            items.append(contentsOf: displayItems)
-        }
-        if supportsCoInsured || supportsCoOwners {
-            items.append(
-                .init(
-                    id: "owner",
-                    type: .coinsured(
-                        item: nil
-                    )
-                )
-            )
-            for stakeholder in stakeholderItems() {
-                items.append(.init(id: stakeholder.id, type: .coinsured(item: stakeholder)))
-            }
-        }
-        return items
-    }
-}
-
-extension Agreement {
-    func getDisplayItems() -> [ContractInformationDisplayItem] {
-        let displayItems = displayItems.map { displayItem in
-            ContractInformationDisplayItem(
-                id: displayItem.id,
-                type: .regular(
-                    title: displayItem.displayTitle,
-                    value: displayItem.displayValue,
-                    subtitle: displayItem.displaySubtitle
-                )
-            )
-        }
-
-        let itemCostDisplayItem = itemCost.map({ itemCost in
-            ContractInformationDisplayItem(id: "itemCost", type: .itemCost(cost: itemCost))
-        })
-        if let itemCostDisplayItem {
-            return displayItems + [itemCostDisplayItem]
-        }
-        return displayItems
-    }
-}
-
-struct ContractInformationDisplayItem: Identifiable {
-    let id: String
-    let type: ContractInformationDisplayItemType
-
-    enum ContractInformationDisplayItemType {
-        case coinsured(item: StakeholderItem?)
-        case itemCost(cost: ItemCost)
-        case regular(title: String, value: String, subtitle: String?)
-    }
-}
-
-extension Contract {
-    fileprivate func stakeholderItems() -> [StakeholderItem] {
-        coInsured.map { $0.asStakeholderItem(type: .coInsured) }
-            + coOwners.map { $0.asStakeholderItem(type: .coOwner) }
-    }
-
     fileprivate var showEditInfoButtonText: String {
         switch true {
         case onlyCoInsured(): L10n.contractEditCoinsured

--- a/Projects/Contracts/Sources/View/ContractInformation.swift
+++ b/Projects/Contracts/Sources/View/ContractInformation.swift
@@ -19,39 +19,9 @@ struct ContractInformationView: View {
                 VStack(spacing: .padding16) {
                     updatedContractView(contract)
                         .transition(.opacity.combined(with: .scale))
-                    hSection(contract.getDisplayItems()) { element in
-                        switch element.type {
-                        case let .stakeholderItem(stakeholderItem):
-                            coInsuredView(stakeholderItem: stakeholderItem, contract: contract)
-                        case let .itemCost(cost):
-                            hRow {
-                                ItemCostView(itemCost: cost)
-                            }
-                        case let .regular(title, value, subtitle):
-                            hRow {
-                                VStack(alignment: .leading, spacing: 0) {
-                                    hText(title)
-                                    if let subtitle {
-                                        hText(subtitle, style: .label)
-                                            .foregroundColor(hTextColor.Translucent.secondary)
-                                    }
-                                }
-                            }
-                            .withCustomAccessory {
-                                Group {
-                                    Spacer()
-                                    if let date = value.localDateToDate?.displayDateDDMMMYYYYFormat {
-                                        hText(date)
-                                    } else {
-                                        ZStack {
-                                            hText(value)
-                                            hText(" ")
-                                        }
-                                    }
-                                }
-                                .foregroundColor(hTextColor.Opaque.secondary)
-                            }
-                            .accessibilityElement(children: .combine)
+                    hSection(contract.getDisplayItems()) { item in
+                        ContractDisplayItemRow(item: item) { stakeholderItem in
+                            stakeholderRow(stakeholderItem, contract: contract)
                         }
                     }
                     .sectionContainerStyle(.opaque)
@@ -91,49 +61,33 @@ struct ContractInformationView: View {
         }
     }
 
-    private func coInsuredView(stakeholderItem: StakeholderItem?, contract: Contract) -> some View {
+    private func stakeholderRow(_ stakeholderItem: StakeholderItem?, contract: Contract) -> some View {
         hRow {
             if let stakeholderItem {
+                let isEditable = contract.canEditStakeholder(stakeholderItem.stakeholder)
                 if stakeholderItem.stakeholder.hasMissingInfo {
                     StakeholderField(
-                        accessoryView: getAccessoryView(
-                            contract: contract,
-                            stakeholder: stakeholderItem.stakeholder
-                        )
-                        .foregroundColor(hSignalColor.Amber.element),
+                        accessoryView: missingInfoAccessory(isEditable: isEditable),
                         date: stakeholderItem.stakeholder.terminatesOn
                             ?? stakeholderItem.stakeholder.activatesOn,
-                        stakeholderType: stakeholderItem.stakeholderType,
+                        stakeholderType: stakeholderItem.stakeholderType
                     )
                     .onTapGesture {
-                        if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo),
-                            stakeholderItem.stakeholder.terminatesOn == nil
-                        {
-                            let contract: StakeholdersConfig = .init(
-                                contract: contract,
-                                stakeholderType: stakeholderItem.stakeholderType,
-                                fromInfoCard: false
-                            )
-                            contractsNavigationVm.editStakeholdersVm.start(fromContract: contract)
-                        }
+                        guard isEditable else { return }
+                        let config: StakeholdersConfig = .init(
+                            contract: contract,
+                            stakeholderType: stakeholderItem.stakeholderType,
+                            fromInfoCard: false
+                        )
+                        contractsNavigationVm.editStakeholdersVm.start(fromContract: config)
                     }
                     .accessibilityAddTraits(.isButton)
-                    .accessibilityAddTraits(
-                        {
-                            if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo)
-                                && stakeholderItem.stakeholder.terminatesOn == nil
-                            {
-                                return .isButton
-                            }
-                            return AccessibilityTraits()
-                        }()
-                    )
                 } else {
                     StakeholderField(
                         stakeholder: stakeholderItem.stakeholder,
                         accessoryView: EmptyView(),
                         date: stakeholderItem.date,
-                        stakeholderType: stakeholderItem.stakeholderType,
+                        stakeholderType: stakeholderItem.stakeholderType
                     )
                 }
             } else {
@@ -230,9 +184,10 @@ struct ContractInformationView: View {
     }
 
     @ViewBuilder
-    private func getAccessoryView(contract: Contract, stakeholder: Stakeholder) -> some View {
-        if (contract.showEditCoInsuredInfo || contract.showEditCoOwnersInfo), stakeholder.terminatesOn == nil {
+    private func missingInfoAccessory(isEditable: Bool) -> some View {
+        if isEditable {
             hCoreUIAssets.warningTriangleFilledSmall.view
+                .foregroundColor(hSignalColor.Amber.element)
         } else {
             EmptyView()
         }
@@ -409,5 +364,10 @@ extension Contract {
         case onlyCoOwners(): L10n.editCoownerTitle
         default: L10n.contractEditInfoLabel
         }
+    }
+
+    /// A stakeholder row is only actionable while the contract allows editing and the person is not being removed.
+    fileprivate func canEditStakeholder(_ stakeholder: Stakeholder) -> Bool {
+        (showEditCoInsuredInfo || showEditCoOwnersInfo) && stakeholder.terminatesOn == nil
     }
 }

--- a/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
+++ b/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
@@ -22,9 +22,7 @@ struct UpcomingChangesScreen: View {
     var body: some View {
         hForm {
             hSection(agreement.getDisplayItems()) { item in
-                ContractDisplayItemRow(item: item) { _ in
-                    EmptyView()
-                }
+                ContractDisplayItemRow(item: item)
             }
         }
         .sectionContainerStyle(.transparent)

--- a/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
+++ b/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
@@ -22,7 +22,9 @@ struct UpcomingChangesScreen: View {
     var body: some View {
         hForm {
             hSection(agreement.getDisplayItems()) { item in
-                ContractDisplayItemRow(item: item)
+                ContractDisplayItemRow(item: item) { _ in
+                    EmptyView()
+                }
             }
         }
         .sectionContainerStyle(.transparent)

--- a/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
+++ b/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
@@ -21,14 +21,39 @@ struct UpcomingChangesScreen: View {
 
     var body: some View {
         hForm {
-            VStack(spacing: 0) {
-                hSection(agreement.displayItems, id: \.displayValue) { item in
-                    displayItemView(item)
-                }
-                if let cost = agreement.itemCost {
-                    hRowDivider()
-                        .padding(.horizontal, .padding16)
-                    ItemCostView(itemCost: cost)
+            hSection(agreement.getDisplayItems()) { item in
+                switch item.type {
+                case let .itemCost(cost):
+                    hRow {
+                        ItemCostView(itemCost: cost)
+                    }
+                case let .regular(title, value, subtitle):
+                    hRow {
+                        VStack(alignment: .leading, spacing: 0) {
+                            hText(title)
+                            if let subtitle {
+                                hText(subtitle, style: .label)
+                                    .foregroundColor(hTextColor.Translucent.secondary)
+                            }
+                        }
+                    }
+                    .withCustomAccessory {
+                        Group {
+                            Spacer()
+                            if let date = value.localDateToDate?.displayDateDDMMMYYYYFormat {
+                                hText(date)
+                            } else {
+                                ZStack {
+                                    hText(value)
+                                    hText(" ")
+                                }
+                            }
+                        }
+                        .foregroundColor(hTextColor.Opaque.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                case .stakeholderItem:
+                    EmptyView()
                 }
             }
         }

--- a/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
+++ b/Projects/Contracts/Sources/View/UpcomingChangesScreen.swift
@@ -22,39 +22,7 @@ struct UpcomingChangesScreen: View {
     var body: some View {
         hForm {
             hSection(agreement.getDisplayItems()) { item in
-                switch item.type {
-                case let .itemCost(cost):
-                    hRow {
-                        ItemCostView(itemCost: cost)
-                    }
-                case let .regular(title, value, subtitle):
-                    hRow {
-                        VStack(alignment: .leading, spacing: 0) {
-                            hText(title)
-                            if let subtitle {
-                                hText(subtitle, style: .label)
-                                    .foregroundColor(hTextColor.Translucent.secondary)
-                            }
-                        }
-                    }
-                    .withCustomAccessory {
-                        Group {
-                            Spacer()
-                            if let date = value.localDateToDate?.displayDateDDMMMYYYYFormat {
-                                hText(date)
-                            } else {
-                                ZStack {
-                                    hText(value)
-                                    hText(" ")
-                                }
-                            }
-                        }
-                        .foregroundColor(hTextColor.Opaque.secondary)
-                    }
-                    .accessibilityElement(children: .combine)
-                case .stakeholderItem:
-                    EmptyView()
-                }
+                ContractDisplayItemRow(item: item)
             }
         }
         .sectionContainerStyle(.transparent)
@@ -95,16 +63,6 @@ struct UpcomingChangesScreen: View {
         }
         .hWithoutHorizontalPadding([.row, .divider])
         .hFormContentPosition(.compact)
-    }
-
-    private func displayItemView(_ item: AgreementDisplayItem) -> some View {
-        hRow {
-            HStack {
-                hText(item.displayTitle)
-                Spacer()
-                hText(item.displayValue).foregroundColor(hTextColor.Opaque.secondary)
-            }
-        }
     }
 }
 

--- a/Projects/EditStakeholders/Sources/View/ContractOwnerField.swift
+++ b/Projects/EditStakeholders/Sources/View/ContractOwnerField.swift
@@ -26,20 +26,18 @@ public struct ContractOwnerField: View {
     }
 
     public var body: some View {
-        VStack(spacing: .padding16) {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    hText(fullName)
-                        .foregroundColor(getTitleColor)
-                    Spacer()
-                    hCoreUIAssets.lock.view
-                        .foregroundColor(hTextColor.Opaque.tertiary)
-                }
-                hText(SSN, style: .label)
-                    .foregroundColor(getSubTitleColor)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                hText(fullName)
+                    .foregroundColor(getTitleColor)
+                Spacer()
+                hCoreUIAssets.lock.view
+                    .foregroundColor(hTextColor.Opaque.tertiary)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            hText(SSN, style: .label)
+                .foregroundColor(getSubTitleColor)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
     }
 

--- a/Projects/EditStakeholders/Sources/View/ContractOwnerField.swift
+++ b/Projects/EditStakeholders/Sources/View/ContractOwnerField.swift
@@ -3,57 +3,44 @@ import hCoreUI
 
 public struct ContractOwnerField: View {
     let enabled: Bool?
-    let hasContentBelow: Bool
     let fullName: String
     let SSN: String
 
     public init(
         enabled: Bool? = false,
-        hasContentBelow: Bool,
         fullName: String,
         SSN: String
     ) {
         self.enabled = enabled
-        self.hasContentBelow = hasContentBelow
         self.fullName = fullName
         self.SSN = SSN.displayFormatSSN ?? ""
     }
 
     public init(
         enabled: Bool? = false,
-        hasContentBelow: Bool,
         config: StakeholdersConfig
     ) {
         self.enabled = enabled
-        self.hasContentBelow = hasContentBelow
         fullName = config.holderFullName
         SSN = config.holderSSN?.displayFormatSSN ?? ""
     }
 
     public var body: some View {
-        hRow {
-            VStack(spacing: .padding16) {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        hText(fullName)
-                            .foregroundColor(getTitleColor)
-                        Spacer()
-                        hCoreUIAssets.lock.view
-                            .foregroundColor(hTextColor.Opaque.tertiary)
-                    }
-                    hText(SSN, style: .label)
-                        .foregroundColor(getSubTitleColor)
+        VStack(spacing: .padding16) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    hText(fullName)
+                        .foregroundColor(getTitleColor)
+                    Spacer()
+                    hCoreUIAssets.lock.view
+                        .foregroundColor(hTextColor.Opaque.tertiary)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                if hasContentBelow {
-                    hRowDivider()
-                        .hWithoutHorizontalPadding([.divider])
-                }
+                hText(SSN, style: .label)
+                    .foregroundColor(getSubTitleColor)
             }
-            .padding(.bottom, hasContentBelow ? 0 : .padding16)
-            .accessibilityElement(children: .combine)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .verticalPadding(0)
+        .accessibilityElement(children: .combine)
     }
 
     @hColorBuilder

--- a/Projects/EditStakeholders/Sources/View/StakeholdersScreen.swift
+++ b/Projects/EditStakeholders/Sources/View/StakeholdersScreen.swift
@@ -8,21 +8,65 @@ struct StakeholdersScreen: View {
     @ObservedObject var intentViewModel: IntentViewModel
     let type: StakeholderFieldType?
 
-    private var displayItems: [StakeholderItem] {
-        vm.items(for: type, activationDate: intentViewModel.intent?.activationDate)
+    private var displayItems: [ShareholderDisplayItemType] {
+        let owner = ShareholderDisplayItemType.owner
+        let items = vm.items(for: type, activationDate: intentViewModel.intent?.activationDate)
+        let coInsured = items.enumerated()
+            .map { (index, stakeholder) in
+                ShareholderDisplayItemType.stakeholder(item: stakeholder, withDivider: index < items.count - 1)
+            }
+        if vm.config.numberOfMissingStakeholdersWithoutTermination == 0 {
+            return [owner] + coInsured + [.add]
+        }
+        return [owner] + coInsured
     }
 
     var body: some View {
         hForm {
-            VStack(spacing: 0) {
-                contractOwnerField(hasContentBelow: !displayItems.isEmpty || vm.hasContentBelow)
-                stakeholderSection(list: displayItems)
-                buttonSection
+            hSection(displayItems) { item in
+                switch item {
+                case .owner:
+                    hRow {
+                        ContractOwnerField(
+                            config: vm.config
+                        )
+                    }
+                case let .stakeholder(stakeholder, withDivider):
+                    hRow {
+                        StakeholderField(
+                            stakeholder: stakeholder.stakeholder,
+                            accessoryView: getAccessoryView(stakeholder: stakeholder),
+                            statusPill: stakeholder.type == .added ? .added : nil,
+                            date: stakeholder.date,
+                            stakeholderType: stakeholder.stakeholderType
+                        )
+                    }
+                    .shouldHideDivider(!withDivider)
+                    .accessibilityValue(accessoryType(for: stakeholder).accessibilityValue)
+                case .add:
+                    hRow {
+                        hButton(
+                            .large,
+                            .secondary,
+                            content: .init(title: vm.config.stakeholderType.addButtonTitle)
+                        ) {
+                            if !vm.hasExistingStakeholders {
+                                editStakeholdersNavigation.stakeholderInputModel = .init(
+                                    actionType: .add,
+                                    stakeholderModel: Stakeholder(),
+                                    title: vm.config.stakeholderType.addButtonTitle,
+                                    contractId: vm.config.contractId
+                                )
+                            } else {
+                                editStakeholdersNavigation.selectStakeholder = .init(id: vm.config.contractId)
+                            }
+                        }
+                    }
+                }
             }
             .hWithoutHorizontalPadding([.section])
             .sectionContainerStyle(.transparent)
             .padding(.bottom, .padding6)
-
             infoCardSection
         }
         .hFormAttachToBottom {
@@ -45,56 +89,6 @@ struct StakeholdersScreen: View {
     private var buttonView: some View {
         if vm.showConfirmChangesButton {
             ConfirmChangesView(editStakeholdersNavigation: editStakeholdersNavigation)
-        }
-    }
-
-    private func contractOwnerField(hasContentBelow: Bool) -> some View {
-        hSection {
-            ContractOwnerField(
-                hasContentBelow: hasContentBelow,
-                config: vm.config
-            )
-            .padding(.top, .padding16)
-        }
-    }
-
-    private func stakeholderSection(list: [StakeholderItem]) -> some View {
-        hSection(list) { item in
-            hRow {
-                StakeholderField(
-                    stakeholder: item.stakeholder,
-                    accessoryView: getAccessoryView(stakeholder: item),
-                    statusPill: item.type == .added ? .added : nil,
-                    date: item.date,
-                    stakeholderType: item.stakeholderType
-                )
-            }
-            .accessibilityValue(accessoryType(for: item).accessibilityValue)
-        }
-    }
-
-    @ViewBuilder
-    private var buttonSection: (some View)? {
-        if vm.config.numberOfMissingStakeholdersWithoutTermination == 0 {
-            hSection {
-                hButton(
-                    .large,
-                    .secondary,
-                    content: .init(title: vm.config.stakeholderType.addButtonTitle)
-                ) {
-                    if !vm.hasExistingStakeholders {
-                        editStakeholdersNavigation.stakeholderInputModel = .init(
-                            actionType: .add,
-                            stakeholderModel: Stakeholder(),
-                            title: vm.config.stakeholderType.addButtonTitle,
-                            contractId: vm.config.contractId
-                        )
-                    } else {
-                        editStakeholdersNavigation.selectStakeholder = .init(id: vm.config.contractId)
-                    }
-                }
-            }
-            .hWithoutHorizontalPadding([.row])
         }
     }
 
@@ -189,4 +183,21 @@ struct StakeholdersScreen: View {
     )
     let vm = StakeholdersViewModel(with: config)
     return StakeholdersScreen(vm: vm, intentViewModel: IntentViewModel(), type: .localEdit)
+}
+
+private enum ShareholderDisplayItemType: Identifiable {
+    var id: String {
+        switch self {
+        case .owner:
+            return "owner"
+        case let .stakeholder(item, _):
+            return item.id
+        case .add:
+            return "add"
+        }
+    }
+
+    case owner
+    case stakeholder(item: StakeholderItem, withDivider: Bool)
+    case add
 }

--- a/Projects/EditStakeholders/Sources/View/StakeholdersScreen.swift
+++ b/Projects/EditStakeholders/Sources/View/StakeholdersScreen.swift
@@ -8,17 +8,17 @@ struct StakeholdersScreen: View {
     @ObservedObject var intentViewModel: IntentViewModel
     let type: StakeholderFieldType?
 
-    private var displayItems: [ShareholderDisplayItemType] {
-        let owner = ShareholderDisplayItemType.owner
-        let items = vm.items(for: type, activationDate: intentViewModel.intent?.activationDate)
-        let coInsured = items.enumerated()
-            .map { (index, stakeholder) in
-                ShareholderDisplayItemType.stakeholder(item: stakeholder, withDivider: index < items.count - 1)
-            }
-        if vm.config.numberOfMissingStakeholdersWithoutTermination == 0 {
-            return [owner] + coInsured + [.add]
+    private var displayItems: [StakeholderRowItem] {
+        let stakeholders = vm.items(for: type, activationDate: intentViewModel.intent?.activationDate)
+        let stakeholderRows = stakeholders.map { stakeholder in
+            StakeholderRowItem.stakeholder(
+                item: stakeholder,
+                // No divider above the add button, so the last person in the list hides its own.
+                hidesDivider: stakeholder.id == stakeholders.last?.id
+            )
         }
-        return [owner] + coInsured
+        let showsAddButton = vm.config.numberOfMissingStakeholdersWithoutTermination == 0
+        return [.owner] + stakeholderRows + (showsAddButton ? [.add] : [])
     }
 
     var body: some View {
@@ -31,7 +31,7 @@ struct StakeholdersScreen: View {
                             config: vm.config
                         )
                     }
-                case let .stakeholder(stakeholder, withDivider):
+                case let .stakeholder(stakeholder, hidesDivider):
                     hRow {
                         StakeholderField(
                             stakeholder: stakeholder.stakeholder,
@@ -41,7 +41,7 @@ struct StakeholdersScreen: View {
                             stakeholderType: stakeholder.stakeholderType
                         )
                     }
-                    .shouldHideDivider(!withDivider)
+                    .shouldHideDivider(hidesDivider)
                     .accessibilityValue(accessoryType(for: stakeholder).accessibilityValue)
                 case .add:
                     hRow {
@@ -185,19 +185,16 @@ struct StakeholdersScreen: View {
     return StakeholdersScreen(vm: vm, intentViewModel: IntentViewModel(), type: .localEdit)
 }
 
-private enum ShareholderDisplayItemType: Identifiable {
+private enum StakeholderRowItem: Identifiable {
+    case owner
+    case stakeholder(item: StakeholderItem, hidesDivider: Bool)
+    case add
+
     var id: String {
         switch self {
-        case .owner:
-            return "owner"
-        case let .stakeholder(item, _):
-            return item.id
-        case .add:
-            return "add"
+        case .owner: "owner"
+        case let .stakeholder(item, _): item.id
+        case .add: "add"
         }
     }
-
-    case owner
-    case stakeholder(item: StakeholderItem, withDivider: Bool)
-    case add
 }

--- a/Projects/EditStakeholders/Sources/View/StakeholdersViewModel.swift
+++ b/Projects/EditStakeholders/Sources/View/StakeholdersViewModel.swift
@@ -17,10 +17,6 @@ class StakeholdersViewModel: ObservableObject {
         self.config = config
     }
 
-    var hasContentBelow: Bool {
-        nbOfMissingStakeholdersExcludingDeleted > 0
-    }
-
     var hasExistingStakeholders: Bool {
         !config.preSelectedStakeholders.filter { !stakeholdersAdded.contains($0) }.isEmpty
     }

--- a/Projects/hCoreUI/Sources/hForm/hSection.swift
+++ b/Projects/hCoreUI/Sources/hForm/hSection.swift
@@ -208,8 +208,8 @@ extension View {
         environment(\.hWithoutDivider, true)
     }
 
-    public func shouldShowDivider(_ show: Bool) -> some View {
-        environment(\.hWithoutDivider, show)
+    public func shouldHideDivider(_ hide: Bool) -> some View {
+        environment(\.hWithoutDivider, hide)
     }
 }
 


### PR DESCRIPTION
## Contract information display items

- Contract details rows are now built from one shared list of display items instead of being assembled separately in each view
- Same list is reused on the contract details, upcoming changes and stakeholders screens, so the rows look and behave consistently
- Dividers and spacing are handled by the section itself, removing the manual divider/padding handling that had to be kept in sync by hand
- Handling of "Insured people" for payment protection

## Blockers

- None

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
