### PR TITLE
eng: explicit @Masked markers for log redaction

### DIFF
--- a/LocalModules/AutomaticLog/Package.swift
+++ b/LocalModules/AutomaticLog/Package.swift
@@ -30,5 +30,14 @@ let package = Package(
 
         // Library that exposes a macro as part of its API, which is used in client programs.
         .target(name: "AutomaticLog", dependencies: ["AutomaticLogMacros"]),
+
+        .testTarget(
+            name: "AutomaticLogTests",
+            dependencies: [
+                "AutomaticLog",
+                "AutomaticLogMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
     ]
 )

--- a/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
@@ -15,25 +15,28 @@ public struct LogOptions: OptionSet, Sendable {
     public static let all: LogOptions = [.output, .error]
 }
 
-public let redactedFieldNames: Set<String> = [
-    "ssn",
-    "personalnumber",
-    "otpstate",
-    "code",
-    "refreshtoken",
-    "token",
-    "email",
-    "phone",
-    "eurobonus",
-    "message",
-    "files",
-]
+public protocol SensitiveFieldsProviding {
+    static var sensitiveLogFields: Set<String> { get }
+}
 
-public func redactedDescription(_ value: Any, name: String? = nil) -> String {
-    if let name, redactedFieldNames.contains(name.lowercased()) {
-        return _mask(value)
+extension SensitiveFieldsProviding {
+    /// Instance-side access, so `logDescription(_:)` can read the set off an existential.
+    var sensitiveLogFieldsForLogging: Set<String> { Self.sensitiveLogFields }
+}
+
+public protocol SensitiveValue {
+    var maskedDescription: String { get }
+}
+
+public func logDescription(_ value: Any) -> String {
+    if let sensitive = value as? SensitiveValue {
+        return sensitive.maskedDescription
     }
-    return _redact(value)
+    return _describe(value)
+}
+
+public func maskedLogDescription(_ value: Any) -> String {
+    _mask(value)
 }
 
 private func _mask(_ value: Any) -> String {
@@ -48,7 +51,7 @@ private func _mask(_ value: Any) -> String {
     return String(repeating: "*", count: length)
 }
 
-private func _redact(_ value: Any) -> String {
+private func _describe(_ value: Any) -> String {
     let mirror = Mirror(reflecting: value)
 
     if mirror.children.isEmpty {
@@ -58,40 +61,52 @@ private func _redact(_ value: Any) -> String {
     switch mirror.displayStyle {
     case .optional:
         if let child = mirror.children.first {
-            return _redact(child.value)
+            return _describe(child.value)
         }
         return "nil"
 
     case .collection, .set:
-        let parts = mirror.children.map { _redact($0.value) }
+        let parts = mirror.children.map { _describe($0.value) }
         return "[\(parts.joined(separator: ", "))]"
 
     case .dictionary:
         let parts = mirror.children.map { child -> String in
             let pairChildren = Array(Mirror(reflecting: child.value).children)
             if pairChildren.count == 2 {
-                return "\(String(describing: pairChildren[0].value)): \(_redact(pairChildren[1].value))"
+                return "\(String(describing: pairChildren[0].value)): \(_describe(pairChildren[1].value))"
             }
-            return _redact(child.value)
+            return _describe(child.value)
         }
         return "[\(parts.joined(separator: ", "))]"
 
     default:
+        let sensitiveFields = (value as? any SensitiveFieldsProviding)?.sensitiveLogFieldsForLogging ?? []
         var parts: [String] = []
         for child in mirror.children {
-            if let label = child.label {
-                if redactedFieldNames.contains(label.lowercased()) {
-                    parts.append("\(label): \(_mask(child.value))")
-                } else {
-                    parts.append("\(label): \(_redact(child.value))")
-                }
+            guard let label = child.label else {
+                parts.append(_describe(child.value))
+                continue
+            }
+            // @Published and property wrappers store under a leading underscore.
+            let name = label.hasPrefix("_") ? String(label.dropFirst()) : label
+            if sensitiveFields.contains(name) {
+                parts.append("\(name): \(_mask(child.value))")
+            } else if let sensitive = child.value as? SensitiveValue {
+                parts.append("\(name): \(sensitive.maskedDescription)")
             } else {
-                parts.append(_redact(child.value))
+                parts.append("\(name): \(_describe(child.value))")
             }
         }
         return "\(type(of: value))(\(parts.joined(separator: ", ")))"
     }
 }
 
+@attached(peer)
+public macro Sensitive() = #externalMacro(module: "AutomaticLogMacros", type: "SensitiveMacro")
+
+@attached(extension, conformances: SensitiveFieldsProviding, names: named(sensitiveLogFields))
+public macro Loggable() = #externalMacro(module: "AutomaticLogMacros", type: "LoggableMacro")
+
 @attached(body)
-public macro Log(_ options: LogOptions = .all) = #externalMacro(module: "AutomaticLogMacros", type: "AutomaticLog")
+public macro Log(_ options: LogOptions = .all, sensitive: [String] = []) =
+    #externalMacro(module: "AutomaticLogMacros", type: "AutomaticLog")

--- a/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
@@ -15,22 +15,22 @@ public struct LogOptions: OptionSet, Sendable {
     public static let all: LogOptions = [.output, .error]
 }
 
-public protocol SensitiveFieldsProviding {
-    static var sensitiveLogFields: Set<String> { get }
+public protocol MaskedFieldsProviding {
+    static var maskedLogFields: Set<String> { get }
 }
 
-extension SensitiveFieldsProviding {
+extension MaskedFieldsProviding {
     /// Instance-side access, so `logDescription(_:)` can read the set off an existential.
-    var sensitiveLogFieldsForLogging: Set<String> { Self.sensitiveLogFields }
+    var maskedLogFieldsForLogging: Set<String> { Self.maskedLogFields }
 }
 
-public protocol SensitiveValue {
+public protocol MaskedValue {
     var maskedDescription: String { get }
 }
 
 public func logDescription(_ value: Any) -> String {
-    if let sensitive = value as? SensitiveValue {
-        return sensitive.maskedDescription
+    if let masked = value as? MaskedValue {
+        return masked.maskedDescription
     }
     return _describe(value)
 }
@@ -80,7 +80,7 @@ private func _describe(_ value: Any) -> String {
         return "[\(parts.joined(separator: ", "))]"
 
     default:
-        let sensitiveFields = (value as? any SensitiveFieldsProviding)?.sensitiveLogFieldsForLogging ?? []
+        let maskedFields = (value as? any MaskedFieldsProviding)?.maskedLogFieldsForLogging ?? []
         var parts: [String] = []
         for child in mirror.children {
             guard let label = child.label else {
@@ -89,10 +89,10 @@ private func _describe(_ value: Any) -> String {
             }
             // @Published and property wrappers store under a leading underscore.
             let name = label.hasPrefix("_") ? String(label.dropFirst()) : label
-            if sensitiveFields.contains(name) {
+            if maskedFields.contains(name) {
                 parts.append("\(name): \(_mask(child.value))")
-            } else if let sensitive = child.value as? SensitiveValue {
-                parts.append("\(name): \(sensitive.maskedDescription)")
+            } else if let masked = child.value as? MaskedValue {
+                parts.append("\(name): \(masked.maskedDescription)")
             } else {
                 parts.append("\(name): \(_describe(child.value))")
             }
@@ -102,11 +102,11 @@ private func _describe(_ value: Any) -> String {
 }
 
 @attached(peer)
-public macro Sensitive() = #externalMacro(module: "AutomaticLogMacros", type: "SensitiveMacro")
+public macro Masked() = #externalMacro(module: "AutomaticLogMacros", type: "MaskedMacro")
 
-@attached(extension, conformances: SensitiveFieldsProviding, names: named(sensitiveLogFields))
+@attached(extension, conformances: MaskedFieldsProviding, names: named(maskedLogFields))
 public macro Loggable() = #externalMacro(module: "AutomaticLogMacros", type: "LoggableMacro")
 
 @attached(body)
-public macro Log(_ options: LogOptions = .all, sensitive: [String] = []) =
+public macro Log(_ options: LogOptions = .all, masked: [String] = []) =
     #externalMacro(module: "AutomaticLogMacros", type: "AutomaticLog")

--- a/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLog/LogMacro.swift
@@ -29,10 +29,7 @@ public protocol MaskedValue {
 }
 
 public func logDescription(_ value: Any) -> String {
-    if let masked = value as? MaskedValue {
-        return masked.maskedDescription
-    }
-    return _describe(value)
+    _describe(value)
 }
 
 public func maskedLogDescription(_ value: Any) -> String {
@@ -52,6 +49,12 @@ private func _mask(_ value: Any) -> String {
 }
 
 private func _describe(_ value: Any) -> String {
+    // Checked here rather than at each call site, so a type that masks itself keeps masking
+    // wherever it sits: a property, an array element, a dictionary value.
+    if let masked = value as? MaskedValue {
+        return masked.maskedDescription
+    }
+
     let mirror = Mirror(reflecting: value)
 
     if mirror.children.isEmpty {
@@ -91,8 +94,6 @@ private func _describe(_ value: Any) -> String {
             let name = label.hasPrefix("_") ? String(label.dropFirst()) : label
             if maskedFields.contains(name) {
                 parts.append("\(name): \(_mask(child.value))")
-            } else if let masked = child.value as? MaskedValue {
-                parts.append("\(name): \(masked.maskedDescription)")
             } else {
                 parts.append("\(name): \(_describe(child.value))")
             }

--- a/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/LogMacroMacro.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/LogMacroMacro.swift
@@ -20,12 +20,12 @@ public struct AutomaticLog: BodyMacro {
 
     private static func parseLogOptions(from attribute: AttributeSyntax) -> ParsedLogOptions {
         guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
-            let firstArgument = arguments.first
+            let optionsArgument = arguments.first(where: { $0.label == nil })
         else {
             return .all
         }
 
-        let argText = firstArgument.expression.description.trimmingCharacters(in: .whitespaces)
+        let argText = optionsArgument.expression.description.trimmingCharacters(in: .whitespaces)
 
         if argText == ".all" {
             return .all
@@ -43,6 +43,46 @@ public struct AutomaticLog: BodyMacro {
         return options.isEmpty ? .all : options
     }
 
+    private static func parseSensitiveNames(from attribute: AttributeSyntax) -> [String] {
+        guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
+            let argument = arguments.first(where: { $0.label?.text == "sensitive" }),
+            let array = argument.expression.as(ArrayExprSyntax.self)
+        else {
+            return []
+        }
+
+        return array.elements.compactMap { element in
+            element.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
+        }
+    }
+
+    /// A name in `sensitive:` that is not a parameter would silently log a secret in plain
+    /// text, so a rename or a typo has to fail the build.
+    private static func validate(
+        sensitiveNames: [String],
+        of funcDecl: FunctionDeclSyntax,
+        attribute: AttributeSyntax,
+        in context: some MacroExpansionContext
+    ) {
+        let parameterNames = funcDecl.signature.parameterClause.parameters
+            .map { ($0.secondName ?? $0.firstName).text }
+
+        for name in sensitiveNames where !parameterNames.contains(name) {
+            let detail =
+                parameterNames.isEmpty
+                ? "it has no parameters"
+                : "parameters are: \(parameterNames.joined(separator: ", "))"
+            context.diagnose(
+                Diagnostic(
+                    node: attribute,
+                    message: MacroExpansionErrorMessage(
+                        "'\(name)' is not a parameter of '\(funcDecl.name.text)' — \(detail)"
+                    )
+                )
+            )
+        }
+    }
+
     public static func expansion(
         of attribute: AttributeSyntax,
         providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
@@ -55,7 +95,14 @@ public struct AutomaticLog: BodyMacro {
         }
 
         let options = parseLogOptions(from: attribute)
-        let metadata = extractFunctionMetadata(from: funcDecl, in: context, options: options)
+        let sensitiveNames = parseSensitiveNames(from: attribute)
+        validate(sensitiveNames: sensitiveNames, of: funcDecl, attribute: attribute, in: context)
+        let metadata = extractFunctionMetadata(
+            from: funcDecl,
+            in: context,
+            options: options,
+            sensitiveNames: sensitiveNames
+        )
         var statements = generateEntryLogStatements(for: metadata)
 
         if metadata.hasReturnType {
@@ -69,10 +116,16 @@ public struct AutomaticLog: BodyMacro {
 
     // MARK: - Function Metadata
 
+    /// A parameter of a logged function, plus whether `@Sensitive` was applied to it.
+    private struct LoggedParameter {
+        let name: String
+        let isSensitive: Bool
+    }
+
     private struct FunctionMetadata {
         let functionName: String
         let fullFunctionName: String
-        let parameterNames: [String]
+        let parameters: [LoggedParameter]
         let hasReturnType: Bool
         let isAsync: Bool
         let isThrows: Bool
@@ -83,14 +136,17 @@ public struct AutomaticLog: BodyMacro {
     private static func extractFunctionMetadata(
         from funcDecl: FunctionDeclSyntax,
         in context: some MacroExpansionContext,
-        options: ParsedLogOptions
+        options: ParsedLogOptions,
+        sensitiveNames: [String]
     ) -> FunctionMetadata {
         let functionName = funcDecl.name.text
         let typeName = findParentTypeName(of: funcDecl, in: context)
         let fullFunctionName = typeName.isEmpty ? functionName : "\(typeName) \(functionName)"
 
-        let parameters = funcDecl.signature.parameterClause.parameters
-        let parameterNames = parameters.map { $0.secondName ?? $0.firstName }.map(\.text)
+        let parameters = funcDecl.signature.parameterClause.parameters.map { parameter in
+            let name = (parameter.secondName ?? parameter.firstName).text
+            return LoggedParameter(name: name, isSensitive: sensitiveNames.contains(name))
+        }
 
         let hasReturnType = funcDecl.signature.returnClause != nil
         let isAsync = funcDecl.signature.effectSpecifiers?.asyncSpecifier != nil
@@ -101,7 +157,7 @@ public struct AutomaticLog: BodyMacro {
         return FunctionMetadata(
             functionName: functionName,
             fullFunctionName: fullFunctionName,
-            parameterNames: parameterNames,
+            parameters: parameters,
             hasReturnType: hasReturnType,
             isAsync: isAsync,
             isThrows: isThrows,
@@ -113,12 +169,18 @@ public struct AutomaticLog: BodyMacro {
     // MARK: - Entry Log Generation
 
     private static func generateEntryLogStatements(for metadata: FunctionMetadata) -> [CodeBlockItemSyntax] {
-        guard !metadata.parameterNames.isEmpty else {
+        guard !metadata.parameters.isEmpty else {
             return []
         }
 
-        let dictElements = metadata.parameterNames
-            .map { "\"\($0)\": AutomaticLog.redactedDescription(\($0) as Any, name: \"\($0)\")" }
+        let dictElements = metadata.parameters
+            .map { parameter in
+                let description =
+                    parameter.isSensitive
+                    ? "AutomaticLog.maskedLogDescription(\(parameter.name) as Any)"
+                    : "AutomaticLog.logDescription(\(parameter.name) as Any)"
+                return "\"\(parameter.name)\": \(description)"
+            }
             .joined(separator: ", ")
 
         let logSetupCode = """
@@ -156,12 +218,12 @@ public struct AutomaticLog: BodyMacro {
         let logError = metadata.options.contains(.error)
 
         let argsString =
-            metadata.parameterNames.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
+            metadata.parameters.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
 
         let successLog: String
         if logOutput {
             successLog = """
-                AutomaticLog.loginClosure("✅ \(metadata.fullFunctionName)\(argsString) → \\(AutomaticLog.redactedDescription(_logResult as Any))")
+                AutomaticLog.loginClosure("✅ \(metadata.fullFunctionName)\(argsString) → \\(AutomaticLog.logDescription(_logResult as Any))")
                 """
         } else {
             successLog = """
@@ -204,12 +266,12 @@ public struct AutomaticLog: BodyMacro {
         let logOutput = metadata.options.contains(.output)
 
         let argsString =
-            metadata.parameterNames.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
+            metadata.parameters.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
 
         let successLog: String
         if logOutput {
             successLog = """
-                AutomaticLog.loginClosure("✅ \(metadata.fullFunctionName)\(argsString) → \\(AutomaticLog.redactedDescription(_logResult as Any))")
+                AutomaticLog.loginClosure("✅ \(metadata.fullFunctionName)\(argsString) → \\(AutomaticLog.logDescription(_logResult as Any))")
                 """
         } else {
             successLog = """
@@ -260,7 +322,7 @@ public struct AutomaticLog: BodyMacro {
         let logError = metadata.options.contains(.error)
 
         let argsString =
-            metadata.parameterNames.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
+            metadata.parameters.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
 
         let successLog: String
         if logOutput {
@@ -307,7 +369,7 @@ public struct AutomaticLog: BodyMacro {
         let logOutput = metadata.options.contains(.output)
 
         let argsString =
-            metadata.parameterNames.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
+            metadata.parameters.isEmpty ? "" : "(\\(String(describing: _logArgs)))"
 
         let successLog: String
         if logOutput {
@@ -362,6 +424,8 @@ public struct AutomaticLog: BodyMacro {
 @main
 struct AutomaticLogPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        AutomaticLog.self
+        AutomaticLog.self,
+        SensitiveMacro.self,
+        LoggableMacro.self,
     ]
 }

--- a/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/LogMacroMacro.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/LogMacroMacro.swift
@@ -43,9 +43,9 @@ public struct AutomaticLog: BodyMacro {
         return options.isEmpty ? .all : options
     }
 
-    private static func parseSensitiveNames(from attribute: AttributeSyntax) -> [String] {
+    private static func parseMaskedNames(from attribute: AttributeSyntax) -> [String] {
         guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
-            let argument = arguments.first(where: { $0.label?.text == "sensitive" }),
+            let argument = arguments.first(where: { $0.label?.text == "masked" }),
             let array = argument.expression.as(ArrayExprSyntax.self)
         else {
             return []
@@ -56,10 +56,10 @@ public struct AutomaticLog: BodyMacro {
         }
     }
 
-    /// A name in `sensitive:` that is not a parameter would silently log a secret in plain
+    /// A name in `masked:` that is not a parameter would silently log a secret in plain
     /// text, so a rename or a typo has to fail the build.
     private static func validate(
-        sensitiveNames: [String],
+        maskedNames: [String],
         of funcDecl: FunctionDeclSyntax,
         attribute: AttributeSyntax,
         in context: some MacroExpansionContext
@@ -67,7 +67,7 @@ public struct AutomaticLog: BodyMacro {
         let parameterNames = funcDecl.signature.parameterClause.parameters
             .map { ($0.secondName ?? $0.firstName).text }
 
-        for name in sensitiveNames where !parameterNames.contains(name) {
+        for name in maskedNames where !parameterNames.contains(name) {
             let detail =
                 parameterNames.isEmpty
                 ? "it has no parameters"
@@ -95,13 +95,13 @@ public struct AutomaticLog: BodyMacro {
         }
 
         let options = parseLogOptions(from: attribute)
-        let sensitiveNames = parseSensitiveNames(from: attribute)
-        validate(sensitiveNames: sensitiveNames, of: funcDecl, attribute: attribute, in: context)
+        let maskedNames = parseMaskedNames(from: attribute)
+        validate(maskedNames: maskedNames, of: funcDecl, attribute: attribute, in: context)
         let metadata = extractFunctionMetadata(
             from: funcDecl,
             in: context,
             options: options,
-            sensitiveNames: sensitiveNames
+            maskedNames: maskedNames
         )
         var statements = generateEntryLogStatements(for: metadata)
 
@@ -116,10 +116,10 @@ public struct AutomaticLog: BodyMacro {
 
     // MARK: - Function Metadata
 
-    /// A parameter of a logged function, plus whether `@Sensitive` was applied to it.
+    /// A parameter of a logged function, plus whether `@Masked` was applied to it.
     private struct LoggedParameter {
         let name: String
-        let isSensitive: Bool
+        let isMasked: Bool
     }
 
     private struct FunctionMetadata {
@@ -137,7 +137,7 @@ public struct AutomaticLog: BodyMacro {
         from funcDecl: FunctionDeclSyntax,
         in context: some MacroExpansionContext,
         options: ParsedLogOptions,
-        sensitiveNames: [String]
+        maskedNames: [String]
     ) -> FunctionMetadata {
         let functionName = funcDecl.name.text
         let typeName = findParentTypeName(of: funcDecl, in: context)
@@ -145,7 +145,7 @@ public struct AutomaticLog: BodyMacro {
 
         let parameters = funcDecl.signature.parameterClause.parameters.map { parameter in
             let name = (parameter.secondName ?? parameter.firstName).text
-            return LoggedParameter(name: name, isSensitive: sensitiveNames.contains(name))
+            return LoggedParameter(name: name, isMasked: maskedNames.contains(name))
         }
 
         let hasReturnType = funcDecl.signature.returnClause != nil
@@ -176,7 +176,7 @@ public struct AutomaticLog: BodyMacro {
         let dictElements = metadata.parameters
             .map { parameter in
                 let description =
-                    parameter.isSensitive
+                    parameter.isMasked
                     ? "AutomaticLog.maskedLogDescription(\(parameter.name) as Any)"
                     : "AutomaticLog.logDescription(\(parameter.name) as Any)"
                 return "\"\(parameter.name)\": \(description)"
@@ -425,7 +425,7 @@ public struct AutomaticLog: BodyMacro {
 struct AutomaticLogPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         AutomaticLog.self,
-        SensitiveMacro.self,
+        MaskedMacro.self,
         LoggableMacro.self,
     ]
 }

--- a/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/MaskedMacros.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/MaskedMacros.swift
@@ -3,12 +3,12 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-/// `@Sensitive` carries no code of its own — it is a marker that `@Loggable` reads.
+/// `@Masked` carries no code of its own — it is a marker that `@Loggable` reads.
 ///
 /// Its whole job at expansion time is to reject the two ways the marker could silently
 /// do nothing: a computed property, which reflection never sees, and a type that is not
 /// `@Loggable`, which never collects the marker.
-public struct SensitiveMacro: PeerMacro {
+public struct MaskedMacro: PeerMacro {
     public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -18,7 +18,7 @@ public struct SensitiveMacro: PeerMacro {
             context.diagnose(
                 Diagnostic(
                     node: node,
-                    message: MacroExpansionErrorMessage("'@Sensitive' can only be applied to a stored property")
+                    message: MacroExpansionErrorMessage("'@Masked' can only be applied to a stored property")
                 )
             )
             return []
@@ -29,7 +29,7 @@ public struct SensitiveMacro: PeerMacro {
                 Diagnostic(
                     node: node,
                     message: MacroExpansionErrorMessage(
-                        "'@Sensitive' has no effect on a computed property, which is never logged"
+                        "'@Masked' has no effect on a computed property, which is never logged"
                     )
                 )
             )
@@ -41,7 +41,7 @@ public struct SensitiveMacro: PeerMacro {
                 Diagnostic(
                     node: node,
                     message: MacroExpansionErrorMessage(
-                        "'@Sensitive' has no effect here: mark '\(typeName)' with '@Loggable' to collect it"
+                        "'@Masked' has no effect here: mark '\(typeName)' with '@Loggable' to collect it"
                     )
                 )
             )
@@ -92,7 +92,7 @@ public struct SensitiveMacro: PeerMacro {
     }
 }
 
-/// Generates the `SensitiveFieldsProviding` conformance from the type's `@Sensitive` properties.
+/// Generates the `MaskedFieldsProviding` conformance from the type's `@Masked` properties.
 public struct LoggableMacro: ExtensionMacro {
     public static func expansion(
         of node: AttributeSyntax,
@@ -105,17 +105,17 @@ public struct LoggableMacro: ExtensionMacro {
         // case the field set is hand-written.
         let alreadyConforms =
             declaration.inheritanceClause?.inheritedTypes
-            .contains { $0.type.trimmedDescription.hasSuffix("SensitiveFieldsProviding") } ?? false
+            .contains { $0.type.trimmedDescription.hasSuffix("MaskedFieldsProviding") } ?? false
         guard !alreadyConforms else { return [] }
 
-        let fields = sensitiveFieldNames(in: declaration)
+        let fields = maskedFieldNames(in: declaration)
 
         if fields.isEmpty {
             context.diagnose(
                 Diagnostic(
                     node: node,
                     message: MacroExpansionWarningMessage(
-                        "'@Loggable' has no effect: no property of '\(type.trimmedDescription)' is marked '@Sensitive'"
+                        "'@Loggable' has no effect: no property of '\(type.trimmedDescription)' is marked '@Masked'"
                     )
                 )
             )
@@ -130,18 +130,18 @@ public struct LoggableMacro: ExtensionMacro {
         return [
             try ExtensionDeclSyntax(
                 """
-                extension \(type.trimmed): AutomaticLog.SensitiveFieldsProviding {
-                    \(raw: accessLevel)static let sensitiveLogFields: Set<String> = [\(raw: elements)]
+                extension \(type.trimmed): AutomaticLog.MaskedFieldsProviding {
+                    \(raw: accessLevel)static let maskedLogFields: Set<String> = [\(raw: elements)]
                 }
                 """
             )
         ]
     }
 
-    private static func sensitiveFieldNames(in declaration: some DeclGroupSyntax) -> [String] {
+    private static func maskedFieldNames(in declaration: some DeclGroupSyntax) -> [String] {
         declaration.memberBlock.members.flatMap { member -> [String] in
             guard let variable = member.decl.as(VariableDeclSyntax.self),
-                variable.attributes.contains(where: isSensitiveAttribute)
+                variable.attributes.contains(where: isMaskedAttribute)
             else {
                 return []
             }
@@ -151,9 +151,9 @@ public struct LoggableMacro: ExtensionMacro {
         }
     }
 
-    private static func isSensitiveAttribute(_ attribute: AttributeListSyntax.Element) -> Bool {
+    private static func isMaskedAttribute(_ attribute: AttributeListSyntax.Element) -> Bool {
         guard case .attribute(let attribute) = attribute else { return false }
         let name = attribute.attributeName.trimmedDescription
-        return name == "Sensitive" || name.hasSuffix(".Sensitive")
+        return name == "Masked" || name.hasSuffix(".Masked")
     }
 }

--- a/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/SensitiveMacros.swift
+++ b/LocalModules/AutomaticLog/Sources/AutomaticLogMacros/SensitiveMacros.swift
@@ -1,0 +1,159 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// `@Sensitive` carries no code of its own — it is a marker that `@Loggable` reads.
+///
+/// Its whole job at expansion time is to reject the two ways the marker could silently
+/// do nothing: a computed property, which reflection never sees, and a type that is not
+/// `@Loggable`, which never collects the marker.
+public struct SensitiveMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let variable = declaration.as(VariableDeclSyntax.self) else {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    message: MacroExpansionErrorMessage("'@Sensitive' can only be applied to a stored property")
+                )
+            )
+            return []
+        }
+
+        if variable.bindings.contains(where: { $0.accessorBlock != nil && !isObserver($0.accessorBlock!) }) {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    message: MacroExpansionErrorMessage(
+                        "'@Sensitive' has no effect on a computed property, which is never logged"
+                    )
+                )
+            )
+            return []
+        }
+
+        if let typeName = enclosingTypeName(in: context), !enclosingTypeIsLoggable(in: context) {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    message: MacroExpansionErrorMessage(
+                        "'@Sensitive' has no effect here: mark '\(typeName)' with '@Loggable' to collect it"
+                    )
+                )
+            )
+        }
+
+        return []
+    }
+
+    /// `willSet`/`didSet` still leave the property stored, so the marker works there.
+    private static func isObserver(_ accessorBlock: AccessorBlockSyntax) -> Bool {
+        guard case .accessors(let accessors) = accessorBlock.accessors else { return false }
+        return accessors.allSatisfy {
+            $0.accessorSpecifier.tokenKind == .keyword(.willSet) || $0.accessorSpecifier.tokenKind == .keyword(.didSet)
+        }
+    }
+
+    private static func enclosingType(
+        in context: some MacroExpansionContext
+    ) -> (name: String, attributes: AttributeListSyntax)? {
+        for lexicalContext in context.lexicalContext {
+            if let decl = lexicalContext.as(StructDeclSyntax.self) {
+                return (decl.name.text, decl.attributes)
+            }
+            if let decl = lexicalContext.as(ClassDeclSyntax.self) {
+                return (decl.name.text, decl.attributes)
+            }
+            if let decl = lexicalContext.as(ActorDeclSyntax.self) {
+                return (decl.name.text, decl.attributes)
+            }
+            if let decl = lexicalContext.as(EnumDeclSyntax.self) {
+                return (decl.name.text, decl.attributes)
+            }
+        }
+        return nil
+    }
+
+    private static func enclosingTypeName(in context: some MacroExpansionContext) -> String? {
+        enclosingType(in: context)?.name
+    }
+
+    private static func enclosingTypeIsLoggable(in context: some MacroExpansionContext) -> Bool {
+        guard let attributes = enclosingType(in: context)?.attributes else { return false }
+        return attributes.contains { attribute in
+            guard case .attribute(let attribute) = attribute else { return false }
+            let name = attribute.attributeName.trimmedDescription
+            return name == "Loggable" || name.hasSuffix(".Loggable")
+        }
+    }
+}
+
+/// Generates the `SensitiveFieldsProviding` conformance from the type's `@Sensitive` properties.
+public struct LoggableMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        // Nothing to add when the conformance is spelled out on the type itself, in which
+        // case the field set is hand-written.
+        let alreadyConforms =
+            declaration.inheritanceClause?.inheritedTypes
+            .contains { $0.type.trimmedDescription.hasSuffix("SensitiveFieldsProviding") } ?? false
+        guard !alreadyConforms else { return [] }
+
+        let fields = sensitiveFieldNames(in: declaration)
+
+        if fields.isEmpty {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    message: MacroExpansionWarningMessage(
+                        "'@Loggable' has no effect: no property of '\(type.trimmedDescription)' is marked '@Sensitive'"
+                    )
+                )
+            )
+        }
+
+        let isPublic = declaration.modifiers.contains { modifier in
+            modifier.name.tokenKind == .keyword(.public) || modifier.name.tokenKind == .keyword(.open)
+        }
+        let accessLevel = isPublic ? "public " : ""
+        let elements = fields.map { "\"\($0)\"" }.joined(separator: ", ")
+
+        return [
+            try ExtensionDeclSyntax(
+                """
+                extension \(type.trimmed): AutomaticLog.SensitiveFieldsProviding {
+                    \(raw: accessLevel)static let sensitiveLogFields: Set<String> = [\(raw: elements)]
+                }
+                """
+            )
+        ]
+    }
+
+    private static func sensitiveFieldNames(in declaration: some DeclGroupSyntax) -> [String] {
+        declaration.memberBlock.members.flatMap { member -> [String] in
+            guard let variable = member.decl.as(VariableDeclSyntax.self),
+                variable.attributes.contains(where: isSensitiveAttribute)
+            else {
+                return []
+            }
+            return variable.bindings.compactMap { binding in
+                binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+            }
+        }
+    }
+
+    private static func isSensitiveAttribute(_ attribute: AttributeListSyntax.Element) -> Bool {
+        guard case .attribute(let attribute) = attribute else { return false }
+        let name = attribute.attributeName.trimmedDescription
+        return name == "Sensitive" || name.hasSuffix(".Sensitive")
+    }
+}

--- a/LocalModules/AutomaticLog/Tests/AutomaticLogTests/LogMacroExpansionTests.swift
+++ b/LocalModules/AutomaticLog/Tests/AutomaticLogTests/LogMacroExpansionTests.swift
@@ -1,0 +1,117 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import AutomaticLogMacros
+
+private let testMacros: [String: any Macro.Type] = [
+    "Log": AutomaticLogMacros.AutomaticLog.self,
+    "Sensitive": SensitiveMacro.self,
+    "Loggable": LoggableMacro.self,
+]
+
+final class LoggableExpansionTests: XCTestCase {
+    func testLoggableCollectsTheSensitivePropertyNames() {
+        assertMacroExpansion(
+            """
+            @Loggable
+            public struct Member {
+                let name: String
+                @Sensitive let email: String
+                @Sensitive var phone: String?
+            }
+            """,
+            expandedSource: """
+
+                public struct Member {
+                    let name: String
+                    let email: String
+                    var phone: String?
+                }
+
+                extension Member: AutomaticLog.SensitiveFieldsProviding {
+                    public static let sensitiveLogFields: Set<String> = ["email", "phone"]
+                }
+                """,
+            macros: testMacros
+        )
+    }
+
+    func testSensitiveWithoutLoggableIsAnError() {
+        assertMacroExpansion(
+            """
+            struct Member {
+                @Sensitive let email: String
+            }
+            """,
+            expandedSource: """
+                struct Member {
+                    let email: String
+                }
+                """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@Sensitive' has no effect here: mark 'Member' with '@Loggable' to collect it",
+                    line: 2,
+                    column: 5
+                )
+            ],
+            macros: testMacros
+        )
+    }
+}
+
+final class LogMacroExpansionTests: XCTestCase {
+    func testListedParameterExpandsToAMaskedDescription() {
+        assertMacroExpansion(
+            """
+            struct Service {
+                @Log(sensitive: ["token"])
+                func exchange(token: String, id: String) {
+                    handle(id)
+                }
+            }
+            """,
+            expandedSource: """
+                struct Service {
+                    func exchange(token: String, id: String) {
+                        let _logArgs: [String: String] = ["token": AutomaticLog.maskedLogDescription(token as Any), "id": AutomaticLog.logDescription(id as Any)]
+                        handle(id)
+                        AutomaticLog.loginClosure("✅ Service exchange(\\(String(describing: _logArgs)))")
+                    }
+                }
+                """,
+            macros: testMacros
+        )
+    }
+
+    func testUnknownSensitiveNameIsAnError() {
+        assertMacroExpansion(
+            """
+            struct Service {
+                @Log(.error, sensitive: ["tokn"])
+                func exchange(token: String) {
+                    handle(token)
+                }
+            }
+            """,
+            expandedSource: """
+                struct Service {
+                    func exchange(token: String) {
+                        let _logArgs: [String: String] = ["token": AutomaticLog.logDescription(token as Any)]
+                        handle(token)
+                        AutomaticLog.loginClosure("📥 Service exchange(\\(String(describing: _logArgs)))")
+                    }
+                }
+                """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'tokn' is not a parameter of 'exchange' — parameters are: token",
+                    line: 2,
+                    column: 5
+                )
+            ],
+            macros: testMacros
+        )
+    }
+}

--- a/LocalModules/AutomaticLog/Tests/AutomaticLogTests/LogMacroExpansionTests.swift
+++ b/LocalModules/AutomaticLog/Tests/AutomaticLogTests/LogMacroExpansionTests.swift
@@ -6,19 +6,19 @@ import XCTest
 
 private let testMacros: [String: any Macro.Type] = [
     "Log": AutomaticLogMacros.AutomaticLog.self,
-    "Sensitive": SensitiveMacro.self,
+    "Masked": MaskedMacro.self,
     "Loggable": LoggableMacro.self,
 ]
 
 final class LoggableExpansionTests: XCTestCase {
-    func testLoggableCollectsTheSensitivePropertyNames() {
+    func testLoggableCollectsTheMaskedPropertyNames() {
         assertMacroExpansion(
             """
             @Loggable
             public struct Member {
                 let name: String
-                @Sensitive let email: String
-                @Sensitive var phone: String?
+                @Masked let email: String
+                @Masked var phone: String?
             }
             """,
             expandedSource: """
@@ -29,19 +29,19 @@ final class LoggableExpansionTests: XCTestCase {
                     var phone: String?
                 }
 
-                extension Member: AutomaticLog.SensitiveFieldsProviding {
-                    public static let sensitiveLogFields: Set<String> = ["email", "phone"]
+                extension Member: AutomaticLog.MaskedFieldsProviding {
+                    public static let maskedLogFields: Set<String> = ["email", "phone"]
                 }
                 """,
             macros: testMacros
         )
     }
 
-    func testSensitiveWithoutLoggableIsAnError() {
+    func testMaskedWithoutLoggableIsAnError() {
         assertMacroExpansion(
             """
             struct Member {
-                @Sensitive let email: String
+                @Masked let email: String
             }
             """,
             expandedSource: """
@@ -51,7 +51,7 @@ final class LoggableExpansionTests: XCTestCase {
                 """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "'@Sensitive' has no effect here: mark 'Member' with '@Loggable' to collect it",
+                    message: "'@Masked' has no effect here: mark 'Member' with '@Loggable' to collect it",
                     line: 2,
                     column: 5
                 )
@@ -66,7 +66,7 @@ final class LogMacroExpansionTests: XCTestCase {
         assertMacroExpansion(
             """
             struct Service {
-                @Log(sensitive: ["token"])
+                @Log(masked: ["token"])
                 func exchange(token: String, id: String) {
                     handle(id)
                 }
@@ -85,11 +85,11 @@ final class LogMacroExpansionTests: XCTestCase {
         )
     }
 
-    func testUnknownSensitiveNameIsAnError() {
+    func testUnknownMaskedNameIsAnError() {
         assertMacroExpansion(
             """
             struct Service {
-                @Log(.error, sensitive: ["tokn"])
+                @Log(.error, masked: ["tokn"])
                 func exchange(token: String) {
                     handle(token)
                 }

--- a/LocalModules/AutomaticLog/Tests/AutomaticLogTests/MaskedTests.swift
+++ b/LocalModules/AutomaticLog/Tests/AutomaticLogTests/MaskedTests.swift
@@ -167,3 +167,42 @@ final class MaskedParameterTests: XCTestCase {
         XCTAssertTrue(log.contains("name: Alice"))
     }
 }
+
+private struct OptionalEnvelope {
+    let sentAt: String
+    let payload: Payload?
+}
+
+private struct Batch {
+    let sentAt: String
+    let payloads: [Payload]
+}
+
+/// `MaskedValue` has to hold wherever the value sits. A type that masks itself as a direct
+/// property but leaks inside an array would be the worst kind of gap: invisible at the
+/// declaration site.
+final class MaskedValueReachabilityTests: XCTestCase {
+    func testMaskedValueInsideAnOptionalPropertyIsMasked() {
+        let described = logDescription(OptionalEnvelope(sentAt: "today", payload: .text(text: "hello there", id: "7")))
+
+        XCTAssertFalse(described.contains("hello there"))
+    }
+
+    func testMaskedValueInsideATopLevelCollectionIsMasked() {
+        let described = logDescription([Payload.text(text: "hello there", id: "7")])
+
+        XCTAssertFalse(described.contains("hello there"))
+    }
+
+    func testMaskedValueInsideACollectionPropertyIsMasked() {
+        let described = logDescription(Batch(sentAt: "today", payloads: [.text(text: "hello there", id: "7")]))
+
+        XCTAssertFalse(described.contains("hello there"))
+    }
+
+    func testMaskedValueInsideADictionaryValueIsMasked() {
+        let described = logDescription(["a": Payload.text(text: "hello there", id: "7")])
+
+        XCTAssertFalse(described.contains("hello there"))
+    }
+}

--- a/LocalModules/AutomaticLog/Tests/AutomaticLogTests/MaskedTests.swift
+++ b/LocalModules/AutomaticLog/Tests/AutomaticLogTests/MaskedTests.swift
@@ -5,27 +5,27 @@ import XCTest
 @Loggable
 private struct Member: Codable, Equatable, Hashable, Sendable {
     let name: String
-    @Sensitive let email: String
-    @Sensitive let phone: String?
+    @Masked let email: String
+    @Masked let phone: String?
 }
 
 /// Field names are matched exactly, so an unconventionally cased property still works.
 @Loggable
 private struct Stakeholder {
     let fullName: String
-    @Sensitive let SSN: String?
+    @Masked let SSN: String?
 }
 
-/// The case `@Sensitive` exists for: a `@Published` property, which no property wrapper
+/// The case `@Masked` exists for: a `@Published` property, which no property wrapper
 /// could have been applied to.
 @Loggable
 private final class LoginState: ObservableObject {
     @Published var isLoading = false
-    @Published @Sensitive var code = "1234"
+    @Published @Masked var code = "1234"
 }
 
 /// An enum case's associated value cannot carry an attribute, so the type masks itself.
-private enum Payload: SensitiveValue {
+private enum Payload: MaskedValue {
     case text(text: String, id: String)
     case empty
 
@@ -48,12 +48,12 @@ private struct Envelope {
 nonisolated(unsafe) private var capturedLogs: [String] = []
 
 private struct Credentials {
-    @Log(sensitive: ["refreshToken"])
+    @Log(masked: ["refreshToken"])
     func exchange(refreshToken: String, id: String) -> String {
         "exchanged \(refreshToken.count) for \(id)"
     }
 
-    @Log(.error, sensitive: ["token"])
+    @Log(.error, masked: ["token"])
     func register(for token: String) async throws {
         _ = token
     }
@@ -64,8 +64,8 @@ private struct Credentials {
     }
 }
 
-final class SensitiveFieldTests: XCTestCase {
-    func testSensitiveStoredPropertyIsMaskedAndKeepsItsName() {
+final class MaskedFieldTests: XCTestCase {
+    func testMaskedStoredPropertyKeepsItsName() {
         let described = logDescription(Member(name: "Alice", email: "alice@example.com", phone: "070"))
 
         XCTAssertTrue(described.contains("name: Alice"))
@@ -74,7 +74,7 @@ final class SensitiveFieldTests: XCTestCase {
         XCTAssertFalse(described.contains("alice@example.com"))
     }
 
-    func testSensitiveOptionalStaysNil() {
+    func testMaskedOptionalStaysNil() {
         XCTAssertTrue(logDescription(Member(name: "A", email: "a@b.c", phone: nil)).contains("phone: nil"))
     }
 
@@ -92,13 +92,13 @@ final class SensitiveFieldTests: XCTestCase {
         XCTAssertTrue(described.contains("code: "))
     }
 
-    func testSensitiveFieldsAreMaskedWhenNested() {
+    func testMaskedFieldsStayMaskedWhenNested() {
         let described = logDescription([Member(name: "A", email: "a@b.c", phone: nil)])
 
         XCTAssertFalse(described.contains("a@b.c"))
     }
 
-    func testNonSensitiveValuesAreUnchanged() {
+    func testNonMaskedValuesAreUnchanged() {
         XCTAssertEqual(logDescription("plain"), "plain")
         XCTAssertEqual(logDescription(Optional<String>.none as Any), "nil")
     }
@@ -112,8 +112,8 @@ final class SensitiveFieldTests: XCTestCase {
     }
 }
 
-final class SensitiveValueConformanceTests: XCTestCase {
-    func testHandWrittenConformanceMasksOnlyTheSensitivePayload() {
+final class MaskedValueConformanceTests: XCTestCase {
+    func testHandWrittenConformanceMasksOnlyThePayload() {
         let described = logDescription(Envelope(sentAt: "today", payload: .text(text: "hello there", id: "7")))
 
         XCTAssertTrue(described.contains("sentAt: today"))
@@ -129,7 +129,7 @@ final class SensitiveValueConformanceTests: XCTestCase {
     }
 }
 
-final class SensitiveParameterTests: XCTestCase {
+final class MaskedParameterTests: XCTestCase {
     override func setUp() {
         super.setUp()
         capturedLogs = []

--- a/LocalModules/AutomaticLog/Tests/AutomaticLogTests/SensitiveTests.swift
+++ b/LocalModules/AutomaticLog/Tests/AutomaticLogTests/SensitiveTests.swift
@@ -1,0 +1,169 @@
+import AutomaticLog
+import Combine
+import XCTest
+
+@Loggable
+private struct Member: Codable, Equatable, Hashable, Sendable {
+    let name: String
+    @Sensitive let email: String
+    @Sensitive let phone: String?
+}
+
+/// Field names are matched exactly, so an unconventionally cased property still works.
+@Loggable
+private struct Stakeholder {
+    let fullName: String
+    @Sensitive let SSN: String?
+}
+
+/// The case `@Sensitive` exists for: a `@Published` property, which no property wrapper
+/// could have been applied to.
+@Loggable
+private final class LoginState: ObservableObject {
+    @Published var isLoading = false
+    @Published @Sensitive var code = "1234"
+}
+
+/// An enum case's associated value cannot carry an attribute, so the type masks itself.
+private enum Payload: SensitiveValue {
+    case text(text: String, id: String)
+    case empty
+
+    var maskedDescription: String {
+        switch self {
+        case let .text(text, id):
+            return "text(text: \(maskedLogDescription(text)), id: \(logDescription(id)))"
+        case .empty:
+            return "empty"
+        }
+    }
+}
+
+private struct Envelope {
+    let sentAt: String
+    let payload: Payload
+}
+
+/// Captures what `@Log` emits. A global because `loginClosure` is `@Sendable`.
+nonisolated(unsafe) private var capturedLogs: [String] = []
+
+private struct Credentials {
+    @Log(sensitive: ["refreshToken"])
+    func exchange(refreshToken: String, id: String) -> String {
+        "exchanged \(refreshToken.count) for \(id)"
+    }
+
+    @Log(.error, sensitive: ["token"])
+    func register(for token: String) async throws {
+        _ = token
+    }
+
+    @Log
+    func member() throws -> Member {
+        Member(name: "Alice", email: "alice@example.com", phone: nil)
+    }
+}
+
+final class SensitiveFieldTests: XCTestCase {
+    func testSensitiveStoredPropertyIsMaskedAndKeepsItsName() {
+        let described = logDescription(Member(name: "Alice", email: "alice@example.com", phone: "070"))
+
+        XCTAssertTrue(described.contains("name: Alice"))
+        XCTAssertTrue(described.contains("email: *****************"))
+        XCTAssertTrue(described.contains("phone: ***"))
+        XCTAssertFalse(described.contains("alice@example.com"))
+    }
+
+    func testSensitiveOptionalStaysNil() {
+        XCTAssertTrue(logDescription(Member(name: "A", email: "a@b.c", phone: nil)).contains("phone: nil"))
+    }
+
+    func testFieldNamesAreMatchedExactly() {
+        let described = logDescription(Stakeholder(fullName: "Alice A", SSN: "199001011234"))
+
+        XCTAssertTrue(described.contains("fullName: Alice A"))
+        XCTAssertFalse(described.contains("199001011234"))
+    }
+
+    func testPublishedPropertyIsMasked() {
+        let described = logDescription(LoginState())
+
+        XCTAssertFalse(described.contains("1234"))
+        XCTAssertTrue(described.contains("code: "))
+    }
+
+    func testSensitiveFieldsAreMaskedWhenNested() {
+        let described = logDescription([Member(name: "A", email: "a@b.c", phone: nil)])
+
+        XCTAssertFalse(described.contains("a@b.c"))
+    }
+
+    func testNonSensitiveValuesAreUnchanged() {
+        XCTAssertEqual(logDescription("plain"), "plain")
+        XCTAssertEqual(logDescription(Optional<String>.none as Any), "nil")
+    }
+
+    func testLoggableDoesNotChangeTheCodableRepresentation() throws {
+        let member = Member(name: "Alice", email: "alice@example.com", phone: "070")
+        let json = String(data: try JSONEncoder().encode(member), encoding: .utf8)
+
+        XCTAssertEqual(json?.contains("\"email\":\"alice@example.com\""), true)
+        XCTAssertFalse(json?.contains("_email") ?? true)
+    }
+}
+
+final class SensitiveValueConformanceTests: XCTestCase {
+    func testHandWrittenConformanceMasksOnlyTheSensitivePayload() {
+        let described = logDescription(Envelope(sentAt: "today", payload: .text(text: "hello there", id: "7")))
+
+        XCTAssertTrue(described.contains("sentAt: today"))
+        XCTAssertTrue(described.contains("payload: text(text: ***********, id: 7)"))
+        XCTAssertFalse(described.contains("hello there"))
+    }
+
+    func testHandWrittenConformanceIsHonouredThroughCollections() {
+        let described = logDescription([Envelope(sentAt: "today", payload: .text(text: "secret", id: "7"))])
+
+        XCTAssertFalse(described.contains("secret"))
+        XCTAssertTrue(described.contains("******"))
+    }
+}
+
+final class SensitiveParameterTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        capturedLogs = []
+        loginClosure = { message in capturedLogs.append(message) }
+    }
+
+    override func tearDown() {
+        loginClosure = { print($0) }
+        super.tearDown()
+    }
+
+    func testListedParameterIsMaskedAndOthersAreNot() {
+        let result = Credentials().exchange(refreshToken: "secret-token", id: "42")
+
+        XCTAssertEqual(result, "exchanged 12 for 42")
+        let log = capturedLogs.first
+        XCTAssertFalse(log?.contains("secret-token") ?? true)
+        XCTAssertEqual(log?.contains("************"), true)
+        XCTAssertEqual(log?.contains("\"id\": \"42\""), true)
+    }
+
+    func testExternallyLabelledParameterIsMasked() async throws {
+        try await Credentials().register(for: "device-token")
+
+        let log = try XCTUnwrap(capturedLogs.first)
+        XCTAssertFalse(log.contains("device-token"))
+        XCTAssertTrue(log.contains("\"token\": \"************\""))
+    }
+
+    func testResultPropertiesAreMasked() throws {
+        _ = try Credentials().member()
+
+        let log = try XCTUnwrap(capturedLogs.first)
+        XCTAssertFalse(log.contains("alice@example.com"))
+        XCTAssertTrue(log.contains("name: Alice"))
+    }
+}

--- a/Projects/App/Sources/Service/Notifications/OctopusImplementation/NotificationClientOctopus.swift
+++ b/Projects/App/Sources/Service/Notifications/OctopusImplementation/NotificationClientOctopus.swift
@@ -6,7 +6,7 @@ import hGraphQL
 public class NotificationService {
     @Inject var service: NotificationClient
 
-    @Log(sensitive: ["token"])
+    @Log(masked: ["token"])
     func register(for token: String) async throws {
         try await service.register(for: token)
     }

--- a/Projects/App/Sources/Service/Notifications/OctopusImplementation/NotificationClientOctopus.swift
+++ b/Projects/App/Sources/Service/Notifications/OctopusImplementation/NotificationClientOctopus.swift
@@ -6,7 +6,7 @@ import hGraphQL
 public class NotificationService {
     @Inject var service: NotificationClient
 
-    @Log
+    @Log(sensitive: ["token"])
     func register(for token: String) async throws {
         try await service.register(for: token)
     }

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/ChatUploadFileClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/ChatUploadFileClientOctopus.swift
@@ -12,7 +12,7 @@ import hGraphQL
 class ChatFileUploaderService {
     @Inject var client: ChatFileUploaderClient
 
-    @Log
+    @Log(sensitive: ["files"])
     func upload(
         files: [File],
         withProgress: (@Sendable (_ progress: Double) -> Void)?

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/ChatUploadFileClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/ChatUploadFileClientOctopus.swift
@@ -12,7 +12,7 @@ import hGraphQL
 class ChatFileUploaderService {
     @Inject var client: ChatFileUploaderClient
 
-    @Log(sensitive: ["files"])
+    @Log(masked: ["files"])
     func upload(
         files: [File],
         withProgress: (@Sendable (_ progress: Double) -> Void)?

--- a/Projects/Authentication/Sources/Service/AuthenticationService.swift
+++ b/Projects/Authentication/Sources/Service/AuthenticationService.swift
@@ -8,37 +8,37 @@ public class AuthenticationService {
 
     public init() {}
 
-    @Log
+    @Log(.error, masked: ["otpState"])
     func submit(otpState: OTPState) async throws -> String {
         try await client.submit(otpState: otpState)
     }
 
-    @Log
+    @Log(.error, masked: ["otpState"])
     func start(with otpState: OTPState) async throws -> (verifyUrl: URL, resendUrl: URL, maskedEmail: String?) {
         try await client.start(with: otpState)
     }
 
-    @Log
+    @Log(.error, masked: ["otpState"])
     func resend(otp otpState: OTPState) async throws {
         try await client.resend(otp: otpState)
     }
 
-    @Log
+    @Log(.error)
     func startSeBankId(updateStatusTo: @escaping (_: ObserveStatusResponseType) -> Void) async throws {
         try await client.startSeBankId(updateStatusTo: updateStatusTo)
     }
 
-    @Log
+    @Log(.error)
     public func logout() async throws {
         try await client.logout()
     }
 
-    @Log
+    @Log(.error, masked: ["code"])
     public func exchange(code: String) async throws {
         try await client.exchange(code: code)
     }
 
-    @Log
+    @Log(.error, masked: ["refreshToken"])
     public func exchange(refreshToken: String) async throws {
         try await client.exchange(refreshToken: refreshToken)
     }

--- a/Projects/AuthenticationCore/Sources/Service/AuthenticationService.swift
+++ b/Projects/AuthenticationCore/Sources/Service/AuthenticationService.swift
@@ -8,19 +8,19 @@ public class AuthenticationService {
 
     public init() {}
 
-    @Log(.error, sensitive: ["otpState"])
+    @Log(.error, masked: ["otpState"])
     public func submit(otpState: OTPState) async throws -> String {
         try await client.submit(otpState: otpState)
     }
 
-    @Log(.error, sensitive: ["otpState"])
+    @Log(.error, masked: ["otpState"])
     public func start(
         with otpState: OTPState
     ) async throws -> (verifyUrl: URL, resendUrl: URL, maskedEmail: String?) {
         try await client.start(with: otpState)
     }
 
-    @Log(.error, sensitive: ["otpState"])
+    @Log(.error, masked: ["otpState"])
     public func resend(otp otpState: OTPState) async throws {
         try await client.resend(otp: otpState)
     }
@@ -35,12 +35,12 @@ public class AuthenticationService {
         try await client.logout()
     }
 
-    @Log(.error, sensitive: ["code"])
+    @Log(.error, masked: ["code"])
     public func exchange(code: String) async throws {
         try await client.exchange(code: code)
     }
 
-    @Log(.error, sensitive: ["refreshToken"])
+    @Log(.error, masked: ["refreshToken"])
     public func exchange(refreshToken: String) async throws {
         try await client.exchange(refreshToken: refreshToken)
     }

--- a/Projects/AuthenticationCore/Sources/Service/AuthenticationService.swift
+++ b/Projects/AuthenticationCore/Sources/Service/AuthenticationService.swift
@@ -8,19 +8,19 @@ public class AuthenticationService {
 
     public init() {}
 
-    @Log(.error)
+    @Log(.error, sensitive: ["otpState"])
     public func submit(otpState: OTPState) async throws -> String {
         try await client.submit(otpState: otpState)
     }
 
-    @Log(.error)
+    @Log(.error, sensitive: ["otpState"])
     public func start(
         with otpState: OTPState
     ) async throws -> (verifyUrl: URL, resendUrl: URL, maskedEmail: String?) {
         try await client.start(with: otpState)
     }
 
-    @Log(.error)
+    @Log(.error, sensitive: ["otpState"])
     public func resend(otp otpState: OTPState) async throws {
         try await client.resend(otp: otpState)
     }
@@ -35,12 +35,12 @@ public class AuthenticationService {
         try await client.logout()
     }
 
-    @Log(.error)
+    @Log(.error, sensitive: ["code"])
     public func exchange(code: String) async throws {
         try await client.exchange(code: code)
     }
 
-    @Log(.error)
+    @Log(.error, sensitive: ["refreshToken"])
     public func exchange(refreshToken: String) async throws {
         try await client.exchange(refreshToken: refreshToken)
     }

--- a/Projects/Chat/Sources/Models/Message.swift
+++ b/Projects/Chat/Sources/Models/Message.swift
@@ -1,3 +1,4 @@
+import AutomaticLog
 import Foundation
 import hCore
 
@@ -111,6 +112,28 @@ public enum MessageType: Codable, Hashable, Sendable {
     case deepLink(url: URL)
     case otherLink(url: URL)
     case unknown
+}
+
+extension MessageType: SensitiveValue {
+    /// An associated value cannot carry `@Sensitive`, so the masking is written out here:
+    /// member-written chat content never reaches the log, while the case itself stays readable.
+    public var maskedDescription: String {
+        switch self {
+        case let .text(text, action):
+            return "text(text: \(AutomaticLog.maskedLogDescription(text)), "
+                + "action: \(AutomaticLog.logDescription(action as Any)))"
+        case let .file(file):
+            return "file(file: \(AutomaticLog.logDescription(file)))"
+        case let .crossSell(url):
+            return "crossSell(url: \(url))"
+        case let .deepLink(url):
+            return "deepLink(url: \(url))"
+        case let .otherLink(url):
+            return "otherLink(url: \(url))"
+        case .unknown:
+            return "unknown"
+        }
+    }
 }
 
 public struct ActionMessage: Codable, Hashable, Sendable {

--- a/Projects/Chat/Sources/Models/Message.swift
+++ b/Projects/Chat/Sources/Models/Message.swift
@@ -114,8 +114,8 @@ public enum MessageType: Codable, Hashable, Sendable {
     case unknown
 }
 
-extension MessageType: SensitiveValue {
-    /// An associated value cannot carry `@Sensitive`, so the masking is written out here:
+extension MessageType: MaskedValue {
+    /// An associated value cannot carry `@Masked`, so the masking is written out here:
     /// member-written chat content never reaches the log, while the case itself stays readable.
     public var maskedDescription: String {
         switch self {

--- a/Projects/Chat/Sources/Service/ChatService.swift
+++ b/Projects/Chat/Sources/Service/ChatService.swift
@@ -115,7 +115,7 @@ public class NewConversationService: ChatServiceProtocol {
         )
     }
 
-    @Log
+    @Log(sensitive: ["message"])
     public func send(message: Message) async throws -> Message {
         if conversationService == nil, generatingConversation == false {
             generatingConversation = true

--- a/Projects/Chat/Sources/Service/ChatService.swift
+++ b/Projects/Chat/Sources/Service/ChatService.swift
@@ -115,7 +115,7 @@ public class NewConversationService: ChatServiceProtocol {
         )
     }
 
-    @Log(sensitive: ["message"])
+    @Log(masked: ["message"])
     public func send(message: Message) async throws -> Message {
         if conversationService == nil, generatingConversation == false {
             generatingConversation = true

--- a/Projects/Claims/Sources/Models/ClaimModel.swift
+++ b/Projects/Claims/Sources/Models/ClaimModel.swift
@@ -1,9 +1,11 @@
+import AutomaticLog
 import Chat
 import CrossSell
 import Foundation
 import hCore
 import hCoreUI
 
+@Loggable
 public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public init(
         id: String,
@@ -57,8 +59,8 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public let status: ClaimStatus
     public let outcome: ClaimOutcome?
     public let submittedAt: Date?
-    public let signedAudioURL: String?
-    public let memberFreeText: String?
+    @Masked public let signedAudioURL: String?
+    @Masked public let memberFreeText: String?
     public let payoutAmount: MonetaryAmount?
     public let targetFileUploadUri: String
     public let conversation: Conversation?
@@ -68,7 +70,7 @@ public struct ClaimModel: Codable, Equatable, Identifiable, Hashable, Sendable {
     public var infoText: String?
     public let displayItems: [ClaimDisplayItem]
     public let isPartnerClaim: Bool
-    public let handlerEmail: String?
+    @Masked public let handlerEmail: String?
     public let exposureDisplayName: String?
     public let externalId: String?
     public let contractId: String?

--- a/Projects/Claims/Sources/Service/OctopusImplementation/UploadClaimFileClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/UploadClaimFileClientOctopus.swift
@@ -12,7 +12,7 @@ public class hClaimFileUploadService {
 
     public init() {}
 
-    @Log
+    @Log(sensitive: ["files"])
     public func upload(
         endPoint: String,
         files: [File],
@@ -26,7 +26,7 @@ public class hClaimFileUploadService {
         }
     }
 
-    @Log
+    @Log(sensitive: ["files"])
     public func uploadClaimsChatFile(
         endPoint: String,
         files: [File],

--- a/Projects/Claims/Sources/Service/OctopusImplementation/UploadClaimFileClientOctopus.swift
+++ b/Projects/Claims/Sources/Service/OctopusImplementation/UploadClaimFileClientOctopus.swift
@@ -12,7 +12,7 @@ public class hClaimFileUploadService {
 
     public init() {}
 
-    @Log(sensitive: ["files"])
+    @Log(masked: ["files"])
     public func upload(
         endPoint: String,
         files: [File],
@@ -26,7 +26,7 @@ public class hClaimFileUploadService {
         }
     }
 
-    @Log(sensitive: ["files"])
+    @Log(masked: ["files"])
     public func uploadClaimsChatFile(
         endPoint: String,
         files: [File],

--- a/Projects/Contracts/Sources/Models/ContractModels.swift
+++ b/Projects/Contracts/Sources/Models/ContractModels.swift
@@ -73,7 +73,7 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public let typeOfContract: TypeOfContract
     public let firstName: String
     public let lastName: String
-    @Sensitive public let ssn: String?
+    @Masked public let ssn: String?
     public let coInsured: [Stakeholder]
     public let coOwners: [Stakeholder]
     public let missingPetChipId: Bool

--- a/Projects/Contracts/Sources/Models/ContractModels.swift
+++ b/Projects/Contracts/Sources/Models/ContractModels.swift
@@ -1,10 +1,12 @@
 import AppStateContainer
+import AutomaticLog
 import EditStakeholders
 import Foundation
 import TerminateContracts
 import hCore
 import hCoreUI
 
+@Loggable
 public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public init(
         id: String,
@@ -71,7 +73,7 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public let typeOfContract: TypeOfContract
     public let firstName: String
     public let lastName: String
-    public let ssn: String?
+    @Sensitive public let ssn: String?
     public let coInsured: [Stakeholder]
     public let coOwners: [Stakeholder]
     public let missingPetChipId: Bool

--- a/Projects/EditStakeholders/Sources/Models/ContractModel.swift
+++ b/Projects/EditStakeholders/Sources/Models/ContractModel.swift
@@ -1,3 +1,6 @@
+import AutomaticLog
+
+@Loggable
 public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public init(
         id: String,
@@ -36,7 +39,7 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public let supportsCoOwners: Bool
     public let firstName: String
     public let lastName: String
-    public let ssn: String?
+    @Sensitive public let ssn: String?
     public let coInsured: [Stakeholder]
     public let coOwners: [Stakeholder]
 

--- a/Projects/EditStakeholders/Sources/Models/ContractModel.swift
+++ b/Projects/EditStakeholders/Sources/Models/ContractModel.swift
@@ -39,7 +39,7 @@ public struct Contract: Codable, Hashable, Equatable, Identifiable, Sendable {
     public let supportsCoOwners: Bool
     public let firstName: String
     public let lastName: String
-    @Sensitive public let ssn: String?
+    @Masked public let ssn: String?
     public let coInsured: [Stakeholder]
     public let coOwners: [Stakeholder]
 

--- a/Projects/EditStakeholders/Sources/Models/StakeholderModel.swift
+++ b/Projects/EditStakeholders/Sources/Models/StakeholderModel.swift
@@ -1,9 +1,11 @@
+import AutomaticLog
 import Foundation
 import SwiftUI
 import hCore
 
+@Loggable
 public struct Stakeholder: Codable, Hashable, Equatable, Sendable {
-    public let SSN: String?
+    @Sensitive public let SSN: String?
     public let hasMissingInfo: Bool
     public var firstName: String?
     public var lastName: String?

--- a/Projects/EditStakeholders/Sources/Models/StakeholderModel.swift
+++ b/Projects/EditStakeholders/Sources/Models/StakeholderModel.swift
@@ -5,7 +5,7 @@ import hCore
 
 @Loggable
 public struct Stakeholder: Codable, Hashable, Equatable, Sendable {
-    @Sensitive public let SSN: String?
+    @Masked public let SSN: String?
     public let hasMissingInfo: Bool
     public var firstName: String?
     public var lastName: String?

--- a/Projects/EditStakeholders/Sources/Service/EditStakeholdersService.swift
+++ b/Projects/EditStakeholders/Sources/Service/EditStakeholdersService.swift
@@ -11,7 +11,7 @@ public class EditStakeholdersService {
         try await service.commitMidtermChange(commitId: commitId)
     }
 
-    @Log(sensitive: ["SSN"])
+    @Log(masked: ["SSN"])
     func fetchPersonalInformation(SSN: String) async throws -> PersonalData? {
         try await service.fetchPersonalInformation(SSN: SSN)
     }

--- a/Projects/EditStakeholders/Sources/Service/EditStakeholdersService.swift
+++ b/Projects/EditStakeholders/Sources/Service/EditStakeholdersService.swift
@@ -11,7 +11,7 @@ public class EditStakeholdersService {
         try await service.commitMidtermChange(commitId: commitId)
     }
 
-    @Log
+    @Log(sensitive: ["SSN"])
     func fetchPersonalInformation(SSN: String) async throws -> PersonalData? {
         try await service.fetchPersonalInformation(SSN: SSN)
     }

--- a/Projects/InsuranceEvidence/Sources/Models/InsuranceEvidenceInitialData.swift
+++ b/Projects/InsuranceEvidence/Sources/Models/InsuranceEvidenceInitialData.swift
@@ -1,5 +1,8 @@
+import AutomaticLog
+
+@Loggable
 public struct InsuranceEvidenceInitialData: Sendable {
-    let email: String
+    @Masked let email: String
 
     public init(email: String) {
         self.email = email

--- a/Projects/InsuranceEvidence/Sources/Models/InsuranceEvidenceInput.swift
+++ b/Projects/InsuranceEvidence/Sources/Models/InsuranceEvidenceInput.swift
@@ -1,3 +1,6 @@
+import AutomaticLog
+
+@Loggable
 public struct InsuranceEvidenceInput: Sendable, Hashable {
-    public internal(set) var email: String
+    @Masked public internal(set) var email: String
 }

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -1,11 +1,13 @@
+import AutomaticLog
 import Contracts
 import CrossSell
 import Forever
 import Foundation
 import hCore
 
+@Loggable
 public struct ContactInfo: Equatable, Hashable, Sendable {
-    public let phone: String
+    @Sensitive public let phone: String
 
     public init(phone: String) {
         self.phone = phone

--- a/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
+++ b/Projects/Onboarding/Sources/Models/OnboardingStepList.swift
@@ -7,7 +7,7 @@ import hCore
 
 @Loggable
 public struct ContactInfo: Equatable, Hashable, Sendable {
-    @Sensitive public let phone: String
+    @Masked public let phone: String
 
     public init(phone: String) {
         self.phone = phone

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -14,7 +14,7 @@ public class OnboardingService {
         try await client.getOnboardingSteps()
     }
 
-    @Log(sensitive: ["phone"])
+    @Log(masked: ["phone"])
     public func updateContactInfo(phone: String) async throws {
         try await client.updateContactInfo(phone: phone)
     }

--- a/Projects/Onboarding/Sources/Service/OnboardingService.swift
+++ b/Projects/Onboarding/Sources/Service/OnboardingService.swift
@@ -14,7 +14,7 @@ public class OnboardingService {
         try await client.getOnboardingSteps()
     }
 
-    @Log
+    @Log(sensitive: ["phone"])
     public func updateContactInfo(phone: String) async throws {
         try await client.updateContactInfo(phone: phone)
     }

--- a/Projects/Payment/Sources/Models/PaymentStatusData.swift
+++ b/Projects/Payment/Sources/Models/PaymentStatusData.swift
@@ -1,3 +1,4 @@
+import AutomaticLog
 import Foundation
 import hCore
 
@@ -165,6 +166,21 @@ public enum PaymentMethodSetupType: Sendable {
     case trustly
     case nordeaPayout(accountNumber: String)
     case swishPayout(phoneNumber: String)
+}
+
+extension PaymentMethodSetupType: MaskedValue {
+    /// An associated value cannot carry `@Masked`, so the masking is written out here:
+    /// the payout destination never reaches the log, while the case itself stays readable.
+    public var maskedDescription: String {
+        switch self {
+        case .trustly:
+            return "trustly"
+        case let .nordeaPayout(accountNumber):
+            return "nordeaPayout(accountNumber: \(AutomaticLog.maskedLogDescription(accountNumber)))"
+        case let .swishPayout(phoneNumber):
+            return "swishPayout(phoneNumber: \(AutomaticLog.maskedLogDescription(phoneNumber)))"
+        }
+    }
 }
 
 public struct PaymentSetupResult: Codable, Equatable, Sendable {

--- a/Projects/Profile/Sources/Models/MemberDetails.swift
+++ b/Projects/Profile/Sources/Models/MemberDetails.swift
@@ -1,9 +1,11 @@
+import AutomaticLog
 import Foundation
 
+@Loggable
 public struct MemberDetails: Codable, Equatable, Identifiable, Hashable, Sendable {
     public var id: String
-    public var phone: String?
-    public var email: String?
+    @Sensitive public var phone: String?
+    @Sensitive public var email: String?
     public var firstName: String
     public var lastName: String
     let isTravelCertificateEnabled: Bool

--- a/Projects/Profile/Sources/Models/MemberDetails.swift
+++ b/Projects/Profile/Sources/Models/MemberDetails.swift
@@ -4,8 +4,8 @@ import Foundation
 @Loggable
 public struct MemberDetails: Codable, Equatable, Identifiable, Hashable, Sendable {
     public var id: String
-    @Sensitive public var phone: String?
-    @Sensitive public var email: String?
+    @Masked public var phone: String?
+    @Masked public var email: String?
     public var firstName: String
     public var lastName: String
     let isTravelCertificateEnabled: Bool

--- a/Projects/Profile/Sources/Service/OctopusImplementation/ProfileService.swift
+++ b/Projects/Profile/Sources/Service/OctopusImplementation/ProfileService.swift
@@ -29,12 +29,14 @@ class ProfileService {
         try await client.updateLanguage()
     }
 
-    @Log
+    // The result tuple echoes the same contact details back and cannot be annotated,
+    // so the output is not logged.
+    @Log(.error, sensitive: ["email", "phone"])
     func update(email: String?, phone: String?) async throws -> (email: String, phone: String) {
         try await client.update(email: email ?? "", phone: phone ?? "")
     }
 
-    @Log
+    @Log(sensitive: ["eurobonus"])
     func update(eurobonus: String) async throws -> PartnerData {
         try await client.update(eurobonus: eurobonus)
     }

--- a/Projects/Profile/Sources/Service/OctopusImplementation/ProfileService.swift
+++ b/Projects/Profile/Sources/Service/OctopusImplementation/ProfileService.swift
@@ -31,12 +31,12 @@ class ProfileService {
 
     // The result tuple echoes the same contact details back and cannot be annotated,
     // so the output is not logged.
-    @Log(.error, sensitive: ["email", "phone"])
+    @Log(.error, masked: ["email", "phone"])
     func update(email: String?, phone: String?) async throws -> (email: String, phone: String) {
         try await client.update(email: email ?? "", phone: phone ?? "")
     }
 
-    @Log(sensitive: ["eurobonus"])
+    @Log(masked: ["eurobonus"])
     func update(eurobonus: String) async throws -> PartnerData {
         try await client.update(eurobonus: eurobonus)
     }

--- a/Projects/Profile/Sources/Store/ProfileStore.swift
+++ b/Projects/Profile/Sources/Store/ProfileStore.swift
@@ -1,4 +1,5 @@
 import AppStateContainer
+import AutomaticLog
 import Foundation
 import UserNotifications
 import hCore
@@ -123,9 +124,10 @@ public struct PartnerData: Codable, Equatable, Hashable, Sendable {
     }
 }
 
+@Loggable
 public struct PartnerDataSas: Codable, Equatable, Hashable, Sendable {
     let eligible: Bool
-    let eurobonusNumber: String?
+    @Masked let eurobonusNumber: String?
     public init(eligible: Bool, eurobonusNumber: String?) {
         self.eligible = eligible
         self.eurobonusNumber = eurobonusNumber

--- a/Projects/TerminateContracts/Sources/Service/TerminateContractsService.swift
+++ b/Projects/TerminateContracts/Sources/Service/TerminateContractsService.swift
@@ -11,7 +11,7 @@ class TerminateContractsService {
         try await client.getTerminationSurvey(contractId: contractId)
     }
 
-    @Log()
+    @Log(masked: ["comment"])
     func terminateContract(
         contractId: String,
         terminationDate: String,
@@ -30,7 +30,7 @@ class TerminateContractsService {
         return data
     }
 
-    @Log()
+    @Log(masked: ["comment"])
     func deleteContract(
         contractId: String,
         surveyOptionId: String,

--- a/Projects/TravelCertificate/Sources/Models/TravelInsuranceContractSpecification.swift
+++ b/Projects/TravelCertificate/Sources/Models/TravelInsuranceContractSpecification.swift
@@ -1,7 +1,9 @@
+import AutomaticLog
 import Foundation
 import hCore
 import hCoreUI
 
+@Loggable
 public struct TravelInsuranceContractSpecification: Codable, Equatable, Hashable, Sendable {
     let contractId: String
     let displayName: String
@@ -9,7 +11,7 @@ public struct TravelInsuranceContractSpecification: Codable, Equatable, Hashable
     let minStartDate: Date
     let maxStartDate: Date
     let maxDuration: Int
-    let email: String?
+    @Sensitive let email: String?
     let fullName: String
 
     public init(
@@ -33,9 +35,10 @@ public struct TravelInsuranceContractSpecification: Codable, Equatable, Hashable
     }
 }
 
+@Loggable
 public struct PolicyCoinsuredPersonModel: Codable, Equatable, Hashable {
     var fullName: String
-    var personalNumber: String? = nil
+    @Sensitive var personalNumber: String? = nil
     var birthDate: String? = nil
 }
 

--- a/Projects/TravelCertificate/Sources/Models/TravelInsuranceContractSpecification.swift
+++ b/Projects/TravelCertificate/Sources/Models/TravelInsuranceContractSpecification.swift
@@ -11,7 +11,7 @@ public struct TravelInsuranceContractSpecification: Codable, Equatable, Hashable
     let minStartDate: Date
     let maxStartDate: Date
     let maxDuration: Int
-    @Sensitive let email: String?
+    @Masked let email: String?
     let fullName: String
 
     public init(
@@ -38,7 +38,7 @@ public struct TravelInsuranceContractSpecification: Codable, Equatable, Hashable
 @Loggable
 public struct PolicyCoinsuredPersonModel: Codable, Equatable, Hashable {
     var fullName: String
-    @Sensitive var personalNumber: String? = nil
+    @Masked var personalNumber: String? = nil
     var birthDate: String? = nil
 }
 

--- a/Projects/TravelCertificate/Sources/Service/Protocols/TravelInsuranceClient.swift
+++ b/Projects/TravelCertificate/Sources/Service/Protocols/TravelInsuranceClient.swift
@@ -20,13 +20,13 @@ public struct TravelInsuranceFormDTO: Encodable {
     public let startDate: String
     public let isMemberIncluded: Bool
     public let coInsured: [CoInsuredDto]
-    @Sensitive public let email: String
+    @Masked public let email: String
 }
 
 @Loggable
 public struct CoInsuredDto: Encodable {
     public let fullName: String
-    @Sensitive public let personalNumber: String?
+    @Masked public let personalNumber: String?
     public let birthDate: String?
 }
 

--- a/Projects/TravelCertificate/Sources/Service/Protocols/TravelInsuranceClient.swift
+++ b/Projects/TravelCertificate/Sources/Service/Protocols/TravelInsuranceClient.swift
@@ -1,4 +1,5 @@
 import Addons
+import AutomaticLog
 import Foundation
 import hCore
 
@@ -13,17 +14,19 @@ public protocol TravelInsuranceClient {
     )
 }
 
+@Loggable
 public struct TravelInsuranceFormDTO: Encodable {
     public let contractId: String
     public let startDate: String
     public let isMemberIncluded: Bool
     public let coInsured: [CoInsuredDto]
-    public let email: String
+    @Sensitive public let email: String
 }
 
+@Loggable
 public struct CoInsuredDto: Encodable {
     public let fullName: String
-    public let personalNumber: String?
+    @Sensitive public let personalNumber: String?
     public let birthDate: String?
 }
 

--- a/Projects/hCore/Sources/Models/File.swift
+++ b/Projects/hCore/Sources/Models/File.swift
@@ -1,13 +1,15 @@
+import AutomaticLog
 import Foundation
 import PhotosUI
 import SwiftUI
 import UniformTypeIdentifiers
 
+@Loggable
 public struct File: Codable, Equatable, Identifiable, Hashable, Sendable {
     public let id: String
     public let size: Double
     public let mimeType: MimeType
-    public let name: String
+    @Masked public let name: String
     public let source: FileSource
 
     public init(id: String, size: Double, mimeType: MimeType, name: String, source: FileSource) {

--- a/Projects/hGraphQL/Sources/OAuthorizationToken.swift
+++ b/Projects/hGraphQL/Sources/OAuthorizationToken.swift
@@ -1,9 +1,11 @@
+import AutomaticLog
 import Foundation
 
+@Loggable
 public struct OAuthorizationToken: Codable {
-    public var accessToken: String
+    @Sensitive public var accessToken: String
     public var accessTokenExpirationDate: Date
-    public var refreshToken: String
+    @Sensitive public var refreshToken: String
     public var refreshTokenExpirationDate: Date
 
     public init(

--- a/Projects/hGraphQL/Sources/OAuthorizationToken.swift
+++ b/Projects/hGraphQL/Sources/OAuthorizationToken.swift
@@ -3,9 +3,9 @@ import Foundation
 
 @Loggable
 public struct OAuthorizationToken: Codable {
-    @Sensitive public var accessToken: String
+    @Masked public var accessToken: String
     public var accessTokenExpirationDate: Date
-    @Sensitive public var refreshToken: String
+    @Masked public var refreshToken: String
     public var refreshTokenExpirationDate: Date
 
     public init(


### PR DESCRIPTION
## What

Replaces the global, name-based redaction list in `AutomaticLog` with explicit per-field markers, then audits every `@Log` site in the app to port and extend the coverage.

Before, `redactedFieldNames` held 11 lowercased property names (`ssn`, `email`, `phone`, `token`, …) and the describer masked any property whose label matched, anywhere in the object graph. Masking was therefore invisible at the declaration site and silently depended on spelling. Now a field is masked because someone marked it.

## How masking is expressed

- **`@Loggable` on the type + `@Masked` on the field** — the common case. `@Loggable` synthesizes `static let maskedLogFields: Set<String>`, which is what the reflection-based describer reads at runtime. `@Masked` generates nothing and is purely a marker, which is what keeps `Codable` output and `@Published` intact — a property wrapper would rename the stored property to `_email` and change the wire format.
- **`MaskedValue` + a hand-written `maskedDescription`** — for enums, where an associated value cannot carry an attribute. Used by `MessageType` and `PaymentMethodSetupType`.
- **`@Log(masked: ["param"])`** — for function parameters, which are not properties.

The pairing is compiler-enforced rather than conventional:

| Mistake | Result |
|---|---|
| `@Masked` on a type that is not `@Loggable` | error |
| `@Masked` on a computed property (never reflected) | error |
| `@Loggable` with no masked field | warning |
| a name in `masked:` that is not a parameter | error |

The last one matters most: under the old list, renaming a parameter silently un-masked it. Now it fails the build.

## Coverage

All 71 `@Log` sites were audited against the types that actually flow through them. Newly masked — none of which the name list caught:

| Field | Reaches the log via |
|---|---|
| `PaymentMethodSetupType.nordeaPayout(accountNumber:)` / `.swishPayout(phoneNumber:)` | `setupPaymentMethod(_:)` parameter — bank account number, phone |
| `ClaimModel.memberFreeText` | `get()` / `getPartnerClaim()` return — the member's own incident description |
| `ClaimModel.signedAudioURL` | same — signed link to the member's audio recording |
| `ClaimModel.handlerEmail` | same |
| `InsuranceEvidenceInput.email`, `InsuranceEvidenceInitialData.email` | `createInsuranceEvidence(input:)` parameter, `getInitialData()` return |
| `comment` on `terminateContract` / `deleteContract` | parameter — the member's free-text cancellation reason |
| `PartnerDataSas.eurobonusNumber` | `getProfileState()` / `update(eurobonus:)` return; the input was already masked, the echo was not |
| `File.name` | `getFiles()` return; the uploads already masked the same type |

The near-misses are the point: the list had `phone` but not `phoneNumber`, `eurobonus` but not `eurobonusNumber`.

Also brought `Projects/Authentication/Sources/Service/AuthenticationService.swift` in line with `AuthenticationCore`. It is an orphan left by the AuthenticationCore/UI split (#2447) — no `Project.swift`, no importers, so Tuist builds no target from it — and it carried bare `@Log` on `otpState`, `exchange(code:)` and `exchange(refreshToken:)`. Worth deleting separately; annotated here so it cannot be copied forward as-is.

## Two bugs fixed along the way

- **`@Published` properties were never masked.** The old matcher compared the stored label against the list, and a wrapped property stores as `_code`, so `"code"` never matched. The leading underscore is now stripped. Covered by `testPublishedPropertyIsMasked`.
- **`MaskedValue` was bypassed inside collections and dictionaries.** It was checked only at the top-level entry and for direct children, so `[SomeMaskedType]` logged in the clear. The check now sits at the recursion entry, collapsing two call sites into one. Covered for property / optional / array / dictionary positions by `MaskedValueReachabilityTests`.

## Testing

`swift test` in `LocalModules/AutomaticLog` — 20 tests, all passing. They cover macro expansion including each diagnostic, stored/optional/published/nested field masking, hand-written conformances, parameter masking, and that `@Loggable` leaves the `Codable` representation unchanged.

The app targets have not been compiled — worth a check before merge.

## Deliberately unchanged

- **Personal names stay unmasked** (`MemberDetails.firstName`, `CoInsuredDto.fullName`, `Stakeholder`, `PersonalData`), matching previous behaviour. Note that `fetchPersonalInformation(SSN:)` masks the SSN going in and logs the resolved name coming back.
- **The error path is not masked.** `String(describing: error)` is logged verbatim, so a backend error echoing PII leaks regardless of annotations — and `.error` is the option used on the most sensitive services.
- **Document URLs are logged plainly**: `InsuranceEvidence.url`, `submitForm → URL`, `DefaultURLOpener.open(_:)`.
- `File.name` lives in hCore, so it is masked in every log containing a `File`, not only in Claims.
