### PR TITLE
feat: animate Task step progress messages [GEN-5736]

### DIFF
--- a/Projects/SubmitClaimChat/Sources/Models/SubmitClaimTaskStep.swift
+++ b/Projects/SubmitClaimChat/Sources/Models/SubmitClaimTaskStep.swift
@@ -13,6 +13,7 @@ final class SubmitClaimTaskStep: ClaimIntentStepHandler {
     }
 
     @Published var taskModel: ClaimIntentStepContentTask
+    @Published var displayText: String?
 
     required init(
         claimIntent: ClaimIntent,
@@ -25,6 +26,7 @@ final class SubmitClaimTaskStep: ClaimIntentStepHandler {
         self.taskModel = model
         super.init(claimIntent: claimIntent, service: service, mainHandler: mainHandler)
         state.showResults = true
+        displayText = taskModel.description
         Task { [weak self] in
             try await Task.sleep(seconds: ClaimChatConstants.Timing.standardAnimation)
             self?.submitResponse()
@@ -41,6 +43,10 @@ final class SubmitClaimTaskStep: ClaimIntentStepHandler {
                 throw ClaimIntentError.invalidResponse
             }
             try await Task.sleep(seconds: ClaimChatConstants.Timing.standardAnimation)
+            Task {
+                await delay(1)
+                displayText = nil
+            }
             taskModel = .init(description: "", isCompleted: true)
             return result
         } catch {
@@ -63,6 +69,13 @@ final class SubmitClaimTaskStep: ClaimIntentStepHandler {
             switch claimIntent {
             case let .intent(model):
                 self.claimIntent = model
+                Task {
+                    if displayText != taskModel.description {
+                        displayText = nil
+                    }
+                    await delay(0.4)
+                    displayText = taskModel.description
+                }
             default:
                 break
             }

--- a/Projects/SubmitClaimChat/Sources/Service/DemoImplementation/ClaimIntentClientDemo.swift
+++ b/Projects/SubmitClaimChat/Sources/Service/DemoImplementation/ClaimIntentClientDemo.swift
@@ -330,15 +330,24 @@ public class ClaimIntentClientDemo: ClaimIntentClient {
         return FormFieldSearchResult(options: filtered, suggestedQuery: "suggested")
     }
 
+    var numberOfTask = 0
+    var texts = [
+        "Analyzing…",
+        "Reading your answer…",
+        "Going through the details…",
+        "Working out the next step…",
+        "One moment…",
+        "Done",
+    ]
     public func getNextStep(claimIntentId: String) async throws -> ClaimIntentType? {
         try await Task.sleep(seconds: 3)
-        return .intent(
+        let intent = ClaimIntentType.intent(
             model: .init(
                 currentStep: .init(
                     content: .task(
                         model: .init(
-                            description: "Text updated",
-                            isCompleted: true
+                            description: texts[min(numberOfTask, texts.count - 1)],
+                            isCompleted: numberOfTask >= texts.count - 1
                         )
                     ),
                     id: "id2323",
@@ -350,6 +359,8 @@ public class ClaimIntentClientDemo: ClaimIntentClient {
                 progress: 0
             )
         )
+        numberOfTask += 1
+        return intent
     }
     let taskDemoStep = SubmitClaimTaskStep(
         claimIntent: .init(

--- a/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimTaskView.swift
+++ b/Projects/SubmitClaimChat/Sources/Views/Steps/SubmitClaimTaskView.swift
@@ -16,21 +16,19 @@ struct SubmitClaimTaskResultView: View {
             )
             //Compensate for Rive asset internal padding
             .padding(.horizontal, -.padding2)
-            if viewModel.taskModel.description != "" {
-                hText(viewModel.taskModel.description, style: .body1)
+            if let displayText = viewModel.displayText {
+                hText(displayText, style: .body1)
                     .modifier(ShimmerTextModifier(isActive: true))
                     .transition(.opacity)
-                    .animation(.easeInOut, value: viewModel.taskModel)
             }
         }
         // Offset to align with chat message content above
         .padding(.top, -.padding16)
         // Offset to align with chat message content below
         .padding(.bottom, -.padding8)
-        .transition(.opacity.animation(.easeOut))
-        .animation(.easeInOut, value: viewModel.taskModel)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(L10n.claimChatTaskContentDescription)
+        .animation(.easeInOut(duration: 0.3), value: viewModel.displayText)
     }
 }
 
@@ -38,7 +36,7 @@ struct SubmitClaimTaskResultView: View {
     let demo = ClaimIntentClientDemo()
     Dependencies.shared.add(module: Module { () -> ClaimIntentClient in demo })
     Dependencies.shared.add(module: Module { () -> DateService in DateService() })
-    let model = ClaimIntentClientDemo().taskDemoStep
+    let model = demo.taskDemoStep
     return VStack(alignment: .leading) {
         SubmitClaimTaskResultView(viewModel: model)
     }

--- a/Projects/hCoreUI/Sources/Views/ShimmerModifier.swift
+++ b/Projects/hCoreUI/Sources/Views/ShimmerModifier.swift
@@ -12,12 +12,12 @@ public struct ShimmerTextModifier: ViewModifier {
     public func body(content: Content) -> some View {
         if isActive {
             content
-                .opacity(0.4)
+                .opacity(0.25)
                 .overlay(
                     content
                         .mask(
                             LinearGradient(
-                                colors: [.white.opacity(0.4), .white.opacity(1), .white.opacity(0.4)],
+                                colors: [.white.opacity(0), .white.opacity(1), .white.opacity(0)],
                                 startPoint: startPoint,
                                 endPoint: endPoint
                             )


### PR DESCRIPTION
The Task step already updated its message on each poll, but the text swapped in place with no transition. Now a new message fades the old line out and the new one in, shimmering while work is ongoing.

- `SubmitClaimTaskStep` — added `displayText`, decoupled from `taskModel`. Since the `if` in the view never re-inserted, `.transition` never ran and the text changed in place; a separate published value lets it clear, wait, then set the new line so the fade actually runs.
- `SubmitClaimTaskResultView` — renders `displayText` with one `.easeInOut(duration: 0.3)`.
- `ShimmerTextModifier` — opacity 0.4 → 0.25, gradient edges 0.4 → 0, so the sweep has contrast. Affects all callers, not just this step.
- `ClaimIntentClientDemo` — walks the [Figma](https://www.figma.com/design/SogcacjzOxkCC46XcZP8lQ/App-P2-2026?node-id=2305-12925&m=dev) message sequence instead of returning a single message, so the transitions are visible in previews.

Client half. The progression itself depends on backend sending a sequence of messages per Task step (RND-2223); an unchanged message is safe — the line just stays put.

Verified by reading the code and in previews; not built in Xcode.