### PR TITLE
fix(file-upload): stop file source picker from retaining view models

### DIFF
--- a/Projects/Claims/Sources/Views/ClaimDetailView.swift
+++ b/Projects/Claims/Sources/Views/ClaimDetailView.swift
@@ -297,18 +297,13 @@ public struct ClaimDetailView: View {
                             }
                             .verticalPadding(0)
                             .fixedSize(horizontal: false, vertical: true)
-                            hButton(
+                            hFileSourcePickerButton(
                                 .medium,
                                 .primary,
                                 content: .init(title: L10n.ClaimStatus.UploadedFiles.uploadButton)
-                            ) { [weak vm] in vm?.showFileSourcePicker = true }
-                            .showFileSourcePicker(
-                                $vm.showFileSourcePicker,
-                                selecedFiles: { [weak vm] files in
-                                    guard let vm else { return }
-                                    vm.showAddFiles(with: files)
-                                }
-                            )
+                            ) { [weak vm] files in
+                                vm?.showAddFiles(with: files)
+                            }
                         }
                     }
                     .sectionContainerStyle(.transparent)
@@ -340,8 +335,8 @@ public struct ClaimDetailView: View {
             InsuranceTermView(
                 documents: documents,
                 withHeader: L10n.ClaimStatusDetail.Documents.title
-            ) { [weak vm] document in
-                vm?.document = document
+            ) { document in
+                vm.document = document
             }
         }
     }
@@ -447,8 +442,6 @@ public class ClaimDetailViewModel: ObservableObject {
         }
     }
 
-    @Published var showFileSourcePicker = false
-
     private(set) var player: AudioPlayer?
     private var claimDetailsService: FetchClaimDetailsService
     @Published var fetchFilesError: String?
