### PR TITLE
feat(x-sells): one cross-sell row everywhere

### DIFF
--- a/Projects/Addons/Sources/Views/AddonCardView.swift
+++ b/Projects/Addons/Sources/Views/AddonCardView.swift
@@ -43,14 +43,14 @@ public struct AddonCardView: View {
         .hShadow(type: .custom(opacity: 0.05, radius: 5, xOffset: 0, yOffset: 4), show: true)
         .hShadow(type: .custom(opacity: 0.1, radius: 1, xOffset: 0, yOffset: 2), show: true)
         .accessibilityElement(children: .combine)
-        .accessibilityHint(L10n.voiceoverPressTo + " " + L10n.addonFlowSeePriceButton)
+        .accessibilityHint(L10n.voiceoverPressTo + " " + L10n.crossSellSeePrice)
     }
 
     var seePriceButton: some View {
         hButton(
             .small,
             .secondary,
-            content: .init(title: L10n.addonFlowSeePriceButton),
+            content: .init(title: L10n.crossSellSeePrice),
             handleSeePrice
         )
         .hButtonTakeFullWidth(true)

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -769,14 +769,7 @@ struct HomeTab: View {
             presentationStyle: .detent(style: [.large]),
             options: .constant([.alwaysOpenOnTop, .withoutGrabber])
         ) { crossSells in
-            CrossSellingModal(
-                crossSells: crossSells,
-                addons: crossSellStore.addonBanners,
-                onAddonTap: { banner in
-                    homeNavigationVm.navBarItems.isNewOfferPresentedModal = nil
-                    presentAddon(for: banner)
-                }
-            )
+            CrossSellingModal(crossSells: crossSells)
         }
         .detent(
             item: $homeNavigationVm.navBarItems.isNewOfferPresentedDetent,

--- a/Projects/App/Sources/Navigation/LoggedInNavigation.swift
+++ b/Projects/App/Sources/Navigation/LoggedInNavigation.swift
@@ -706,6 +706,16 @@ struct HandleMoving: View {
 struct HomeTab: View {
     @ObservedObject var homeNavigationVm: HomeNavigationViewModel
     @ObservedObject var loggedInVm: LoggedInNavigationViewModel
+    @AppObservedObject private var crossSellStore: CrossSellStore
+    @AppObservedObject private var contractStore: ContractStore
+
+    /// Add-on rows in the cross-sell sheets open the purchase flow rather than a store URL,
+    /// and the flow's input needs contract data the CrossSell module cannot reach.
+    private func presentAddon(for banner: AddonBanner) {
+        let contractInfos = contractStore.getAddonContractInfosFor(contractIds: banner.contractIds)
+        homeNavigationVm.isAddonPresented = .init(addonSource: .crossSell, contractInfos: contractInfos)
+    }
+
     var body: some View {
         hNavigationStack(router: homeNavigationVm.router, options: .ignoreNavigationBarVisibility, tracking: self) {
             HomeScreen()
@@ -759,14 +769,28 @@ struct HomeTab: View {
             presentationStyle: .detent(style: [.large]),
             options: .constant([.alwaysOpenOnTop, .withoutGrabber])
         ) { crossSells in
-            CrossSellingModal(crossSells: crossSells)
+            CrossSellingModal(
+                crossSells: crossSells,
+                addons: crossSellStore.addonBanners,
+                onAddonTap: { banner in
+                    homeNavigationVm.navBarItems.isNewOfferPresentedModal = nil
+                    presentAddon(for: banner)
+                }
+            )
         }
         .detent(
             item: $homeNavigationVm.navBarItems.isNewOfferPresentedDetent,
             presentationStyle: .detent(style: [.height]),
             options: .constant([.alwaysOpenOnTop])
         ) { crossSells in
-            CrossSellingDetent(crossSells: crossSells)
+            CrossSellingDetent(
+                crossSells: crossSells,
+                addons: crossSellStore.addonBanners,
+                onAddonTap: { banner in
+                    homeNavigationVm.navBarItems.isNewOfferPresentedDetent = nil
+                    presentAddon(for: banner)
+                }
+            )
         }
         .detent(
             item: $homeNavigationVm.openChat,

--- a/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
+++ b/Projects/App/Sources/Service/OctopusClientsImplementation/CrossSellClientOctopus.swift
@@ -27,8 +27,7 @@ class CrossSellClientOctopus: CrossSellClient {
             }
             return nil
         }()
-        let discountAvailable = crossSells.currentMember.crossSellV2.discountAvailable
-        return .init(recommended: recommendedCrossSell, others: otherCrossSells, discountAvailable: discountAvailable)
+        return .init(recommended: recommendedCrossSell, others: otherCrossSells)
     }
 
     func getAddonBanners(source: AddonSource) async throws -> [AddonBanner] {

--- a/Projects/Contracts/Sources/View/ContractTable.swift
+++ b/Projects/Contracts/Sources/View/ContractTable.swift
@@ -64,7 +64,7 @@ struct ContractTable: View {
                     )
                 if !showTerminated {
                     VStack(spacing: .padding8) {
-                        CrossSellingView(withHeader: true)
+                        CrossSellingView()
                             .padding(.top, .padding8)
                         addonBannersView
                         movingToANewHomeView

--- a/Projects/Contracts/Sources/View/ContractTable.swift
+++ b/Projects/Contracts/Sources/View/ContractTable.swift
@@ -216,17 +216,19 @@ struct ContractTable: View {
                         let contractInfo = store.getAddonContractInfosFor(contractIds: banner.contractIds)
                         let input = ChangeAddonInput(addonSource: .insurances, contractInfos: contractInfo)
 
-                        AddonCardView(
-                            openAddon: {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    contractsNavigationVm.isAddonPresented = input
-                                }
-                            },
-                            addon: banner
-                        )
-                        .hButtonIsLoading(
-                            contractsNavigationVm.isAddonPresented?.contractInfos == input.contractInfos
-                        )
+                        CrossSellRow(
+                            title: banner.displayTitle,
+                            subtitle: banner.displayDescription,
+                            buttonTitle: L10n.crossSellSeePrice,
+                            variant: .secondary,
+                            isLoading: contractsNavigationVm.isAddonPresented?.contractInfos
+                                == input.contractInfos,
+                            pillow: { AddonPillowView(type: banner.addonType) }
+                        ) {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                contractsNavigationVm.isAddonPresented = input
+                            }
+                        }
                     }
                 }
             }

--- a/Projects/CrossSell/Sources/Models/CrossSellModels.swift
+++ b/Projects/CrossSell/Sources/Models/CrossSellModels.swift
@@ -5,22 +5,19 @@ public struct CrossSells: Codable, Equatable, Hashable, Sendable, Identifiable {
     public let id = UUID()
     public let recommended: RecommendedCrossSell?
     public let others: [CrossSell]
-    public let discountAvailable: Bool
     enum CodingKeys: String, CodingKey {
         case id
         case recommended
         case others
-        case discountAvailable
     }
 
     var hasRecommendation: Bool {
         recommended != nil
     }
 
-    public init(recommended: RecommendedCrossSell?, others: [CrossSell], discountAvailable: Bool) {
+    public init(recommended: RecommendedCrossSell?, others: [CrossSell]) {
         self.recommended = recommended
         self.others = others
-        self.discountAvailable = discountAvailable
     }
 }
 

--- a/Projects/CrossSell/Sources/Service/CrossSellClientDemo.swift
+++ b/Projects/CrossSell/Sources/Service/CrossSellClientDemo.swift
@@ -9,13 +9,13 @@ public class CrossSellClientDemo: CrossSellClient {
                 id: "1",
                 title: "title",
                 description: "description",
-                buttonTitle: "Save 15%",
+                buttonTitle: "See price",
                 webActionURL: "",
                 imageUrl: nil,
                 buttonDescription: "buttonDescription"
             )
         ]
-        return .init(recommended: nil, others: crossSells, discountAvailable: true)
+        return .init(recommended: nil, others: crossSells)
     }
 
     public func getAddonBanners(source: Addons.AddonSource) async throws -> [Addons.AddonBanner] {

--- a/Projects/CrossSell/Sources/View/Components/CrossSellAddonsSection.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellAddonsSection.swift
@@ -1,0 +1,41 @@
+import Addons
+import SwiftUI
+import hCore
+import hCoreUI
+
+/// The "Addons" heading and one row per add-on, shown beneath a cross-sell list.
+///
+/// Add-ons open the purchase flow rather than a store URL, and building that flow's input
+/// needs contract data this module cannot reach, so the tap is handed to the presenting
+/// navigation through `onAddonTap`.
+public struct CrossSellAddonsSection: View {
+    private let addons: [AddonBanner]
+    private let onAddonTap: (AddonBanner) -> Void
+
+    public init(addons: [AddonBanner], onAddonTap: @escaping (AddonBanner) -> Void) {
+        self.addons = addons
+        self.onAddonTap = onAddonTap
+    }
+
+    public var body: some View {
+        if !addons.isEmpty {
+            hSection {
+                VStack(spacing: .padding8) {
+                    ForEach(addons, id: \.self) { banner in
+                        CrossSellRow(
+                            title: banner.displayTitle,
+                            subtitle: banner.displayDescription,
+                            buttonTitle: L10n.crossSellSeePrice,
+                            variant: .secondary,
+                            pillow: { AddonPillowView(type: banner.addonType) }
+                        ) {
+                            onAddonTap(banner)
+                        }
+                    }
+                }
+            }
+            .withHeader(title: L10n.insuranceAddonsSubheading)
+            .sectionContainerStyle(.transparent)
+        }
+    }
+}

--- a/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
@@ -4,25 +4,16 @@ import hCoreUI
 
 public struct CrossSellStackComponent: View {
     let crossSells: [CrossSell]
-    let withHeader: Bool
-    public init(crossSells: [CrossSell], withHeader: Bool) {
+    public init(crossSells: [CrossSell]) {
         self.crossSells = crossSells
-        self.withHeader = withHeader
     }
     public var body: some View {
-        let content = hSection {
+        hSection {
             VStack(spacing: .padding4) {
                 ForEach(crossSells, id: \.title) { crossSell in
                     CrossSellingItem(crossSell: crossSell)
                         .transition(.opacity)
                 }
-            }
-        }
-        Group {
-            if withHeader {
-                content.withHeader(title: L10n.InsuranceTab.CrossSells.title)
-            } else {
-                content
             }
         }
         .sectionContainerStyle(.transparent)
@@ -51,7 +42,6 @@ public struct CrossSellStackComponent: View {
                 imageUrl: nil,
                 buttonDescription: "button"
             ),
-        ],
-        withHeader: true
+        ]
     )
 }

--- a/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
@@ -5,27 +5,22 @@ import hCoreUI
 public struct CrossSellStackComponent: View {
     let crossSells: [CrossSell]
     let withHeader: Bool
-    let headerTitle: String
-    let discountAvailable: Bool
-    public init(crossSells: [CrossSell], discountAvailable: Bool, withHeader: Bool, headerTitle: String? = nil) {
+    public init(crossSells: [CrossSell], withHeader: Bool) {
         self.crossSells = crossSells
         self.withHeader = withHeader
-        self.discountAvailable = discountAvailable
-        self.headerTitle =
-            headerTitle ?? (discountAvailable ? L10n.insuranceOffersSubheading : L10n.InsuranceTab.CrossSells.title)
     }
     public var body: some View {
         let content = hSection {
             VStack(spacing: .padding4) {
                 ForEach(crossSells, id: \.title) { crossSell in
-                    CrossSellingItem(crossSell: crossSell, discountAvailable: discountAvailable)
+                    CrossSellingItem(crossSell: crossSell)
                         .transition(.opacity)
                 }
             }
         }
         Group {
             if withHeader {
-                content.withHeader(title: headerTitle)
+                content.withHeader(title: L10n.InsuranceTab.CrossSells.title)
             } else {
                 content
             }
@@ -42,7 +37,7 @@ public struct CrossSellStackComponent: View {
                 id: "id",
                 title: "title",
                 description: "long description that goes long way",
-                buttonTitle: "Save 15%",
+                buttonTitle: "See price",
                 webActionURL: "",
                 imageUrl: nil,
                 buttonDescription: "button"
@@ -51,13 +46,12 @@ public struct CrossSellStackComponent: View {
                 id: "id",
                 title: "short btn",
                 description: "short",
-                buttonTitle: "Save 15%",
+                buttonTitle: "See price",
                 webActionURL: "",
                 imageUrl: nil,
                 buttonDescription: "button"
             ),
         ],
-        discountAvailable: true,
         withHeader: true
     )
 }

--- a/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
+++ b/Projects/CrossSell/Sources/View/Components/CrossSellStackComponent.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import hCore
 import hCoreUI
 
 public struct CrossSellStackComponent: View {

--- a/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
@@ -1,3 +1,4 @@
+import Addons
 import SwiftUI
 import hCore
 import hCoreUI
@@ -6,17 +7,24 @@ public struct CrossSellingDetent: View {
     @StateObject private var router = NavigationRouter()
 
     let crossSells: CrossSells
+    let addons: [AddonBanner]
+    let onAddonTap: (AddonBanner) -> Void
 
     public init(
-        crossSells: CrossSells
+        crossSells: CrossSells,
+        addons: [AddonBanner],
+        onAddonTap: @escaping (AddonBanner) -> Void
     ) {
         self.crossSells = crossSells
+        self.addons = addons
+        self.onAddonTap = onAddonTap
     }
 
     public var body: some View {
         hForm {
             VStack(spacing: .padding48) {
                 CrossSellStackComponent(crossSells: crossSells.others)
+                CrossSellAddonsSection(addons: addons, onAddonTap: onAddonTap)
             }
         }
         .hFormAttachToBottom {
@@ -46,5 +54,5 @@ extension CrossSellingDetent: TrackingViewNameProtocol {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingDetent(crossSells: .init(recommended: nil, others: []))
+    return CrossSellingDetent(crossSells: .init(recommended: nil, others: []), addons: [], onAddonTap: { _ in })
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
@@ -37,7 +37,7 @@ public struct CrossSellingDetent: View {
             .padding(.top, .padding16)
         }
         .hFormContentPosition(.compact)
-        .configureTitleView(title: L10n.crossSellSubtitle)
+        .configureTitleView(title: L10n.crossSellTitle, subTitle: L10n.crossSellSubtitle)
         .embededInNavigation(
             router: router,
             options: [.navigationType(type: .large), .extendedNavigationWidth],

--- a/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
@@ -16,7 +16,7 @@ public struct CrossSellingDetent: View {
     public var body: some View {
         hForm {
             VStack(spacing: .padding48) {
-                CrossSellStackComponent(crossSells: crossSells.others, withHeader: false)
+                CrossSellStackComponent(crossSells: crossSells.others)
             }
         }
         .hFormAttachToBottom {

--- a/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingDetent.swift
@@ -16,7 +16,7 @@ public struct CrossSellingDetent: View {
     public var body: some View {
         hForm {
             VStack(spacing: .padding48) {
-                CrossSellStackComponent(crossSells: crossSells.others, discountAvailable: true, withHeader: false)
+                CrossSellStackComponent(crossSells: crossSells.others, withHeader: false)
             }
         }
         .hFormAttachToBottom {
@@ -46,5 +46,5 @@ extension CrossSellingDetent: TrackingViewNameProtocol {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingDetent(crossSells: .init(recommended: nil, others: [], discountAvailable: true))
+    return CrossSellingDetent(crossSells: .init(recommended: nil, others: []))
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingItem.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingItem.swift
@@ -5,7 +5,6 @@ import hCoreUI
 
 struct CrossSellingItem: View {
     let crossSell: CrossSell
-    let discountAvailable: Bool
     @State private var isCrossSellLoading = false
 
     func openExternal() {
@@ -22,9 +21,8 @@ struct CrossSellingItem: View {
             title: crossSell.title,
             subtitle: crossSell.description,
             buttonTitle: crossSell.buttonTitle,
-            variant: discountAvailable ? .primaryAlt : .secondary,
+            variant: .secondary,
             isLoading: isCrossSellLoading,
-            accessibilityAction: L10n.crossSellGetPrice,
             pillow: { Pillow(imageUrl: crossSell.imageUrl) }
         ) {
             openExternal()
@@ -49,11 +47,10 @@ struct CrossSellingItem: View {
             id: "id",
             title: "Accident Insurance",
             description: "From 79 SEK/mo.",
-            buttonTitle: "Save 50%",
+            buttonTitle: "See price",
             webActionURL: "",
             imageUrl: nil,
             buttonDescription: "button description"
-        ),
-        discountAvailable: true
+        )
     )
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingModal.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingModal.swift
@@ -1,14 +1,21 @@
+import Addons
 import SwiftUI
 import hCore
 import hCoreUI
 
 public struct CrossSellingModal: View {
     let crossSells: CrossSells
+    let addons: [AddonBanner]
+    let onAddonTap: (AddonBanner) -> Void
 
     public init(
-        crossSells: CrossSells
+        crossSells: CrossSells,
+        addons: [AddonBanner],
+        onAddonTap: @escaping (AddonBanner) -> Void
     ) {
         self.crossSells = crossSells
+        self.addons = addons
+        self.onAddonTap = onAddonTap
     }
 
     public var body: some View {
@@ -28,6 +35,7 @@ public struct CrossSellingModal: View {
                         }
                     }
                     CrossSellStackComponent(crossSells: crossSells.others)
+                    CrossSellAddonsSection(addons: addons, onAddonTap: onAddonTap)
                 }
                 .padding(.bottom, .padding16)
             }
@@ -48,5 +56,5 @@ extension CrossSellingModal: TrackingViewNameProtocol {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingModal(crossSells: .init(recommended: nil, others: []))
+    return CrossSellingModal(crossSells: .init(recommended: nil, others: []), addons: [], onAddonTap: { _ in })
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingModal.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingModal.swift
@@ -1,21 +1,14 @@
-import Addons
 import SwiftUI
 import hCore
 import hCoreUI
 
 public struct CrossSellingModal: View {
     let crossSells: CrossSells
-    let addons: [AddonBanner]
-    let onAddonTap: (AddonBanner) -> Void
 
     public init(
-        crossSells: CrossSells,
-        addons: [AddonBanner],
-        onAddonTap: @escaping (AddonBanner) -> Void
+        crossSells: CrossSells
     ) {
         self.crossSells = crossSells
-        self.addons = addons
-        self.onAddonTap = onAddonTap
     }
 
     public var body: some View {
@@ -35,7 +28,6 @@ public struct CrossSellingModal: View {
                         }
                     }
                     CrossSellStackComponent(crossSells: crossSells.others)
-                    CrossSellAddonsSection(addons: addons, onAddonTap: onAddonTap)
                 }
                 .padding(.bottom, .padding16)
             }
@@ -56,5 +48,5 @@ extension CrossSellingModal: TrackingViewNameProtocol {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingModal(crossSells: .init(recommended: nil, others: []), addons: [], onAddonTap: { _ in })
+    return CrossSellingModal(crossSells: .init(recommended: nil, others: []))
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingModal.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingModal.swift
@@ -27,10 +27,7 @@ public struct CrossSellingModal: View {
                             CrossSellButtonComponent(crossSell: recommended)
                         }
                     }
-                    CrossSellStackComponent(
-                        crossSells: crossSells.others,
-                        withHeader: crossSells.hasRecommendation
-                    )
+                    CrossSellStackComponent(crossSells: crossSells.others)
                 }
                 .padding(.bottom, .padding16)
             }

--- a/Projects/CrossSell/Sources/View/CrossSellingModal.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingModal.swift
@@ -29,7 +29,6 @@ public struct CrossSellingModal: View {
                     }
                     CrossSellStackComponent(
                         crossSells: crossSells.others,
-                        discountAvailable: crossSells.discountAvailable,
                         withHeader: crossSells.hasRecommendation
                     )
                 }
@@ -52,5 +51,5 @@ extension CrossSellingModal: TrackingViewNameProtocol {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingModal(crossSells: .init(recommended: nil, others: [], discountAvailable: true))
+    return CrossSellingModal(crossSells: .init(recommended: nil, others: []))
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingView.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingView.swift
@@ -3,22 +3,16 @@ import SwiftUI
 import hCore
 
 public struct CrossSellingView: View {
-    let withHeader: Bool
     @AppObservedObject var store: CrossSellStore
 
-    public init(
-        withHeader: Bool
-    ) {
-        self.withHeader = withHeader
-    }
+    public init() {}
 
     public var body: some View {
         VStack {
             if let crossSells = store.crossSells, !crossSells.others.isEmpty {
                 CrossSellStackComponent(
                     crossSells: crossSells.others,
-                    discountAvailable: crossSells.discountAvailable,
-                    withHeader: withHeader
+                    withHeader: false
                 )
             }
         }
@@ -30,5 +24,5 @@ public struct CrossSellingView: View {
 
 #Preview {
     Dependencies.shared.add(module: Module { () -> CrossSellClient in CrossSellClientDemo() })
-    return CrossSellingView(withHeader: true)
+    return CrossSellingView()
 }

--- a/Projects/CrossSell/Sources/View/CrossSellingView.swift
+++ b/Projects/CrossSell/Sources/View/CrossSellingView.swift
@@ -10,10 +10,7 @@ public struct CrossSellingView: View {
     public var body: some View {
         VStack {
             if let crossSells = store.crossSells, !crossSells.others.isEmpty {
-                CrossSellStackComponent(
-                    crossSells: crossSells.others,
-                    withHeader: false
-                )
+                CrossSellStackComponent(crossSells: crossSells.others)
             }
         }
         .task {

--- a/Projects/CrossSell/Tests/CrossSellTests.swift
+++ b/Projects/CrossSell/Tests/CrossSellTests.swift
@@ -37,8 +37,7 @@ final class CrossSellTests: XCTestCase {
                     imageUrl: nil,
                     buttonDescription: "button description"
                 ),
-            ],
-            discountAvailable: true
+            ]
         )
 
         let mockService = MockData.createMockCrossSellService(

--- a/Projects/CrossSell/Tests/MockData.swift
+++ b/Projects/CrossSell/Tests/MockData.swift
@@ -20,8 +20,7 @@ struct MockData {
         fetchCrossSell: @escaping FetchCrossSell = { _ in
             .init(
                 recommended: nil,
-                others: [],
-                discountAvailable: true
+                others: []
             )
         }
     ) -> MockCrossSellService {

--- a/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
+++ b/Projects/CrossSell/Tests/RecommendedCrossSellTests.swift
@@ -56,8 +56,7 @@ final class RecommendedCrossSellTests: XCTestCase {
     func testHasRecommendationTrueForInsurance() {
         let crossSells: CrossSells = .init(
             recommended: .insurance(makeInsurance()),
-            others: [],
-            discountAvailable: false
+            others: []
         )
 
         assert(crossSells.hasRecommendation)
@@ -66,8 +65,7 @@ final class RecommendedCrossSellTests: XCTestCase {
     func testHasRecommendationTrueForAddon() {
         let crossSells: CrossSells = .init(
             recommended: .addon(makeAddon()),
-            others: [],
-            discountAvailable: false
+            others: []
         )
 
         assert(crossSells.hasRecommendation)
@@ -76,8 +74,7 @@ final class RecommendedCrossSellTests: XCTestCase {
     func testHasRecommendationFalseWhenNil() {
         let crossSells: CrossSells = .init(
             recommended: nil,
-            others: [],
-            discountAvailable: false
+            others: []
         )
 
         assert(!crossSells.hasRecommendation)

--- a/Projects/CrossSell/Tests/StoreTests/CrossSellStoreTests.swift
+++ b/Projects/CrossSell/Tests/StoreTests/CrossSellStoreTests.swift
@@ -117,8 +117,7 @@ extension CrossSell {
                 imageUrl: nil,
                 buttonDescription: "button description"
             ),
-        ],
-        discountAvailable: true
+        ]
     )
 
     fileprivate static let getDefaultWithRecommendation: CrossSells = .init(
@@ -143,8 +142,7 @@ extension CrossSell {
                 imageUrl: nil,
                 buttonDescription: "button description"
             )
-        ],
-        discountAvailable: true
+        ]
     )
 }
 

--- a/Projects/Home/Sources/Screens/Components/HomeAddonsSection.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeAddonsSection.swift
@@ -21,7 +21,7 @@ struct HomeAddonsSection: View {
                         CrossSellRow(
                             title: banner.displayTitle,
                             subtitle: banner.displayDescription,
-                            buttonTitle: L10n.homeAddonsReadMoreButton,
+                            buttonTitle: L10n.crossSellSeePrice,
                             variant: .secondary,
                             isLoading: navigationVm.isAddonPresented?.contractInfos == input.contractInfos,
                             pillow: { AddonPillowView(type: banner.addonType) }

--- a/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
@@ -7,10 +7,7 @@ struct HomeCrossSellsSection: View {
 
     var body: some View {
         if let crossSells, !crossSells.others.isEmpty {
-            CrossSellStackComponent(
-                crossSells: crossSells.others,
-                withHeader: false
-            )
+            CrossSellStackComponent(crossSells: crossSells.others)
         }
     }
 }

--- a/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
+++ b/Projects/Home/Sources/Screens/Components/HomeCrossSellsSection.swift
@@ -9,9 +9,7 @@ struct HomeCrossSellsSection: View {
         if let crossSells, !crossSells.others.isEmpty {
             CrossSellStackComponent(
                 crossSells: crossSells.others,
-                discountAvailable: crossSells.discountAvailable,
-                withHeader: true,
-                headerTitle: L10n.crossSellSubtitle
+                withHeader: false
             )
         }
     }
@@ -25,7 +23,7 @@ struct HomeCrossSellsSection: View {
                     id: "2",
                     title: "Accident Insurance",
                     description: "From 79 SEK/mo.",
-                    buttonTitle: "Save 50%",
+                    buttonTitle: "See price",
                     webActionURL: "",
                     imageUrl: nil,
                     buttonDescription: ""
@@ -36,13 +34,12 @@ struct HomeCrossSellsSection: View {
                     id: "1",
                     title: "Pet Insurance",
                     description: "For your dog or cat",
-                    buttonTitle: "Get price",
+                    buttonTitle: "See price",
                     webActionURL: "",
                     imageUrl: nil,
                     buttonDescription: ""
                 )
-            ],
-            discountAvailable: false
+            ]
         )
     )
 }

--- a/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
@@ -7,7 +7,7 @@ struct OnboardingCrossSellScreen: View {
     @EnvironmentObject var vm: OnboardingNavigationViewModel
     var body: some View {
         hForm {
-            CrossSellStackComponent(crossSells: vm.crossSells, withHeader: false)
+            CrossSellStackComponent(crossSells: vm.crossSells)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .hFormTitle(

--- a/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
+++ b/Projects/Onboarding/Sources/Screens/OnboardingCrossSellScreen.swift
@@ -1,5 +1,4 @@
 import CrossSell
-import Kingfisher
 import SwiftUI
 import hCore
 import hCoreUI
@@ -8,7 +7,7 @@ struct OnboardingCrossSellScreen: View {
     @EnvironmentObject var vm: OnboardingNavigationViewModel
     var body: some View {
         hForm {
-            CrossSellStackComponent(crossSells: vm.crossSells, discountAvailable: false, withHeader: false)
+            CrossSellStackComponent(crossSells: vm.crossSells, withHeader: false)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .hFormTitle(
@@ -33,35 +32,6 @@ struct OnboardingCrossSellScreen: View {
         .task {
             await vm.fetchCrossSells()
         }
-    }
-}
-
-private struct OnboardingCrossSellRow: View {
-    let crossSell: CrossSell
-
-    var body: some View {
-        HStack(spacing: .padding16) {
-            KFImage(crossSell.imageUrl)
-                .placeholder {
-                    hCoreUIAssets.bigPillowHome.view
-                        .resizable()
-                        .frame(width: 48, height: 48)
-                }
-                .fade(duration: 0.25)
-                .resizable()
-                .frame(width: 48, height: 48)
-                .aspectRatio(contentMode: .fill)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: .padding2) {
-                hText(crossSell.title, style: .body1)
-                hText(crossSell.description, style: .label)
-                    .foregroundColor(hTextColor.Opaque.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Projects/hCore/Resources/en.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/en.lproj/Localizable.strings
@@ -249,6 +249,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CROSS_SELL_BANNER_TEXT" = "Popular choice";
 "CROSS_SELL_BUTTON" = "See your price";
 "CROSS_SELL_SUBTITLE" = "Discover more coverage";
+"CROSS_SELL_TITLE" = "For you";
 "DASHBOARD_INSURANCE_STATUS_ACTIVE" = "Active";
 /* Figma */
 "DASHBOARD_INSURANCE_STATUS_ACTIVE_UPDATE_DATE" = "To be updated %1$@";

--- a/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
+++ b/Projects/hCore/Resources/sv-SE.lproj/Localizable.strings
@@ -249,6 +249,7 @@ A message is then appended under the image next to the timestamp to indicate tha
 "CROSS_SELL_BANNER_TEXT" = "Populärt val";
 "CROSS_SELL_BUTTON" = "Se ditt pris";
 "CROSS_SELL_SUBTITLE" = "Upptäck mer skydd";
+"CROSS_SELL_TITLE" = "För dig";
 "DASHBOARD_INSURANCE_STATUS_ACTIVE" = "Aktiv";
 /* Figma */
 "DASHBOARD_INSURANCE_STATUS_ACTIVE_UPDATE_DATE" = "Uppdateras %1$@";

--- a/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
+++ b/Projects/hGraphQL/GraphQL/Octopus/CrossSell/CrossSale.graphql
@@ -4,7 +4,6 @@ query CrossSell($input: CrossSellInput!) {
 		  otherCrossSells {
 			  ...CrossSellFragment
 		  }
-		  discountAvailable
 		  recommendedAddon {
 			  id
 			  title


### PR DESCRIPTION
WIP - https://claude.ai/code/artifact/9d05ac7b-6ebf-4be2-9369-25a9d7e2d447?sk=y8RT-Dbaa0Uwq5yDAabeew - https://hedviginsurance.slack.com/archives/C03U9C6Q7TP/p1788763511277219

🤖 AI description:

The iOS half of the "X-sell lists in app 1.5" design. 126 insertions, 137 deletions.

`discountAvailable` is retired end to end. It drove three things on iOS: the button style in `CrossSellingItem`, the section header title in `CrossSellStackComponent`, and a hardcoded `true` in `CrossSellingDetent`. The field is gone from the query, the model and the client, so the storefront field can eventually be deleted rather than living on as a constant.

Per surface:

- **Home and Contracts tab** lose their cross-sell section headers. The row is always `.secondary` now.
- **Contracts tab** add-ons move from `AddonCardView` to the shared `CrossSellRow`, matching Home. The card's badge pills go with it, which matches the Figma and what Android did.
- **The sheets** gain an Addons block, and the detent leads with "For you" over "Discover more coverage". Per Figma 2.1, 2.2 and 3.1, the Addons block and the heading belong only to the plain list sheet: the modal, which leads with a recommendation, has neither.
- **Travel certificate** keeps its card, since design is still working on that screen, but its button reads "See price" so the copy is consistent everywhere.

Three things a reviewer can't get from the diff:

1. **This depends on the storefront change deploying.** Until then the Contracts tab renders backend-supplied "Save 50%" text in the new plain pill. Deploy order is backend first, then this: the backend change is safe against every shipped client and moves old builds toward the new design rather than away from it.

2. **The VoiceOver label was removed rather than updated.** `CrossSellingItem` used to pass `L10n.crossSellGetPrice` explicitly, which would now contradict a button reading "See price". `CrossSellRow` already falls back to `accessibilityAction ?? buttonTitle`, so dropping the argument makes the spoken label follow the visible one.

3. **Add-on rows are handed their tap target from outside.** Add-ons open the purchase flow rather than a store URL, and building that input needs contract data the `CrossSell` module cannot reach, so `CrossSellAddonsSection` takes an `onAddonTap` closure that `HomeTab` fills in. Neither parameter is defaulted on purpose: a sheet with rows and no handler would fail silently.

Two `Localizable.strings` lines are from `CROSS_SELL_TITLE` being ticked for ios in Lokalise; the rest of those files are untouched so the usual sync still owns them.

Verified: full `Ugglan` scheme builds clean on an arm64 simulator with all changed files force-recompiled, and `build-for-testing` on the `CrossSell` scheme compiles the four updated test files. Driven in the simulator in demo mode across Home, the Contracts tab and the sheet. Note `generic/platform=iOS Simulator` cannot build this workspace at all: the pinned `HedvigShared.xcframework` has no x86_64 slice, so a universal simulator build fails at link regardless of the code. Add-on tap navigation is not verifiable in demo mode, because the demo banner carries no contract ids; the pre-existing Home add-on row behaves identically.
