### PR TITLE
chore: round all buttons

### DIFF
--- a/Projects/Home/Sources/Screens/Components/HomeActionChips.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeActionChips.swift
@@ -73,7 +73,6 @@ struct HomeActionChips: View {
                     .padding(.top, .padding8)
                     .padding(.bottom, .padding6)
             }
-            .hCustomButtonCornerRadius(.cornerRadiusRounded)
             .hShadow(type: .light)
         }
     }

--- a/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
+++ b/Projects/Onboarding/Sources/Navigation/OnboardingNavigation.swift
@@ -33,7 +33,6 @@ struct OnboardingNavigation: View {
         .handleEditStakeholders(with: vm.editStakeholdersVm)
         .handleConnectPayment(with: vm.connectPaymentVm)
         .handleMissingChipIds(input: $vm.missingPetChipIdInput)
-        .hCustomButtonCornerRadius(.cornerRadiusRounded)
     }
 
     @ViewBuilder

--- a/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
+++ b/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
@@ -451,7 +451,7 @@ extension CGFloat {
     public static let cornerRadiusXL: CGFloat = 16
     public static let cornerRadiusXXL: CGFloat = 24
     public static let cornerRadiusXXXL: CGFloat = 32
-    public static let cornerRadiusRounded: CGFloat = 999
+    public static let cornerRadiusRounded: CGFloat = 36
 }
 
 extension CGFloat {

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -88,15 +88,6 @@ public enum hButtonSize: CaseIterable {
     case large
     case medium
     case small
-
-    @MainActor
-    var cornerRadius: CGFloat {
-        switch self {
-        case .small: .cornerRadiusS
-        case .medium: .cornerRadiusM
-        case .large: .cornerRadiusL
-        }
-    }
 }
 
 struct _hButton<Content: View>: View {

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -148,18 +148,11 @@ extension EnvironmentValues {
     @Entry public var hUseButtonTextColor: hButtonTextColor = .default
     @Entry var hWithTransition: AnyTransition? = nil
     @Entry public var hCustomButtonView: AnyView? = nil
-    @Entry var hCustomButtonCornerRadius: CGFloat? = nil
 }
 
 extension View {
     public var hUseLightMode: some View {
         environment(\.hUseLightMode, true)
-    }
-}
-
-extension View {
-    public func hCustomButtonCornerRadius(_ radius: CGFloat) -> some View {
-        environment(\.hCustomButtonCornerRadius, radius)
     }
 }
 

--- a/Projects/hCoreUI/Sources/hButton/hButtonStyle/hButtonStyle.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButtonStyle/hButtonStyle.swift
@@ -35,7 +35,6 @@ public enum hButtonConfigurationType: Sendable, CaseIterable {
 public struct ButtonFilledStyle: SwiftUI.ButtonStyle {
     @Environment(\.hButtonWithBorder) var withBorder
     var size: hButtonSize
-    @Environment(\.hCustomButtonCornerRadius) var customBorderRadius
 
     public func makeBody(configuration: Configuration) -> some View {
         VStack {
@@ -43,7 +42,7 @@ public struct ButtonFilledStyle: SwiftUI.ButtonStyle {
         }
         .buttonSizeModifier(size)
         .background(hButtonFilledBackground(configuration: configuration))
-        .buttonCornerModifier(customBorderRadius ?? size.cornerRadius, withBorder: withBorder)
+        .buttonCornerModifier(.cornerRadiusRounded, withBorder: withBorder)
     }
 
     // content


### PR DESCRIPTION
Filled buttons are now always pill-shaped, instead of being rounded per-size with an opt-in override at a few call sites.

- `ButtonFilledStyle` uses `.cornerRadiusRounded` unconditionally; `hButtonSize.cornerRadius` (`cornerRadiusS`/`M`/`L`) no longer feeds into it
- Removed the `hCustomButtonCornerRadius` environment value and its `View` modifier, plus the two call sites that opted in (`HomeActionChips`, `OnboardingNavigation`) — they now get the rounded shape by default
- `cornerRadiusRounded` changed from `999` to `36`. With the capsule hack gone it only needs to exceed half the tallest button height, and a real value keeps `RoundedRectangle` from over-clipping

## Checklist

- [ ] Dark/light mode verification
- [ ] Unit tests pass
- [ ] Accessibility tests pass
- [ ] Landscape verification
- [ ] iPad verification
- [ ] iPod/iPhone 12 mini/iPhone SE verification
