### PR TITLE
fix: hForm memory leak

### DIFF
--- a/Projects/hCoreUI/Sources/hForm/hForm.swift
+++ b/Projects/hCoreUI/Sources/hForm/hForm.swift
@@ -14,7 +14,6 @@ public struct hForm<Content: View>: View, KeyboardReadable {
     @Environment(\.hFormIgnoreBottomPadding) var hFormIgnoreBottomPadding
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.verticalSizeClass) var verticalSizeClass
-    @State private var ignoreKeyboard = false
     @StateObject fileprivate var vm = hUpdatedFormViewModel()
     @Namespace var animationNamespace
     var content: Content
@@ -74,7 +73,7 @@ public struct hForm<Content: View>: View, KeyboardReadable {
                     }
                 }
             }
-            .ignoresSafeArea(.keyboard, edges: ignoreKeyboard ? .bottom : [])
+            .ignoresSafeArea(.keyboard, edges: vm.ignoreKeyboard ? .bottom : [])
         }
         .task {
             vm.scrollBounces = hEnableScrollBounce
@@ -123,10 +122,10 @@ public struct hForm<Content: View>: View, KeyboardReadable {
                                 || vm?.vc?.presentedViewController?.isKind(of: UISearchController.self) == true
                             {
                                 vm?.keyboardVisible = keyboardHeight != nil
-                                ignoreKeyboard = false
+                                vm?.ignoreKeyboard = false
                             } else {
                                 vm?.keyboardVisible = false
-                                ignoreKeyboard = true
+                                vm?.ignoreKeyboard = true
                             }
                         }
                 }
@@ -254,6 +253,7 @@ public struct hForm<Content: View>: View, KeyboardReadable {
 private class hUpdatedFormViewModel: ObservableObject {
     var keyboardCancellable: AnyCancellable?
     @Published var keyboardVisible: Bool = false
+    @Published var ignoreKeyboard: Bool = false
     weak var scrollView: UIScrollView? {
         didSet {
             scrollView?.clipsToBounds = false


### PR DESCRIPTION
## What

Move `hForm`'s `ignoreKeyboard` flag from `@State` on the view into the existing `hUpdatedFormViewModel` as a `@Published` property.

## Why

The keyboard-visibility Combine subscription mutates `ignoreKeyboard` from inside its `sink` closure. Because `ignoreKeyboard` was a `@State` on the `hForm` struct, that closure captured the view itself (the `@State` accessor), keeping `hForm` — and everything it holds — alive for as long as the subscription lived. The rest of the closure already used `vm?` weakly, so this flag was the one remaining strong reference.

Storing the flag on the view model instead means the closure only touches `vm?`, which it already captures weakly, so nothing pins the view.

## Changes

- `Projects/hCoreUI/Sources/hForm/hForm.swift`
  - Removed `@State private var ignoreKeyboard`
  - Added `@Published var ignoreKeyboard: Bool = false` to `hUpdatedFormViewModel`
  - `.ignoresSafeArea(.keyboard, ...)` and the keyboard sink now read/write `vm.ignoreKeyboard`

Behavior is unchanged — same flag, same transitions, just owned by the view model.

tnx @victor-reyes-by for figuring it out ⭐ 