@@ -547,12 +540,12 @@ public class ClaimDetailViewModel: ObservableObject {
         do {
             let files = try await claimDetailsService.getFiles()
             store.setFiles(files, for: type.claimId)
-            withAnimation { [weak self] in
-                self?.fileGridViewModel.files = files
+            withAnimation {
+                self.fileGridViewModel.files = files
             }
         } catch let ex {
-            withAnimation { [weak self] in
-                self?.fetchFilesError = ex.localizedDescription
+            withAnimation {
+                self.fetchFilesError = ex.localizedDescription
             }
         }
     }

--- a/Projects/Claims/Sources/Views/ClaimFilesView.swift
+++ b/Projects/Claims/Sources/Views/ClaimFilesView.swift
@@ -50,17 +50,16 @@ public struct ClaimFilesView: View {
                 .hFormAttachToBottom {
                     hSection {
                         VStack(spacing: .padding8) {
-                            hButton(
+                            hFileSourcePickerButton(
                                 .large,
                                 .secondary,
                                 content: .init(title: L10n.ClaimStatusDetail.addMoreFiles)
-                            ) { [weak vm] in vm?.showFileSourcePicker = true }
-                            .disabled(vm.isLoading)
-                            .showFileSourcePicker($vm.showFileSourcePicker) { [weak vm] files in
+                            ) { [weak vm] files in
                                 for file in files {
                                     vm?.add(file: file)
                                 }
                             }
+                            .disabled(vm.isLoading)
                             hButton(
                                 .large,
                                 .primary,
@@ -106,7 +105,6 @@ public class ClaimFilesViewModel: ObservableObject {
     @Published var success = false
     @Published var error: String?
     @Published var progress: Double = 0
-    @Published var showFileSourcePicker = false
 
     private let endPoint: String
     let fileGridViewModel: FileGridViewModel

--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimFileUploadStep.swift
@@ -6,7 +6,6 @@ import hCore
 
 final class SubmitClaimFileUploadStep: ClaimIntentStepHandler {
     @Published var selectedOption: String?
-    @Published var showFileSourcePicker = false
 
     let model: ClaimIntentStepContentFileUpload
     let fileUploadVm: FilesUploadViewModel

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFileUploadView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimFileUploadView.swift
@@ -38,9 +38,6 @@ struct SubmitClaimFileUploadView: View {
                             addFilesButton
                         }
                     }
-                    .showFileSourcePicker($viewModel.showFileSourcePicker) { files in
-                        fileUploadVm.addFiles(with: files)
-                    }
                     .hButtonIsLoading(false)
                 }
             }
@@ -54,11 +51,13 @@ struct SubmitClaimFileUploadView: View {
 
     @ViewBuilder
     private var addMoreFilesButton: some View {
-        hButton(
+        hFileSourcePickerButton(
             .large,
             .secondary,
             content: .init(title: L10n.ClaimStatusDetail.addMoreFiles)
-        ) { [weak viewModel] in viewModel?.showFileSourcePicker = true }
+        ) { [weak fileUploadVm] files in
+            fileUploadVm?.addFiles(with: files)
+        }
     }
 
     @ViewBuilder
@@ -90,13 +89,15 @@ struct SubmitClaimFileUploadView: View {
 
     @ViewBuilder
     private var addFilesButton: some View {
-        hButton(
+        hFileSourcePickerButton(
             .large,
             .primary,
             content: .init(
                 title: L10n.ClaimStatusDetail.addFiles
             )
-        ) { viewModel.showFileSourcePicker = true }
+        ) { [weak fileUploadVm] files in
+            fileUploadVm?.addFiles(with: files)
+        }
     }
 }
 

--- a/Projects/hCoreUI/Sources/Views/FileSourcePickerView.swift
+++ b/Projects/hCoreUI/Sources/Views/FileSourcePickerView.swift
@@ -10,6 +10,39 @@ extension View {
     }
 }
 
+/// A button that presents the file source picker from locally-owned state.
+///
+/// Prefer this over applying `showFileSourcePicker(_:selecedFiles:)` yourself. The picker presents
+/// through native `.confirmationDialog`/`.sheet`, whose presentation registration outlives the
+/// presenting screen and retains the view value it is attached to — including whatever that view's
+/// bindings capture. A binding derived from `$viewModel` captures the view model strongly, so
+/// storing the flag on a view model leaks the whole model graph. `@State` here has nothing to pin;
+/// keep `selectedFiles` weak at the call site.
+public struct hFileSourcePickerButton: View {
+    @State private var showPicker = false
+    private let size: hButtonSize
+    private let type: hButtonConfigurationType
+    private let content: hButtonContent
+    private let selectedFiles: SelectedFiles
+
+    public init(
+        _ size: hButtonSize,
+        _ type: hButtonConfigurationType,
+        content: hButtonContent,
+        selectedFiles: @escaping SelectedFiles
+    ) {
+        self.size = size
+        self.type = type
+        self.content = content
+        self.selectedFiles = selectedFiles
+    }
+
+    public var body: some View {
+        hButton(size, type, content: content) { showPicker = true }
+            .showFileSourcePicker($showPicker, selecedFiles: selectedFiles)
+    }
+}
+
 private struct FileSourcePickerView: ViewModifier {
     @Binding private var presentFileSourcePicker: Bool
     @State private var showCamera: Bool = false


### PR DESCRIPTION
## Root cause

`showFileSourcePicker` presents through native `.confirmationDialog` + `.sheet`, and SwiftUI's presentation registration outlives the screen that installed it, retaining whatever that view's bindings captured. Every call site passed `$vm.showFileSourcePicker` — and `$vm.x` returns a `Binding` that captures the `ObservableObject` **strongly**, so the registration pinned the view model and the whole model graph leaked on pop.

Native presentation is the discriminator, not strong capture as such: the same screens pass strong `$vm` bindings to hCoreUI's `.modally`/`.detent` without leaking, since those tear down with the view. Confirmed on `ClaimDetailViewModel` — never reached `deinit`, but did once the modifier was passed `.constant(false)`.

## Fix

New `hFileSourcePickerButton` (hCoreUI) owns the flag as `@State`, so the native presentation holds nothing that can pin a view model. All three callers moved onto it and the dead flags dropped from their view models. `SubmitClaimFileUploadView` needed a restructure — the modifier sat on the enclosing `VStack`, so its two mutually-exclusive trigger buttons now own a picker each, with a weak `selecedFiles` callback.

## Testing

Not built from my side. Needs a compile plus a pass through all three screens: open the picker, pick a file, navigate away, confirm the deinit.

Unrelated hunk in `ClaimDetailView.swift`: `InsuranceTermView`'s callback went `[weak vm]` → strong, plus two inert `withAnimation { [weak self] }` captures dropped. Not a retention path; happy to restore the weak capture.
