### PR TITLE
fix: iOS 26 SDF crash - possible corner radius issue and empty glass container

### DIFF
--- a/Projects/CrossSell/Sources/View/Components/CrossSellDiscountProgressComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellDiscountProgressComponent.swift
@@ -19,7 +19,7 @@ struct CrossSellDiscountProgressComponent: View {
                     ForEach(1..<4) { column in
                         VStack(spacing: 4) {
                             ZStack {
-                                RoundedRectangle(cornerRadius: .cornerRadiusS)
+                                Capsule()
                                     .fill(hSurfaceColor.Opaque.secondary)
                                 if (column <= numberOfInsurances + 1) {
                                     AnimatedProgressView(orderOfExecution: column, pulse: column > numberOfInsurances)
@@ -76,11 +76,11 @@ private struct AnimatedProgressView: View {
     var body: some View {
         GeometryReader { geo in
             if pulse {
-                RoundedRectangle(cornerRadius: .cornerRadiusS)
+                Capsule()
                     .fill(hSignalColor.Green.element.opacity(animationProgress))
                     .scaleEffect(x: 1, y: 1 + animationProgress / 4)
             } else {
-                RoundedRectangle(cornerRadius: .cornerRadiusS)
+                Capsule()
                     .fill(hSignalColor.Green.element)
                     .mask(alignment: .leading) {
                         Rectangle()

--- a/Projects/Home/Sources/Screens/ActiveHomeView.swift
+++ b/Projects/Home/Sources/Screens/ActiveHomeView.swift
@@ -14,7 +14,6 @@ struct ActiveHomeView: View {
     @State private var headerHeight: CGFloat = 0
     @State private var scrollOffset: CGFloat = 0
     @State private var navBarHeight: CGFloat = 0
-    @State private var topSafeAreaInset: CGFloat = 0
 
     private let scrollSpace = "homeScroll"
 
@@ -41,7 +40,7 @@ struct ActiveHomeView: View {
                                 // The greeting is lazy: once scrolled off it's recycled and
                                 // reports 0, which would blow up the clip inset and the sheet's
                                 // minimum height. Latch the last real measurement.
-                                if height > 0 { greetingHeight = height }
+                                if height > 0, height.isFinite { greetingHeight = height }
                             }
                             .offset(x: 0, y: scrollOffset > 0 ? -(scrollOffset / 2) : -(scrollOffset / 3))
                     }
@@ -53,7 +52,7 @@ struct ActiveHomeView: View {
                         )
                         .padding(.bottom, proxy.safeAreaInsets.bottom + surfaceBottomGap)
                         // The sheet must always reach the screen bottom at rest.
-                        .frame(minHeight: viewportHeight - greetingHeight - headerHeight, alignment: .top)
+                        .frame(minHeight: max(0, viewportHeight - greetingHeight - headerHeight), alignment: .top)
                         // Two masks, with the surface sandwiched between them. This one runs
                         // before the background, so it fades the content alone: text and cards
                         // dissolve into the sheet rather than vanishing mid-glyph.
@@ -81,22 +80,30 @@ struct ActiveHomeView: View {
                         }
                     } header: {
                         HomeSheetContainer()
-                            .onGeometryChange(for: CGFloat.self, of: \.size.height) { headerHeight = $0 }
+                            .onGeometryChange(for: CGFloat.self, of: \.size.height) {
+                                headerHeight = $0.isFinite ? $0 : 0
+                            }
                     }
                 }
                 .frame(maxWidth: maxContentWidth)
                 .frame(maxWidth: .infinity)
                 .onGeometryChange(for: CGFloat.self, of: { $0.frame(in: .named(scrollSpace)).minY }) {
-                    scrollOffset = $0
+                    // A named coordinate space that hasn't resolved yet reports CGRect.infinite,
+                    // so minY arrives as -inf. `topInset` below clamps negatives but not
+                    // infinities, so such a value reaches a mask shape as .frame(height: .infinity)
+                    // and trips the iOS 26 SDF renderer (inf - inf = NaN when SDFStyle.distanceRange
+                    // builds its ClosedRange, which traps). Keep the stored offset finite.
+                    scrollOffset = $0.isFinite ? $0 : 0
                 }
             }
             .coordinateSpace(name: scrollSpace)
             .ignoresSafeArea(edges: .bottom)
-            .onGeometryChange(for: CGFloat.self, of: \.safeAreaInsets.top) { topSafeAreaInset = $0 }
             .overlay(alignment: .topTrailing) {
                 HomeNavigationBar()
                     .padding(.vertical, .padding4)
-                    .onGeometryChange(for: CGFloat.self, of: \.size.height) { navBarHeight = $0 }
+                    .onGeometryChange(for: CGFloat.self, of: \.size.height) {
+                        navBarHeight = $0.isFinite ? $0 : 0
+                    }
                     .opacity(showNavigation ? 1 : 0)
                     .offset(y: showNavigation ? 0 : -30)
                     // Animate only when the bar's visibility flips, not on every scroll tick.
@@ -183,12 +190,14 @@ private struct HomeNavigationBar: View {
     @EnvironmentObject private var navigationVm: HomeNavigationViewModel
 
     var body: some View {
-        if #available(iOS 26.0, *) {
-            GlassEffectContainer(spacing: .padding8) {
+        if !homeStore.toolbarOptionTypes.isEmpty {
+            if #available(iOS 26.0, *) {
+                GlassEffectContainer(spacing: .padding8) {
+                    toolbar()
+                }
+            } else {
                 toolbar()
             }
-        } else {
-            toolbar()
         }
     }
 

--- a/Projects/Home/Sources/Screens/Components/HomeSheetContainer.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeSheetContainer.swift
@@ -23,8 +23,8 @@ struct HomeSheetContainer: View {
 
     private var surfaceShape: UnevenRoundedRectangle {
         UnevenRoundedRectangle(
-            topLeadingRadius: .cornerRadiusXXXL,
-            topTrailingRadius: .cornerRadiusXXXL
+            topLeadingRadius: 20,
+            topTrailingRadius: 20
         )
     }
 

--- a/Projects/hCoreUI/Sources/Pill/hPill.swift
+++ b/Projects/hCoreUI/Sources/Pill/hPill.swift
@@ -79,12 +79,12 @@ fileprivate struct PillModifier: ViewModifier {
             .padding(.top, getTopPadding)
             .padding(.bottom, getBottomPadding)
             .background(
-                RoundedRectangle(cornerRadius: getCornerRadius)
+                pillShape
                     .fill(color.pillBackgroundColor(level: colorLevel))
             )
             .overlay {
                 if withBorder {
-                    RoundedRectangle(cornerRadius: getCornerRadius)
+                    pillShape
                         .stroke(hBorderColor.primary, lineWidth: 1)
                 }
             }
@@ -133,10 +133,17 @@ fileprivate struct PillModifier: ViewModifier {
         }
     }
 
+    /// `capsuleShape` was expressed as cornerRadius 24, which only rendered as a capsule
+    /// because the radius exceeded half the pill's height and CoreGraphics clamped it. iOS 26
+    /// renders shapes through a signed-distance-field path that is not forgiving of a radius
+    /// larger than the shape allows, so name the capsule directly instead.
+    private var pillShape: AnyShape {
+        capsuleShape
+            ? AnyShape(Capsule())
+            : AnyShape(RoundedRectangle(cornerRadius: getCornerRadius))
+    }
+
     private var getCornerRadius: CGFloat {
-        if capsuleShape {
-            return .cornerRadiusXXL
-        }
         switch fieldSize {
         case .small:
             return .cornerRadiusXS

--- a/Projects/hCoreUI/Sources/Pill/hPill.swift
+++ b/Projects/hCoreUI/Sources/Pill/hPill.swift
@@ -166,12 +166,12 @@ fileprivate struct PillWrapperModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
-                RoundedRectangle(cornerRadius: .infinity)
+                Capsule()
                     .fill(color.pillBackgroundColor(level: colorLevel))
             )
             .overlay {
                 if withBorder {
-                    RoundedRectangle(cornerRadius: .infinity)
+                    Capsule()
                         .stroke(hBorderColor.primary, lineWidth: 1)
                 }
             }

--- a/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
+++ b/Projects/hCoreUI/Sources/Styling/DefaultStyling.swift
@@ -451,7 +451,6 @@ extension CGFloat {
     public static let cornerRadiusXL: CGFloat = 16
     public static let cornerRadiusXXL: CGFloat = 24
     public static let cornerRadiusXXXL: CGFloat = 32
-    public static let cornerRadiusRounded: CGFloat = 36
 }
 
 extension CGFloat {

--- a/Projects/hCoreUI/Sources/hButton/hButton.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButton.swift
@@ -116,13 +116,13 @@ struct _hButton<Content: View>: View {
 }
 
 extension View {
-    func buttonCornerModifier(_ cornerRadius: CGFloat, withBorder: Bool) -> some View {
-        self.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+    func buttonCornerModifier(withBorder: Bool) -> some View {
+        self.clipShape(Capsule())
+            .contentShape(Capsule())
             .overlay(
                 Group {
                     if withBorder {
-                        RoundedRectangle(cornerRadius: cornerRadius).stroke(hBorderColor.primary, lineWidth: 1)
+                        Capsule().stroke(hBorderColor.primary, lineWidth: 1)
                     }
                 }
             )

--- a/Projects/hCoreUI/Sources/hButton/hButtonStyle/hButtonStyle.swift
+++ b/Projects/hCoreUI/Sources/hButton/hButtonStyle/hButtonStyle.swift
@@ -42,7 +42,7 @@ public struct ButtonFilledStyle: SwiftUI.ButtonStyle {
         }
         .buttonSizeModifier(size)
         .background(hButtonFilledBackground(configuration: configuration))
-        .buttonCornerModifier(.cornerRadiusRounded, withBorder: withBorder)
+        .buttonCornerModifier(withBorder: withBorder)
     }
 
     // content


### PR DESCRIPTION
## Problem

Production `SIGTRAP` in `SDFStyle.distanceRange.getter` on the Home tab, iOS 26. Seen in 14.0.3 (iPhone 12, 26.3.1) and 14.0.2 (iPhone 11 Pro Max, 26.3) and on iPhone 16 Pro Max, 26.6.1 with identical stacks.

## Root cause

A corner radius **larger than the shape's geometry allows**. It only ever rendered because CoreGraphics silently clamped it. iOS 26 renders shapes through a signed-distance-field path where `SDFStyle.distanceRange` builds a `ClosedRange`; an out-of-range radius yields invalid bounds and traps instead of clamping. `cornerRadius: .infinity` is the extreme case, not a separate bug.

The limit is per edge — two adjacent radii can't exceed the edge they share. For a `RoundedRectangle` (all four corners) that means `min(w, h)`; for the `UnevenRoundedRectangle` below, where only the top corners are set and the bottom two are 0, the top radius can use the full height.

## Changes

| Site | Radius vs max valid | Fix |
|---|---|---|
| `HomeSheetContainer.surfaceShape` | 32 on a 20pt-tall shape, top corners only (max 20) | radius `20` |
| `hButton.buttonCornerModifier` | 36 on 32–56pt buttons (max 16–28) | `Capsule()` |
| `hPill` `capsuleShape` | 24 on a ~36pt pill (max ~18) | `Capsule()` |
| `CrossSellDiscountProgressComponent` ×3 | 8 in an 8pt track (max 4) | `Capsule()` |
| `hPill` wrapper | `.infinity` | `Capsule()` |

All pixel-identical to what shipped — each radius was already being clamped to the value it is now given explicitly.

Also: removed the unusable `cornerRadiusRounded` token; `isFinite` guards on `ActiveHomeView` geometry; `GlassEffectContainer` no longer built when `toolbarOptionTypes` is empty (it starts `[]`, so every cold launch wrapped a glass backdrop group around zero-sized content); removed dead `topSafeAreaInset`.

🤞 
