### PR TITLE
chore: suppress duplicate Datadog logs within 0.5s

### DIFF
--- a/Projects/App/Sources/DatadogLogger.swift
+++ b/Projects/App/Sources/DatadogLogger.swift
@@ -3,20 +3,51 @@ import DatadogInternal
 import DatadogLogs
 import DatadogRUM
 import Environment
+import Foundation
 import Logger
 import SwiftUI
 
 class DatadogLogger: Logging {
+    /// Identical messages logged within this window are dropped, so a repeating log
+    /// (a redraw, a retry loop) does not flood Datadog.
+    private static let duplicateWindow: TimeInterval = 0.5
+    /// Upper bound on tracked messages, so a stream of unique messages cannot grow the cache forever.
+    private static let maxTrackedMessages = 200
+
+    private struct LogKey: Hashable {
+        let level: String
+        let message: String
+    }
+
     private let datadogLogger: LoggerProtocol
+    private let lock = NSLock()
+    private var lastLoggedAt: [LogKey: TimeInterval] = [:]
 
     init(datadogLogger: LoggerProtocol) {
         self.datadogLogger = datadogLogger
     }
 
-    func debug(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
-        if Environment.current != .production {
-            datadogLogger.debug(message, error: error, attributes: attributes)
+    /// Returns `false` when the same message was already logged at the same level less than
+    /// `duplicateWindow` ago, meaning the caller should skip it.
+    private func shouldLog(_ message: String, level: String) -> Bool {
+        let key = LogKey(level: level, message: message)
+        let now = ProcessInfo.processInfo.systemUptime
+        lock.lock()
+        defer { lock.unlock() }
+        if let previous = lastLoggedAt[key], now - previous < Self.duplicateWindow {
+            print("NOT LOGGED \(message)")
+            return false
         }
+        if lastLoggedAt.count >= Self.maxTrackedMessages {
+            lastLoggedAt = lastLoggedAt.filter { now - $0.value < Self.duplicateWindow }
+        }
+        lastLoggedAt[key] = now
+        return true
+    }
+
+    func debug(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard Environment.current != .production, shouldLog(message, level: "debug") else { return }
+        datadogLogger.debug(message, error: error, attributes: attributes)
     }
 
     /// Sends an INFO log message.
@@ -26,6 +57,7 @@ class DatadogLogger: Logging {
     ///   - attributes: a dictionary of attributes to add for this message. If an attribute with
     /// the same key already exist in this logger, it will be overridden (just for this message).
     func info(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard shouldLog(message, level: "info") else { return }
         datadogLogger.info(message, error: error, attributes: attributes)
     }
 
@@ -36,6 +68,7 @@ class DatadogLogger: Logging {
     ///   - attributes: a dictionary of attributes to add for this message. If an attribute with
     /// the same key already exist in this logger, it will be overridden (just for this message).
     func notice(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard shouldLog(message, level: "notice") else { return }
         datadogLogger.notice(message, error: error, attributes: attributes)
     }
 
@@ -46,6 +79,7 @@ class DatadogLogger: Logging {
     ///   - attributes: a dictionary of attributes to add for this message. If an attribute with
     /// the same key already exist in this logger, it will be overridden (just for this message).
     func warn(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard shouldLog(message, level: "warn") else { return }
         datadogLogger.warn(message, error: error, attributes: attributes)
     }
 
@@ -56,6 +90,7 @@ class DatadogLogger: Logging {
     ///   - attributes: a dictionary of attributes to add for this message. If an attribute with
     /// the same key already exist in this logger, it will be overridden (just for this message).
     func error(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard shouldLog(message, level: "error") else { return }
         datadogLogger.error(message, error: error, attributes: attributes)
     }
 
@@ -66,6 +101,7 @@ class DatadogLogger: Logging {
     ///   - attributes: a dictionary of attributes to add for this message. If an attribute with
     /// the same key already exist in this logger, it will be overridden (just for this message).
     func critical(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        guard shouldLog(message, level: "critical") else { return }
         datadogLogger.critical(message, error: error, attributes: attributes)
     }
 


### PR DESCRIPTION
## What

`DatadogLogger` now drops an identical message if the same one was already logged less than half a second ago. A repeating log — a view redraw, a retry loop — no longer floods Datadog with the same line.

All six level methods (`debug`/`info`/`notice`/`warn`/`error`/`critical`) guard on a new `shouldLog(_:level:)`. `addUserAction` and `addError` are untouched, since those are RUM actions/errors rather than log messages.

## Notes on the implementation

- **Keyed on level + message**, not message alone. Keying on the message alone would let an `info("Fetching")` swallow a following `error("Fetching")` — the kind of suppression that hides real problems. `error:` and `attributes:` are not part of the key, so message identity alone decides.
- **`ProcessInfo.processInfo.systemUptime`** rather than `Date()`, so a wall-clock change can't produce a negative delta and wrongly let a duplicate through.
- **`NSLock` around the dictionary.** `Logging` isn't `@MainActor`, so logs arrive on arbitrary threads and unsynchronized writes to a `Dictionary` can corrupt its buffer mid-resize, not merely miss a dedup.
- **The emission stays outside the lock.** `datadogLogger.x(...)` is called after the unlock, so the actual log write isn't serialized and there's no deadlock risk from the Datadog SDK taking its own locks.
- **Cache capped at 200 entries**, pruning expired ones on overflow. Log messages routinely embed dynamic data (IDs, URLs, error text), so a high-cardinality stream would otherwise grow the cache forever.

## Alternatives considered

- An `actor` for the cache — rejected because `Logging`'s methods are synchronous, so the emission would have to move inside a `Task`, delaying and reordering logs. A lot of logging happens right before a crash, which is exactly when that loss matters.
- A `Set` plus a delayed `Task` to evict each entry — self-pruning, but it still needs the lock (the eviction is a second writer), costs a timer per log line, and makes the window imprecise under load.

One follow-up left on the table: `NSLock` has no priority donation, so a low-QoS thread holding it while descheduled could stall a waiting main thread. With a critical section this small the odds are remote; `OSAllocatedUnfairLock` is a drop-in swap if it ever shows up in a trace.

## Testing

Not covered by tests, and not compiled locally — SwiftLint isn't installed on this machine and the build was left to Xcode/CI. Behaviour is unverified beyond code reading.
