### PR TITLE
feat: use server-provided actionText for termination suggestion buttons

### DIFF
--- a/Projects/App/Sources/Service/OctopusClientsImplementation/TerminateContractsClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/TerminateContractsClientOctopus.swift
@@ -146,6 +146,7 @@ extension OctopusGraphQL.TerminationSurveyOptionSuggestionFragment {
         .init(
             type: type.asTerminationSuggestionType,
             description: description,
+            actionText: actionText,
             url: url
         )
     }

--- a/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
+++ b/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
@@ -76,11 +76,13 @@ public struct TerminationRedirectionImage: Codable, Equatable, Hashable, Sendabl
 public struct TerminationSuggestion: Codable, Equatable, Hashable, Sendable {
     public let type: TerminationSuggestionType
     public let description: String
+    public let actionText: String?
     public let url: String?
 
-    public init(type: TerminationSuggestionType, description: String, url: String?) {
+    public init(type: TerminationSuggestionType, description: String, actionText: String? = nil, url: String?) {
         self.type = type
         self.description = description
+        self.actionText = actionText
         self.url = url
     }
 
@@ -95,6 +97,9 @@ public struct TerminationSuggestion: Codable, Equatable, Hashable, Sendable {
     }
 
     public var buttonTitle: String {
+        if let actionText, !actionText.isEmpty {
+            return actionText
+        }
         switch type {
         case .updateAddress:
             return L10n.terminationOfferButtonUpdateAddress

--- a/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
+++ b/Projects/TerminateContracts/Sources/Models/TerminationFlowSurveyStepModel.swift
@@ -97,7 +97,7 @@ public struct TerminationSuggestion: Codable, Equatable, Hashable, Sendable {
     }
 
     public var buttonTitle: String {
-        if let actionText, !actionText.isEmpty {
+        if let actionText {
             return actionText
         }
         switch type {

--- a/Projects/TerminateContracts/Sources/Service/DemoImplementation/TerminateContractsClientDemo.swift
+++ b/Projects/TerminateContracts/Sources/Service/DemoImplementation/TerminateContractsClientDemo.swift
@@ -24,7 +24,12 @@ class TerminateContractsClientDemo: TerminateContractsClient {
                     id: "option1",
                     title: "I found a better price",
                     feedbackRequired: false,
-                    suggestion: .init(type: .downgradePrice, description: "We can offer you a better price", url: nil),
+                    suggestion: .init(
+                        type: .downgradePrice,
+                        description: "We can offer you a better price",
+                        actionText: "Change amount",
+                        url: nil
+                    ),
                     subOptions: []
                 ),
                 .init(

--- a/Projects/TerminateContracts/Tests/TerminationSuggestionTests.swift
+++ b/Projects/TerminateContracts/Tests/TerminationSuggestionTests.swift
@@ -36,14 +36,4 @@ final class TerminationSuggestionTests: XCTestCase {
         )
         XCTAssertEqual(redirect.buttonTitle, L10n.terminationFlowLearnMore)
     }
-
-    func testButtonTitle_fallsBackToTypeWhenActionTextIsEmpty() {
-        let suggestion = TerminationSuggestion(
-            type: .downgradePrice,
-            description: "We can offer you a better price",
-            actionText: "",
-            url: nil
-        )
-        XCTAssertEqual(suggestion.buttonTitle, L10n.terminationOfferButtonChangeTier)
-    }
 }

--- a/Projects/TerminateContracts/Tests/TerminationSuggestionTests.swift
+++ b/Projects/TerminateContracts/Tests/TerminationSuggestionTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import hCore
+
+@testable import TerminateContracts
+
+final class TerminationSuggestionTests: XCTestCase {
+    func testButtonTitle_usesActionTextWhenProvided() {
+        let suggestion = TerminationSuggestion(
+            type: .downgradePrice,
+            description: "We can offer you a better price",
+            actionText: "Change amount",
+            url: nil
+        )
+        XCTAssertEqual(suggestion.buttonTitle, "Change amount")
+    }
+
+    func testButtonTitle_fallsBackToTypeWhenActionTextIsMissing() {
+        let upgradeCoverage = TerminationSuggestion(
+            type: .upgradeCoverage,
+            description: "We can offer better coverage",
+            url: nil
+        )
+        XCTAssertEqual(upgradeCoverage.buttonTitle, L10n.terminationOfferButtonChangeTier)
+
+        let updateAddress = TerminationSuggestion(
+            type: .updateAddress,
+            description: "We can move your insurance",
+            url: nil
+        )
+        XCTAssertEqual(updateAddress.buttonTitle, L10n.terminationOfferButtonUpdateAddress)
+
+        let redirect = TerminationSuggestion(
+            type: .redirect,
+            description: "Read more about your options",
+            url: "https://www.hedvig.com"
+        )
+        XCTAssertEqual(redirect.buttonTitle, L10n.terminationFlowLearnMore)
+    }
+
+    func testButtonTitle_fallsBackToTypeWhenActionTextIsEmpty() {
+        let suggestion = TerminationSuggestion(
+            type: .downgradePrice,
+            description: "We can offer you a better price",
+            actionText: "",
+            url: nil
+        )
+        XCTAssertEqual(suggestion.buttonTitle, L10n.terminationOfferButtonChangeTier)
+    }
+}

--- a/Projects/hGraphQL/GraphQL/Octopus/TerminiateContracts/TerminationSurvey.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/TerminiateContracts/TerminationSurvey.graphql
@@ -55,6 +55,7 @@ fragment TerminationSurveyOptionRedirectionFragment on TerminationFlowSurveyOpti
 fragment TerminationSurveyOptionSuggestionFragment on TerminationFlowSurveyOptionSuggestion {
   type
   description
+  actionText
   url
 }
 


### PR DESCRIPTION
## What?

Propagates the new `actionText` field on `TerminationFlowSurveyOptionSuggestion` added in [underwriter#1766](https://github.com/HedvigInsurance/underwriter/pull/1766).

- Added `actionText` to `TerminationSurveyOptionSuggestionFragment`.
- `TerminationSuggestion` gains `actionText: String?`, and `buttonTitle` returns it when present, falling back to the existing type → `L10n` mapping when it is `nil`/empty.
- Mapped the field in `TerminateContractsClientOctopus`, and gave the demo client an `actionText` so demo mode exercises the new path.
- Added `TerminationSuggestionTests` covering actionText-wins, nil-falls-back-per-type, and empty-string-falls-back.

`TerminationSurveyScreen` already renders `suggestion.buttonTitle` on the `InfoCard` button, so no view change was needed.

## Why?

Payment Protection has no tiers to move between — the thing a member can actually change is the insured amount. The button label can no longer be derived from the suggestion type alone, so the backend now sends it.

The rest of underwriter#1766 needs no iOS work: the new option ids (`BETTER_PRICE_CHANGE_AMOUNT`, `MISSING_COVERAGE_OR_TERMS_CHANGE_AMOUNT`) and the `SURVEY_OTHER_REASON` retitling flow through automatically, since the app never hardcodes survey option ids and takes all titles from the server.

## Tests

New unit tests for `TerminationSuggestion.buttonTitle`. Not verified by a build — swift-format is clean on all changed files.

## Note

The change-amount suggestions reuse the `UPGRADE_COVERAGE` / `DOWNGRADE_PRICE` types, which route into the ChangeTier flow. Worth sanity-checking that ChangeTier returns an amount option for a Payment Protection contract rather than falling into the `.emptyTier` branch.